### PR TITLE
Add MechJeb2 2.4.1

### DIFF
--- a/MechJeb2-2.4.1.ckan
+++ b/MechJeb2-2.4.1.ckan
@@ -1,0 +1,16 @@
+{
+	"spec_version": 1,
+	"identifier": "MechJeb2",
+	"ksp_version": "0.90",
+	"resources":
+	{
+		"homepage": "http://forum.kerbalspaceprogram.com/threads/12384-PART-0-90-Anatid-Robotics-MuMech-MechJeb-Autopilot-v2-4-1"
+	},
+	"name": "MechJeb 2",
+	"license": "GPL-3.0",
+	"abstract": "Anatid Robotics and Multiversal Mechatronics proudly presents the first flight assistant autopilot: MechJeb",
+	"author": "sarbian",
+	"version": "2.4.1",
+	"download": "http://addons.curse.cursecdn.com/files/2222/5/MechJeb2-2.4.1.0.zip",
+	"comment" : "Hand packaged by dominics, if anything's wrong, it's my fault."
+}


### PR DESCRIPTION
0.90 compatible MechJeb.

I saw mention of NetKAN in the last change to the MechJeb ckan files. But then I figure KSP-CKAN/CKAN#195 hasn't been implemented yet, and we're doing MechJeb manually still?
