### PR TITLE
Manually added Fusebox 1.3

### DIFF
--- a/Fusebox/Fusebox-1.3.ckan
+++ b/Fusebox/Fusebox-1.3.ckan
@@ -1,0 +1,16 @@
+{
+  "spec_version": 1,
+  "identifier": "Fusebox",
+  "ksp_version": "0.90",
+  "license": "GPL-2.0",
+  "resources": {
+    "homepage": "http://forum.kerbalspaceprogram.com/threads/50077"
+  },
+  "name": "Fusebox",
+  "abstract": "Fusebox - electric charge tracker and build helper.",
+  "author": "Ratzap",
+  "version": "1.3",
+  "download": "https://dl.dropboxusercontent.com/u/71576136/Fusebox_1_3.zip",
+  "x_maintained_by": "hakan42",
+  "download_size": 41761
+}


### PR DESCRIPTION
According to forum post, not on curse, and only on Dropbox, so updated link to
point to new version.