### PR TITLE
Adjust CustomBiomes to also include its config.xml file

### DIFF
--- a/CustomBiomes-1.6.8.ckan
+++ b/CustomBiomes-1.6.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.2",
     "name"           : "Custom Biomes",
     "identifier"     : "CustomBiomes",
     "abstract"       : "Add or replace biomes to any celestial body in KSP",
@@ -21,7 +21,12 @@
         {
             "file"       : "CustomBiomes",
             "install_to" : "GameData",
-            "filter"     : "PluginData"
+            "filter"     : [ "PluginData", "Thumbs.db" ]
+        },
+        {
+            "file"       : "CustomBiomes/PluginData/CustomBiomes/config.xml",
+            "install_to" : "GameData/CustomBiomes/PluginData/CustomBiomes",
+            "comment"    : "Config for the mod itself, not the biomes."
         }
     ]
 }

--- a/CustomBiomes-Data-RSS-v8.2.1.ckan
+++ b/CustomBiomes-Data-RSS-v8.2.1.ckan
@@ -31,7 +31,7 @@
       "file": "CustomBiomes",
       "install_to": "GameData",
       "comment": "This regexp only installs PluginData, and nothing else",
-      "filter_regexp": "^(?!CustomBiomes/PluginData/)"
+      "filter_regexp": "^(?!CustomBiomes/PluginData/)|config.xml"
     }
   ],
   "author": "NathanKell",

--- a/CustomBiomes-Data-RSS-v8.3.ckan
+++ b/CustomBiomes-Data-RSS-v8.3.ckan
@@ -31,7 +31,7 @@
       "file": "CustomBiomes",
       "install_to": "GameData",
       "comment": "This regexp only installs PluginData, and nothing else",
-      "filter_regexp": "^(?!CustomBiomes/PluginData/)"
+      "filter_regexp": "^(?!CustomBiomes/PluginData/)|config.xml"
     }
   ],
   "author": "NathanKell",

--- a/CustomBiomes-Data-Stock.ckan
+++ b/CustomBiomes-Data-Stock.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.2",
     "name"           : "Custom Biomes (Stock data)",
     "identifier"     : "CustomBiomes-Data-Stock",
     "abstract"       : "Custom biomes data for the stock Kerbol system",
@@ -16,10 +16,10 @@
     },
     "install" : [
         {
-            "file"          : "CustomBiomes",
-            "install_to"    : "GameData",
-            "comment"       : "This regexp only installs PluginData, and nothing else",
-            "filter_regexp" : "^(?!CustomBiomes/PluginData/)"
+            "file"          : "CustomBiomes/PluginData/CustomBiomes",
+            "install_to"    : "GameData/CustomBiomes/PluginData",
+            "filter"        : [ "config.xml", "Thumbs.db" ],
+            "comment"       : "config.xml is bundled with the main mod itself"
         }
     ]
 }


### PR DESCRIPTION
CustomBiomes has a config.xml file that is associated with the mod
itself, not the biome data.

This change has config.xml installed with the mod, _not_ its data. This
provides compatibility with newer CustomBiomes releases.

This also updates some of the older CustomBiomes-Data-RSS packs to do the right thing as well.

Typical manifest of the new CustomBiomes install:

```
Custom Biomes version 1.6.8

== Files ==

GameData/CustomBiomes
GameData/CustomBiomes/biome.png
GameData/CustomBiomes/BiomeIcon.png
GameData/CustomBiomes/CustomBiomes.dll
GameData/CustomBiomes/License.txt
GameData/CustomBiomes/PluginData/CustomBiomes/config.xml
```

(Also, this reveals that new ckans cause `ckan show` to crash!)
