### PR TITLE
Add DDSLoader 1.9.0.0

### DIFF
--- a/DDSLoader/DDSLoader-1.9.0.0.ckan
+++ b/DDSLoader/DDSLoader-1.9.0.0.ckan
@@ -1,0 +1,15 @@
+{
+  "spec_version": 1,
+  "identifier": "DDSLoader",
+  "ksp_version": "0.90",
+  "resources": {
+    "homepage"   : "http://forum.kerbalspaceprogram.com/threads/96729",
+    "repository" : "https://github.com/sarbian/DDSLoader/"
+  },
+  "name": "DDSLoader",
+  "license": "CC-BY-NC-SA-4.0",
+  "abstract": "Loads DDS Textures boringly fast!",
+  "author": "sarbian",
+  "version": "1.9.0.0",
+  "download": "https://ksp.sarbian.com/jenkins/job/DDSLoader/lastSuccessfulBuild/artifact/DDSLoader-1.9.0.0.zip"
+}


### PR DESCRIPTION
Now loads DDS textures boringly fast, with boringly fewer bugs!

```
$ ckan.exe show DDSLoader
DDSLoader: Loads DDS Textures boringly fast!

Module info:
- version:  1.9.0.0
- authors:  sarbian
- status:   stable
- license:  CC-BY-NC-SA-4.0

Provides:
- DDSLoader

Resources:
- homepage: http://forum.kerbalspaceprogram.com/threads/96729
- repository: https://github.com/sarbian/DDSLoader/

Showing 4 installed files:
- GameData/DDSLoader
- GameData/DDSLoader/DDSLoader.cfg
- GameData/DDSLoader/DDSLoader.dll
- GameData/DDSLoader/LICENSE.txt
```