### PR TITLE
Automated checking of all .ckan files by travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: java
+
+# Our validator actually lives in the CKAN directory, which
+# means CKAN-meta can stay nice and lightweight for then it
+# gets downloaded by every single CKAN client. :)
+
+install:
+    - git clone https://github.com/KSP-CKAN/CKAN.git
+
+# Our test is merely checking that all the ckan files validate
+# against the current spec.
+
+script:
+    - CKAN/bin/ckan-validate *.ckan


### PR DESCRIPTION
Tested on pjf/CKAN-meta by having a repo full of good files (travis
passes), and another which includes a bad file (travis fails).

This means should any invalid CKAN files end up in the CKAN-meta
directory, we'll know about them!

You can see a sample output at:

https://travis-ci.org/pjf/CKAN-meta
