### PR TITLE
Hand-packaged KSP-AVC as the addon is curse-only at the moment

### DIFF
--- a/KSP-AVC-1.1.5.0.ckan
+++ b/KSP-AVC-1.1.5.0.ckan
@@ -1,0 +1,18 @@
+{
+	"spec_version": 1,
+	"identifier": "KSP-AVC",
+	"ksp_version": "0.25",
+	"resources": 
+	{
+		"homepage": "http://forum.kerbalspaceprogram.com/threads/79745",
+		"repository": "https://github.com/CYBUTEK/KSPAddonVersionChecker"
+	},
+	"name": "KSP AVC",
+	"license": "GPL-3.0",
+	"abstract": "In-Game GUI for KSP Addon Version Checker",
+	"author": "cybutek",
+	"version": "1.1.5.0",
+	"download": "http://addons.cursecdn.com/files/2216/818/KSP-AVC-1.1.5.0.zip",
+    "download_size": 22263178,
+    "x_packaged_by": "hakan42 - hand-packaged as the mod is curse-only at the moment"
+}


### PR DESCRIPTION
A partial solution to KSP-CKAN/CKAN#387 , this only allows installation of the in-game GUI to the "loading" screen.
