### PR TITLE
Astronomer's Visual Pack

### DIFF
--- a/AstronomersPack-AtmosphericScattering/AstronomersPack-AtmosphericScattering-Interstellar-V2.ckan
+++ b/AstronomersPack-AtmosphericScattering/AstronomersPack-AtmosphericScattering-Interstellar-V2.ckan
@@ -1,0 +1,26 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-AtmosphericScattering",
+    "name": "Astronomer's Pack: Atmospheric Scattering",
+    "abstract": "Astronomer's Pack option",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "4th Step - Optional Features/Essential Features (still optional though)/0MB Atmospheric Scattering (tinted glow)/~ Medium (recommended)/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "AstronomersPack-Clouds"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Auroras-4K/AstronomersPack-Auroras-4K-Interstellar-V2.ckan
+++ b/AstronomersPack-Auroras-4K/AstronomersPack-Auroras-4K-Interstellar-V2.ckan
@@ -1,0 +1,44 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Auroras-4K",
+    "name": "Astronomer's Pack: Auroras - 4K (recommended)",
+    "abstract": "Astronomer's Pack option",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "4th Step - Optional Features/Essential Features (still optional though)/Auroras/Step 1/With PlanetShine/GameData/BoulderCo",
+            "install_to": "GameData"
+        },
+        {
+            "file": "4th Step - Optional Features/Essential Features (still optional though)/Auroras/Step 2/7MB 4K Auroras (recommended)/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "PlanetShine"
+        },
+        {
+            "name": "PlanetShine-Config-Astronomer"
+        },
+        {
+            "name": "AstronomersPack-Clouds"
+        }
+    ],
+    "provides": [
+        "AstronomersPack-Auroras"
+    ],
+    "conflicts": [
+        {
+            "name": "AstronomersPack-Auroras"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Auroras-8K/AstronomersPack-Auroras-8K-Interstellar-V2.ckan
+++ b/AstronomersPack-Auroras-8K/AstronomersPack-Auroras-8K-Interstellar-V2.ckan
@@ -1,0 +1,44 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Auroras-8K",
+    "name": "Astronomer's Pack: Auroras - 8K",
+    "abstract": "Astronomer's Pack option",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "4th Step - Optional Features/Essential Features (still optional though)/Auroras/Step 1/With PlanetShine/GameData/BoulderCo",
+            "install_to": "GameData"
+        },
+        {
+            "file": "4th Step - Optional Features/Essential Features (still optional though)/Auroras/Step 2/22MB 8K Auroras/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "PlanetShine"
+        },
+        {
+            "name": "PlanetShine-Config-Astronomer"
+        },
+        {
+            "name": "AstronomersPack-Clouds"
+        }
+    ],
+    "provides": [
+        "AstronomersPack-Auroras"
+    ],
+    "conflicts": [
+        {
+            "name": "AstronomersPack-Auroras"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Clouds-High/AstronomersPack-Clouds-High-Interstellar-V2.ckan
+++ b/AstronomersPack-Clouds-High/AstronomersPack-Clouds-High-Interstellar-V2.ckan
@@ -1,0 +1,39 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Clouds-High",
+    "name": "Astronomer's Pack - Clouds - High",
+    "abstract": "Astronomer's Pack core EVE configuration, with high-resolution volumetric clouds.",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "2nd Step - Volumetric Clouds/512 - Higher Resolution (maybe)/GameData/BoulderCo",
+            "install_to": "GameData"
+        },
+        {
+            "file": "3rd Step - Core Mod (just clouds)/Core Mod/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config",
+        "AstronomersPack-Clouds"
+    ],
+    "depends": [
+        {
+            "name": "EnvironmentalVisualEnhancements"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "EnvironmentalVisualEnhancements-Config"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Clouds-Low/AstronomersPack-Clouds-Low-Interstellar-V2.ckan
+++ b/AstronomersPack-Clouds-Low/AstronomersPack-Clouds-Low-Interstellar-V2.ckan
@@ -19,7 +19,7 @@
         }
     ],
     "provides": [
-        "EnvironmentalVisualEnhancements-Config"
+        "EnvironmentalVisualEnhancements-Config",
         "AstronomersPack-Clouds"
     ],
     "depends": [

--- a/AstronomersPack-Clouds-Low/AstronomersPack-Clouds-Low-Interstellar-V2.ckan
+++ b/AstronomersPack-Clouds-Low/AstronomersPack-Clouds-Low-Interstellar-V2.ckan
@@ -1,0 +1,39 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Clouds-Low",
+    "name": "Astronomer's Pack - Clouds - Low",
+    "abstract": "Astronomer's Pack core EVE configuration, with low-resolution volumetric clouds.",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "2nd Step - Volumetric Clouds/128 - Lower Resolution (best FPS)/GameData/BoulderCo",
+            "install_to": "GameData"
+        },
+        {
+            "file": "3rd Step - Core Mod (just clouds)/Core Mod/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config"
+        "AstronomersPack-Clouds"
+    ],
+    "depends": [
+        {
+            "name": "EnvironmentalVisualEnhancements"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "EnvironmentalVisualEnhancements-Config"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Clouds-Medium/AstronomersPack-Clouds-Medium-Interstellar-V2.ckan
+++ b/AstronomersPack-Clouds-Medium/AstronomersPack-Clouds-Medium-Interstellar-V2.ckan
@@ -1,0 +1,39 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Clouds-Medium",
+    "name": "Astronomer's Pack - Clouds - Medium",
+    "abstract": "Astronomer's Pack core EVE configuration, with medium-resolution volumetric clouds.",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "2nd Step - Volumetric Clouds/256 - Default Resolution (recommended)/GameData/BoulderCo",
+            "install_to": "GameData"
+        },
+        {
+            "file": "3rd Step - Core Mod (just clouds)/Core Mod/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config",
+        "AstronomersPack-Clouds"
+    ],
+    "depends": [
+        {
+            "name": "EnvironmentalVisualEnhancements"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "EnvironmentalVisualEnhancements-Config"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-DistantObjectEnhancement/AstronomersPack-DistantObjectEnhancement-Interstellar-V2.ckan
+++ b/AstronomersPack-DistantObjectEnhancement/AstronomersPack-DistantObjectEnhancement-Interstellar-V2.ckan
@@ -1,0 +1,34 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-DistantObjectEnhancement",
+    "name": "Astronomer's Pack - Distant Object Enhancement config",
+    "abstract": "Distant Object Enhancement Configuration from Astronomer's Pack.",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "3rd Step - Core Mod (just clouds)/Core Mod/GameData/DistantObject",
+            "install_to": "GameData"
+        }
+    ],
+    "provides": [
+        "DistantObject-config"
+    ],
+    "depends": [
+        {
+            "name": "DistantObject"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "DistantObject-config"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Eve-Jool-Clouds-2K/AstronomersPack-Eve-Jool-Clouds-2K-Interstellar-V2.ckan
+++ b/AstronomersPack-Eve-Jool-Clouds-2K/AstronomersPack-Eve-Jool-Clouds-2K-Interstellar-V2.ckan
@@ -1,0 +1,34 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Eve-Jool-Clouds-2K",
+    "name": "Astronomer's Pack: Clouds for Eve & Jool - 2K",
+    "abstract": "Astronomer's Pack option",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "4th Step - Optional Features/Essential Features (still optional though)/Clouds for Eve & Jool/11MB 2K (if you crash with 4K)/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "AstronomersPack-Clouds"
+        }
+    ],
+    "provides": [
+        "AstronomersPack-Eve-Jool-Clouds"
+    ],
+    "conflicts": [
+        {
+            "name": "AstronomersPack-Eve-Jool-Clouds"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Eve-Jool-Clouds-4K/AstronomersPack-Eve-Jool-Clouds-4K-Interstellar-V2.ckan
+++ b/AstronomersPack-Eve-Jool-Clouds-4K/AstronomersPack-Eve-Jool-Clouds-4K-Interstellar-V2.ckan
@@ -1,0 +1,34 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Eve-Jool-Clouds-4K",
+    "name": "Astronomer's Pack: Clouds for Eve & Jool - 4K (recommended)",
+    "abstract": "Astronomer's Pack option",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "4th Step - Optional Features/Essential Features (still optional though)/Clouds for Eve & Jool/38MB 4K (recommended)/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "AstronomersPack-Clouds"
+        }
+    ],
+    "provides": [
+        "AstronomersPack-Eve-Jool-Clouds"
+    ],
+    "conflicts": [
+        {
+            "name": "AstronomersPack-Eve-Jool-Clouds"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Eve-Jool-Clouds-8K/AstronomersPack-Eve-Jool-Clouds-8K-Interstellar-V2.ckan
+++ b/AstronomersPack-Eve-Jool-Clouds-8K/AstronomersPack-Eve-Jool-Clouds-8K-Interstellar-V2.ckan
@@ -1,0 +1,34 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Eve-Jool-Clouds-8K",
+    "name": "Astronomer's Pack: Clouds for Eve & Jool - 8K",
+    "abstract": "Astronomer's Pack option",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "4th Step - Optional Features/Essential Features (still optional though)/Clouds for Eve & Jool/107MB 8K/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "AstronomersPack-Clouds"
+        }
+    ],
+    "provides": [
+        "AstronomersPack-Eve-Jool-Clouds"
+    ],
+    "conflicts": [
+        {
+            "name": "AstronomersPack-Eve-Jool-Clouds"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Lightning/AstronomersPack-Lightning-Interstellar-V2.ckan
+++ b/AstronomersPack-Lightning/AstronomersPack-Lightning-Interstellar-V2.ckan
@@ -1,0 +1,36 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Lightning",
+    "name": "Astronomer's Pack: Lightning",
+    "abstract": "Astronomer's Pack option",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "4th Step - Optional Features/Extra Features (make sure KSP can run first)/29MB Lightning (Kerbin, Duna, Eve, Laythe)/Step 1/With PlanetShine/GameData/BoulderCo",
+            "install_to": "GameData"
+        },
+        {
+            "file": "4th Step - Optional Features/Extra Features (make sure KSP can run first)/29MB Lightning (Kerbin, Duna, Eve, Laythe)/Step 2/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "PlanetShine"
+        },
+        {
+            "name": "PlanetShine-Config-Astronomer"
+        },
+        {
+            "name": "AstronomersPack-Clouds"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-PlanetShine/AstronomersPack-PlanetShine-Interstellar-V2.ckan
+++ b/AstronomersPack-PlanetShine/AstronomersPack-PlanetShine-Interstellar-V2.ckan
@@ -1,0 +1,34 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-PlanetShine",
+    "name": "Astronomer's Pack - PlanetShine configuration",
+    "abstract": "Astronomer's Pack PlanetShine configuration.",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "3rd Step - Core Mod (just clouds)/Core Mod/GameData/PlanetShine",
+            "install_to": "GameData"
+        }
+    ],
+    "provides": [
+        "PlanetShine-Config"
+    ],
+    "depends": [
+        {
+            "name": "PlanetShine"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "PlanetShine-Config"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Sandstorms/AstronomersPack-Sandstorms-Interstellar-V2.ckan
+++ b/AstronomersPack-Sandstorms/AstronomersPack-Sandstorms-Interstellar-V2.ckan
@@ -1,0 +1,26 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Sandstorms",
+    "name": "Astronomer's Pack: Sandstorms and Surface Dust",
+    "abstract": "Astronomer's Pack option",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "4th Step - Optional Features/Essential Features (still optional though)/0MB Sandstorms and Surface Dust/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "AstronomersPack-Clouds"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-Snow/AstronomersPack-Snow-Interstellar-V2.ckan
+++ b/AstronomersPack-Snow/AstronomersPack-Snow-Interstellar-V2.ckan
@@ -1,0 +1,26 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-Snow",
+    "name": "Astronomer's Pack: Snow",
+    "abstract": "Astronomer's Pack option",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "4th Step - Optional Features/Essential Features (still optional though)/0MB Snow (Kerbin, Duna, Laythe)/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "AstronomersPack-Clouds"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack-SurfaceGlow/AstronomersPack-SurfaceGlow-Interstellar-V2.ckan
+++ b/AstronomersPack-SurfaceGlow/AstronomersPack-SurfaceGlow-Interstellar-V2.ckan
@@ -1,0 +1,26 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack-SurfaceGlow",
+    "name": "Astronomer's Pack: Surface Glow",
+    "abstract": "Astronomer's Pack option",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "file": "4th Step - Optional Features/Essential Features (still optional though)/0MB Surface Glow (sunlight refection)/GameData/BoulderCo",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "AstronomersPack-Clouds"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}

--- a/AstronomersPack/AstronomersPack-Interstellar-V2.ckan
+++ b/AstronomersPack/AstronomersPack-Interstellar-V2.ckan
@@ -1,0 +1,58 @@
+{
+    "spec_version": 1,
+    "identifier": "AstronomersPack",
+    "name": "Astronomer's Visual Pack",
+    "abstract": "Meta-package for Astronomer's Visual Pack and its options",
+    "license": "restricted",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
+    },
+    "install": [
+        {
+            "comment": "this is a workaround, since we have to copy something",
+            "file": "10 License.txt",
+            "install_to": "GameData/BoulderCo"
+        }
+    ],
+    "depends": [
+        {
+            "name": "AstronomersPack-Clouds"
+        },
+        {
+            "name": "AstronomersPack-DistantObjectEnhancement"
+        },
+        {
+            "name": "AstronomersPack-PlanetShine"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AstronomersPack-AtmosphericScattering"
+        },
+        {
+            "name": "AstronomersPack-Auroras-4K"
+        },
+        {
+            "name": "AstronomersPack-Eve-Jool-Clouds-4K"
+        },
+        {
+            "name": "AstronomersPack-Sandstorms"
+        },
+        {
+            "name": "AstronomersPack-Snow"
+        },
+        {
+            "name": "AstronomersPack-SurfaceGlow"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "AstronomersPack-Lightning"
+        }
+    ],
+    "author": "Astronomer",
+    "version": "Interstellar.V2",
+    "download": "http://kerbal.curseforge.com/ksp-mods/220335-astronomers-visual-pack-interstellar-v2/files/2221625/download",
+    "download_size": 398413030
+}


### PR DESCRIPTION
Astronomer's Pack consists of many different parts, most of which I have managed to split up into mods that can be managed by CKAN. Those are:

* A core part with:
 * Base EVE configuration with volumetric clouds in low, medium and high resolution variants
 * PlanetShine configuration
 * Distant Object Enhancement configuration
* Optional features, all implemented as supplementary EVE configuration files and textures:
 * Atmospheric scattering
 * Sandstorms and surface dust
 * Snow
 * Surface glow
 * Auroras in low and high resolution variants
 * Clouds for Eve and Jool in low, medium and high resolution variants
 * Lightning

Extra features not included in CKAN for various reasons are:
* Lens Flare (replaces core game files in KSP_Data)
* Holiday Season City Lights (replace files already installed by the pack)
* New Sun (replaces files already installed by the pack)
* Skyboxes (not included in the pack's ZIP file)

I am submitting this to CKAN-meta because NetKAN cannot automatically check for updates on this one and the structure (as well as the complexity) of the pack's ZIP file makes it improbable that new releases can be automatically supported.
