### PR TITLE
Removes RealEffects recommendation from SmokeScreen

### DIFF
--- a/SmokeScreen-2.5.0.ckan
+++ b/SmokeScreen-2.5.0.ckan
@@ -22,7 +22,6 @@
         { "name" : "ModuleManager", "min_version" : "2.5.1" }
     ],
 	"recommends" : [
-        { "name" : "HotRockets" },
-		{ "name" : "RealEffects" }
+        { "name" : "HotRockets" }
     ]
 }


### PR DESCRIPTION
RealEffects depends on RealismOverhaul, so SmokeScreen should definitely not install it with the recommends.
