### PR TITLE
TechManager compatibility file for 0.90

### DIFF
--- a/TechManager/TechManager-1.5-compat.ckan
+++ b/TechManager/TechManager-1.5-compat.ckan
@@ -1,0 +1,17 @@
+{
+    "spec_version": 1,
+    "identifier": "TechManager",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/98293-0-25-TechManager-Version-1-0",
+        "kerbalstuff": "https://kerbalstuff.com/mod/297/TechManager"
+    },
+    "ksp_version": "0.90",
+    "comment": "Nobody's had problems running TM 1.5 under 0.90, so this is a compatibility shim to allow it to be installed. Once TM 1.6 comes out, CKAN users should be able to install without pain.",
+    "name": "TechManager",
+    "license": "MIT",
+    "abstract": "This mod will allow you to change the tech tree, including the creation of new tech nodes. ",
+    "author": "anonish",
+    "version": "1.5-compat",
+    "download": "https://kerbalstuff.com/mod/297/TechManager/download/1.5",
+    "download_size": 39956
+}


### PR DESCRIPTION
Nobody ever¹ has had any problems with TechManager 1.5 for 0.90, and
the author hasn't been seen in WEEKS. Since evrything good in the world²
uses TechManager and the Community Tech Tree, here's a compatibility
shim that will install v1.5 for 0.90.

"Why not change the existing metadata?", I hear you ask. Mainly it's
because it's generated by netkan, and if KerbalStuff ever gets
updated, or if the metadata ever gets regenerated, we don't want
anything to break.

Many thanks to Daz for the prompting.

Attentioning @NathanKell, because relevance.

Also, this means I might finally upgrade to KSP 0.90.

¹ Allegedly.
² RP-0