### PR TITLE
Update Near Future Spacecraft

### DIFF
--- a/NearFutureSpacecraft/NearFutureSpacecraft-0.3.1.ckan
+++ b/NearFutureSpacecraft/NearFutureSpacecraft-0.3.1.ckan
@@ -25,7 +25,8 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/52042-0-21",
         "kerbalstuff": "https://kerbalstuff.com/mod/350/Near%20Future%20Spacecraft%20Parts"
     },
-    "ksp_version": "0.25",
+    "ksp_version_min": "0.25",
+    "ksp_version_max": "0.90",
     "name": "Near Future Spacecraft Parts",
     "abstract": "Stockalike parts for constructing futuristic spacecraft",
     "author": "Nertea",


### PR DESCRIPTION
Nertea updated the [forum page for Near Future Technologies](http://forum.kerbalspaceprogram.com/threads/52042), confirming that Near Future Spacecraft Parts v3.1 is compatible with KSP 0.90.