### PR TITLE
Add author to Toolbar metadata

### DIFF
--- a/Toolbar-1.7.7.ckan
+++ b/Toolbar-1.7.7.ckan
@@ -1,6 +1,7 @@
 {
     "spec_version"   : 1,
     "name"           : "Toolbar",
+    "author"         : "blizzy78",
     "identifier"     : "Toolbar",
     "abstract"       : "API for third-party plugins to provide toolbar buttons",
     "download"       : "http://blizzy.de/toolbar/Toolbar-1.7.7.zip",


### PR DESCRIPTION
Metadata was missing author name, for some reason, this has been corrected.
