### PR TITLE
Fix spec_version on ContractConfigurator-ContractPack-SCANsat

### DIFF
--- a/ContractConfigurator-ContractPack-SCANsat/ContractConfigurator-ContractPack-SCANsat-v0.3.1.ckan
+++ b/ContractConfigurator-ContractPack-SCANsat/ContractConfigurator-ContractPack-SCANsat-v0.3.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "1",
+    "spec_version": 1,
     "identifier": "ContractConfigurator-ContractPack-SCANsat",
     "abstract": "A contract pack containing contracts for SCANSat.",
     "name": "Contract Pack: SCANSat",

--- a/ContractConfigurator-ContractPack-SCANsat/ContractConfigurator-ContractPack-SCANsat-v0.4.0.ckan
+++ b/ContractConfigurator-ContractPack-SCANsat/ContractConfigurator-ContractPack-SCANsat-v0.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "1",
+    "spec_version": 1,
     "identifier": "ContractConfigurator-ContractPack-SCANsat",
     "abstract": "A contract pack containing contracts for SCANSat.",
     "name": "Contract Pack: SCANSat",


### PR DESCRIPTION
The spec special-cases `1` as a spec version, which is defined as an
integer. However these files contained `1` as a string. My whiny
pedantic validator complains as a result. :)