### PR TITLE
Restore missing Toolbar for KSP 0.25

### DIFF
--- a/Toolbar-1.7.7.ckan
+++ b/Toolbar-1.7.7.ckan
@@ -4,17 +4,15 @@
     "author"         : "blizzy78",
     "identifier"     : "Toolbar",
     "abstract"       : "API for third-party plugins to provide toolbar buttons",
-    "download"       : "http://blizzy.de/toolbar/Toolbar-1.7.7.zip",
+    "x_original_download" : "http://blizzy.de/toolbar/Toolbar-1.7.7.zip",
+    "download"       : "http://amsterdam.ksp-ckan.org/A0A3807B.zip",
     "license"        : "BSD-2-clause",
     "version"        : "1.7.7",
     "release_status" : "stable",
-    "ksp_version_min"    : "0.25",
+    "ksp_version"    : "0.25",
     "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/threads/60863",
-        "github"   : {
-            "url"      : "https://github.com/blizzy78/ksp_toolbar",
-            "releases" : true
-        }
+        "homepage"   : "http://forum.kerbalspaceprogram.com/threads/60863",
+        "repository" : "https://github.com/blizzy78/ksp_toolbar"
     },
     "install" : [
         {


### PR DESCRIPTION
Toolbar-1.7.7 for KSP 0.25 no longer seems to be at the original site.
This PR flips to using a mirror (thank goodness for free licenses) so
0.25 users can still install Toolbar and its mods.

Attn @blizzy78, as we'd really rather download from your site directly.

Relates to #169, which I'll be processing in a minuteto provide
1.7.8/0.90 support.
