### PR TITLE
Create biggerlaunchpads-0.5.ckan

### DIFF
--- a/biggerlaunchpads-0.5.ckan
+++ b/biggerlaunchpads-0.5.ckan
@@ -1,0 +1,5 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "Bigger Launchpads",
+    "$kref"          : "#/ckan/kerbalstuff/322"
+}


### PR DESCRIPTION
Added the ckan file (not full this time !) for a new upload: bigger launchpads. Also, file is not included in the archive.
