### PR TITLE
Added the core mods of Astronomer's Pack.

### DIFF
--- a/AstronomersPack-Clouds-High/AstronomersPack-Clouds-High-Interstellar-V2.ckan
+++ b/AstronomersPack-Clouds-High/AstronomersPack-Clouds-High-Interstellar-V2.ckan
@@ -1,0 +1,39 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Clouds-High",
+    "name": "Astronomer's Pack - Clouds - High",
+    "abstract": "Astronomer's Pack core EVE configuration, with high-resolution volumetric clouds.",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "2nd Step - Volumetric Clouds/512 - Higher Resolution (maybe)/GameData/BoulderCo",
+            "install_to": "GameData"
+        },
+        {
+            "file": "3rd Step - Core Mod (just clouds)/Core Mod/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config",
+        "AstronomersPack-Clouds"
+    ],
+    "depends": [
+        {
+            "name": "EnvironmentalVisualEnhancements"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "EnvironmentalVisualEnhancements-Config"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Clouds-Low/AstronomersPack-Clouds-Low-Interstellar-V2.ckan
+++ b/AstronomersPack-Clouds-Low/AstronomersPack-Clouds-Low-Interstellar-V2.ckan
@@ -1,0 +1,39 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Clouds-Low",
+    "name": "Astronomer's Pack - Clouds - Low",
+    "abstract": "Astronomer's Pack core EVE configuration, with low-resolution volumetric clouds.",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "2nd Step - Volumetric Clouds/128 - Lower Resolution (best FPS)/GameData/BoulderCo",
+            "install_to": "GameData"
+        },
+        {
+            "file": "3rd Step - Core Mod (just clouds)/Core Mod/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config"
+        "AstronomersPack-Clouds"
+    ],
+    "depends": [
+        {
+            "name": "EnvironmentalVisualEnhancements"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "EnvironmentalVisualEnhancements-Config"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Clouds-Medium/AstronomersPack-Clouds-Medium-Interstellar-V2.ckan
+++ b/AstronomersPack-Clouds-Medium/AstronomersPack-Clouds-Medium-Interstellar-V2.ckan
@@ -1,0 +1,39 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Clouds-Medium",
+    "name": "Astronomer's Pack - Clouds - Medium",
+    "abstract": "Astronomer's Pack core EVE configuration, with medium-resolution volumetric clouds.",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "2nd Step - Volumetric Clouds/256 - Default Resolution (recommended)/GameData/BoulderCo",
+            "install_to": "GameData"
+        },
+        {
+            "file": "3rd Step - Core Mod (just clouds)/Core Mod/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config",
+        "AstronomersPack-Clouds"
+    ],
+    "depends": [
+        {
+            "name": "EnvironmentalVisualEnhancements"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "EnvironmentalVisualEnhancements-Config"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-DistantObjectEnhancement/AstronomersPack-DistantObjectEnhancement-Interstellar-V2.ckan
+++ b/AstronomersPack-DistantObjectEnhancement/AstronomersPack-DistantObjectEnhancement-Interstellar-V2.ckan
@@ -1,0 +1,34 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-DistantObjectEnhancement",
+    "name": "Astronomer's Pack - Distant Object Enhancement config",
+    "abstract": "Distant Object Enhancement Configuration from Astronomer's Pack.",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "3rd Step - Core Mod (just clouds)/Core Mod/GameData/DistantObject",
+            "install_to": "GameData"
+        }
+    ],
+    "provides": [
+        "DistantObject-config"
+    ],
+    "depends": [
+        {
+            "name": "DistantObject"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "DistantObject-config"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-PlanetShine/AstronomersPack-PlanetShine-Interstellar-V2.ckan
+++ b/AstronomersPack-PlanetShine/AstronomersPack-PlanetShine-Interstellar-V2.ckan
@@ -1,0 +1,34 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-PlanetShine",
+    "name": "Astronomer's Pack - PlanetShine configuration",
+    "abstract": "Astronomer's Pack PlanetShine configuration.",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "3rd Step - Core Mod (just clouds)/Core Mod/GameData/PlanetShine",
+            "install_to": "GameData"
+        }
+    ],
+    "provides": [
+        "PlanetShine-Config"
+    ],
+    "depends": [
+        {
+            "name": "PlanetShine"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "PlanetShine-Config"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}


### PR DESCRIPTION
Astronomer's Pack consists of many different parts, most of which I have managed to split up into mods that can be managed by CKAN. Those are:

* A core part with:
 * A base EVE configuration with volumetric clouds in low, medium and high resolution variants
 * A PlanetShine configuration
 * A Distant Object Enhancement configuration
* Optional features, all implemented as supplementary EVE configuration files and textures:
 * Atmospheric scattering
 * Sandstorms and surface dust
 * Snow
 * Surface glow
 * Auroras in low and high resolution variants
 * Clouds for Eve and Jool in low, medium and high resolution variants
 * Lightning

I am submitting this to CKAN-meta because NetKAN cannot automatically check for updates on this one and the structure (as well as the complexity) of the pack's ZIP file makes it improbable that new releases can be automatically supported.

This PR contains the core part mentioned above. A second shall come with the optional parts.