### PR TITLE
ToadicusTools: Added dedicated ckan file for ToadicusTools rolling release.

### DIFF
--- a/ToadicusTools-latest.ckan
+++ b/ToadicusTools-latest.ckan
@@ -1,0 +1,15 @@
+{
+  "spec_version": 1,
+  "identifier": "ToadicusTools",
+  "license": "BSD-2-clause",
+  "resources": {
+    "repository": "http://git.toad.homelinux.net/projects/ToadicusTools.git"
+  },
+  "ksp_version": "0.25",
+  "name": "ToadicusTools",
+  "abstract": "A library of tools for toadicus' KSP mods.",
+  "author": "toadicus",
+  "version": "0:latest",
+  "download": "http://ksp.hawkbats.com/ToadicusTools/ToadicusTools.zip",
+  "description": "A library of tools used in toadicus' KSP mods.  This is a rolling release; the version never changes.  Yet."
+}


### PR DESCRIPTION
ToadicusTools is a rolling-release library for toadicus' KSP mods, included here to resolve conflicts between toadicus' mods as discussed in KSP-CKAN/NetKAN#131.
