### PR TITLE
Updating Toolbar download from 1.7.7 to 1.7.8

### DIFF
--- a/Toolbar-1.7.8.ckan
+++ b/Toolbar-1.7.8.ckan
@@ -4,9 +4,9 @@
     "author"         : "blizzy78",
     "identifier"     : "Toolbar",
     "abstract"       : "API for third-party plugins to provide toolbar buttons",
-    "download"       : "http://blizzy.de/toolbar/Toolbar-1.7.7.zip",
+    "download"       : "http://blizzy.de/toolbar/Toolbar-1.7.8.zip",
     "license"        : "BSD-2-clause",
-    "version"        : "1.7.7",
+    "version"        : "1.7.8",
     "release_status" : "stable",
     "ksp_version_min"    : "0.25",
     "resources" : {
@@ -18,7 +18,7 @@
     },
     "install" : [
         {
-            "file"       : "Toolbar-1.7.7/GameData/000_Toolbar",
+            "file"       : "Toolbar-1.7.8/GameData/000_Toolbar",
             "install_to" : "GameData"
         }
     ]


### PR DESCRIPTION
I noticed that Blizzy78 updated his Toolbar mod, creating a new download link - as well as removing the previous version from his page entirely. This is a corrected version to take this update into account.
