### PR TITLE
Add PlanetFactoryCE-core

### DIFF
--- a/PlanetFactoryCE-core/PlanetFactoryCE-core.ckan
+++ b/PlanetFactoryCE-core/PlanetFactoryCE-core.ckan
@@ -1,0 +1,24 @@
+{
+	"spec_version"		: "v1.4",
+	"ksp_version"		: "0.90",
+	"identifier"		: "PlanetFactoryCE-core",
+	"version"			: "beta",
+	"name"				: "Planet Factory CE core",
+	"author"			: "Kragrathea",
+	"abstract"			: "Core files for Planet factory CE",
+	"license"			: "GPL-3.0",
+	"resources"			: { "homepage" : "http://forum.kerbalspaceprogram.com/threads/65401"},
+	"download"			: "https://tlwcbw.dm2301.livefilestore.com/y2mK5vetKfHkFFI0RbKP7GjXVPO7edKXwBqqCxbmCRbYyurslvn2vxHap57Mj_J1XKWA5SIWETlsXegNffi7IYTOtBrq5XF9cu3dGcGnBIyvQfi8T2EL8dtHNpL6UqW81o2mvtEmghv2QawqXIsEsjNpP6VulI_F7EN5cVGBjzVYqE/PlanetFactory-Dec30-2014.zip?download&psid=1",
+	"install"			: [
+					{
+					"file" : "PlanetFactory",
+					"install_to" : "GameData",
+					"filter_regexp" : "^(?!PlanetFactory/PlanetFactory.dll)"
+					},
+					{
+					"file" : "PlanetFactory/PluginData/PlanetFactory",
+					"install_to" : "GameData/PlanetFactory/PluginData",
+					"filter_regexp" : "^(?!PlanetFactory/PluginData/PlanetFactory/PlanetFactory.cfg)"
+					}
+		]
+}

--- a/PlanetFactoryCE-core/PlanetFactoryCE-core.ckan
+++ b/PlanetFactoryCE-core/PlanetFactoryCE-core.ckan
@@ -14,11 +14,6 @@
 					"file" : "PlanetFactory",
 					"install_to" : "GameData",
 					"filter_regexp" : "^(?!PlanetFactory/PlanetFactory.dll)"
-					},
-					{
-					"file" : "PlanetFactory/PluginData/PlanetFactory",
-					"install_to" : "GameData/PlanetFactory/PluginData",
-					"filter_regexp" : "^(?!PlanetFactory/PluginData/PlanetFactory/PlanetFactory.cfg)"
 					}
 		]
 }


### PR DESCRIPTION
I am unable to locate a version number and development have been cancelled so therefor the file has no version numbering.

I've seen a mod or two out in the wild that still appear to depend on this. Afaik it does not conflic with Kopernicus nor any of the other mods that muck about with planets. Specifically we have an old PR https://github.com/KSP-CKAN/NetKAN/pull/598 which seems to depend on this and/or the whole shebang seen in #345 