### PR TITLE
ToadicusTools: Updated KSP version to 0.90.

### DIFF
--- a/ToadicusTools-latest.ckan
+++ b/ToadicusTools-latest.ckan
@@ -5,7 +5,7 @@
   "resources": {
     "repository": "http://git.toad.homelinux.net/projects/ToadicusTools.git"
   },
-  "ksp_version": "0.25",
+  "ksp_version": "0.90",
   "name": "ToadicusTools",
   "abstract": "A library of tools for toadicus' KSP mods.",
   "author": "toadicus",


### PR DESCRIPTION
ToadicusTools is a rolling-release library used by most of my mods.  It was updated for 0.90 along with my mods, but since it's not on GitHub or KerbalStuff, here's the manual version change.
