### PR TITLE
Add FinalFrontier 0.5.10-178

### DIFF
--- a/FinalFrontier-0.5.10-178.ckan
+++ b/FinalFrontier-0.5.10-178.ckan
@@ -1,0 +1,24 @@
+{
+  "spec_version": 1,
+  "identifier": "FinalFrontier",
+  "release_status": "stable",
+  "license": "BSD-2-clause",
+  "resources": {
+    "homepage": "http://forum.kerbalspaceprogram.com/threads/67246",
+    "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+  },
+  "install": [
+    {
+      "file": "GameData",
+      "install_to": "GameData",
+      "filter": [ "000_Toolbar", "Source" ]
+    }
+  ],
+  "ksp_version": "0.90",
+  "name": "Final Frontier",
+  "abstract": "The Final Frontier plugin will handle ribbons for extraordinary merits for you. And the number of missions flown (i.e. vessel recovered) is recorded, too.",
+  "author": "Nereid",
+  "version": "0.5.10-178",
+  "x_packaged_by": "hakan42 - hand-packaged as the mod is curse-only at the moment",
+  "download": "http://nereid42.de/FinalFrontier/FinalFrontier0.5.10-178.zip"
+}


### PR DESCRIPTION
FinalFrontier is still self-hosted and curse only, so this commit uses the metadata from 85bc774b27eea81c3b70e6791184f0aae0f6ad19. 
