### PR TITLE
ContractConfigurator 0.3.4 - bad download link.

### DIFF
--- a/ContractConfigurator-0.3.4.ckan
+++ b/ContractConfigurator-0.3.4.ckan
@@ -23,7 +23,7 @@
     "repository": "https://github.com/jrossignol/ContractConfigurator"
   },
   "version": "0.3.4",
-  "download": "https://github.com/jrossignol/ContractConfigurator/releases/download/0.3.4/GameData.zip",
+  "download": "https://github.com/jrossignol/ContractConfigurator/releases/download/0.3.4/ContractConfigurator_0.3.4.zip",
   "x_generated_by": "netkan",
   "download_size": 42070,
   "ksp_version_min": "0.90.0",


### PR DESCRIPTION
Fixed the download link that I borked on the GitHub release.
