### PR TITLE
RasterPropMonitor Core update

### DIFF
--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.ckan
@@ -1,0 +1,35 @@
+{
+  "spec_version": 1,
+  "name": "RasterPropMonitor Core",
+  "identifier": "RasterPropMonitor-Core",
+  "author": ["Mihara", "MOARdV"],
+  "abstract": "A toolkit for creating interactive IVA experiences.",
+  "comment": "This package contains the plugin, and the standard parts library. In Mihara's absence, MOARdv has kindly recompiled fixed versions of the RasterPropMonitor DLL for KSP 0.90.0",
+  "license": "GPL-3.0",
+  "ksp_version_min": "0.90",
+  "release_status": "development",
+  "resources": {
+    "homepage": "http://forum.kerbalspaceprogram.com/threads/57603",
+    "manual": "https://github.com/Mihara/RasterPropMonitor/wiki",
+    "repository": "https://github.com/Mihara/RasterPropMonitor"
+  },
+  "depends": [
+    {
+      "name": "ModuleManager"
+    }
+  ],
+  "install": [
+    {
+      "file": "GameData/JSI",
+      "filter": [
+        "Agencies",
+        "RPMPodPatches"
+      ],
+      "install_to": "GameData"
+    }
+  ],
+  "version": "v0.19",
+  "download": "https://github.com/Mihara/RasterPropMonitor/releases/download/v0.19/RasterPropMonitor-dev19.zip",
+  "x_generated_by": "netkan",
+  "download_size": 586836
+}


### PR DESCRIPTION
From forum thread [link](http://forum.kerbalspaceprogram.com/threads/57603-0-25-RasterPropMonitor-putting-the-A-in-your-IVA-%28v0-18-3%29-8-Oct)
> A Note on 0.90.0 Compatibility:
>In Mihara's absence, MOARdv has kindly recompiled fixed versions of the RasterPropMonitor DLL for KSP 0.90.0

It's marked as a Pre-release on github (netkan.exe by default won't index this) however I think it should be used now instead v0.18.3