### PR TITLE
Updating HotRockets to 0.90 and adding Community Configs

### DIFF
--- a/HotRockets/HotRockets-7.9.ckan
+++ b/HotRockets/HotRockets-7.9.ckan
@@ -1,0 +1,25 @@
+{
+    "spec_version" : 1,
+    "name"         : "HotRockets! Particle FX Replacement",
+    "abstract"     : "Replacement for stock engine particle FX",
+    "identifier"   : "HotRockets",
+    "download"     : "http://addons-origin.cursecdn.com/files/2227/270/HotRockets_7.9_CorePack.zip",
+    "license"      : "CC-BY-NC",
+    "author"       : [ "Nazari1382" ],
+    "version"      : "7.9",
+    "release_status" : "stable",
+    "ksp_version"  : "0.90",
+    "resources" : {
+        "homepage" : "http://forum.kerbalspaceprogram.com/threads/65754"
+    },
+    "install" : [
+        {
+            "file"       : "MP_Nazari",
+            "install_to" : "GameData"
+        }
+    ],
+    "depends" : [
+        { "name" : "ModuleManager", "min_version" : "2.5.1" },
+		{ "name" : "SmokeScreen", "min_version" : "2.5.0" }
+    ]
+}

--- a/HotRocketsCommunityConfigs/HotRocketsCommunityConfigs-7.25.ckan
+++ b/HotRocketsCommunityConfigs/HotRocketsCommunityConfigs-7.25.ckan
@@ -1,0 +1,24 @@
+{
+    "spec_version" : 1,
+    "name"         : "HotRockets - Community Configs",
+    "abstract"     : "Community configs for popular partpacks",
+    "identifier"   : "HotRocketsCommunityConfigs",
+    "download"     : "http://addons-origin.cursecdn.com/files/2216/165/HotRockets_Community_CFGs.zip",
+    "license"      : "CC-BY-NC",
+    "author"       : [ "Nazari1382" ],
+    "version"      : "7.25",
+    "release_status" : "stable",
+    "ksp_version"  : "0.25",
+    "resources" : {
+        "homepage" : "http://forum.kerbalspaceprogram.com/threads/65754"
+    },
+    "install" : [
+        {
+            "file"       : "MP_Nazari",
+            "install_to" : "GameData"
+        }
+    ],
+    "depends" : [
+        { "name" : "HotRockets", "max_version" : "7.25" }
+    ]
+}

--- a/HotRocketsCommunityConfigs/HotRocketsCommunityConfigs-7.25.ckan
+++ b/HotRocketsCommunityConfigs/HotRocketsCommunityConfigs-7.25.ckan
@@ -8,7 +8,8 @@
     "author"       : [ "Nazari1382" ],
     "version"      : "7.25",
     "release_status" : "stable",
-    "ksp_version"  : "0.25",
+    "ksp_version_min"  : "0.25",
+	"ksp_version_max"	: "0.90",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/65754"
     },

--- a/HotRocketsEmissivePatch/HotRocketsEmissivePatch-7.9.ckan
+++ b/HotRocketsEmissivePatch/HotRocketsEmissivePatch-7.9.ckan
@@ -1,0 +1,24 @@
+{
+    "spec_version" : 1,
+    "name"         : "HotRockets - Emissive patch",
+    "abstract"     : "A simple patch to adjust the emissive color of the Turbofan engine",
+    "identifier"   : "HotRocketsEmissivePatch",
+    "download"     : "http://addons-origin.cursecdn.com/files/2227/269/HotRockets%20emissive%20patch.zip",
+    "license"      : "CC-BY-NC",
+    "author"       : [ "Nazari1382" ],
+    "version"      : "7.9",
+    "release_status" : "stable",
+    "ksp_version"  : "0.90",
+    "resources" : {
+        "homepage" : "http://forum.kerbalspaceprogram.com/threads/65754"
+    },
+    "install" : [
+        {
+            "file"       : "MP_Nazari",
+            "install_to" : "GameData"
+        }
+    ],
+    "depends" : [
+        { "name" : "HotRockets", "min_version" : "7.9" }
+    ]
+}


### PR DESCRIPTION
closes https://github.com/KSP-CKAN/CKAN-meta/issues/5

Community Configs are only 0.25 compliant in accordance with curseforge, they probably work with 0.90 but right now I don't have the motivation to confirm this by reading through the whole HotRockets thread on forums so they're stuck at 0.25 for now.

Do note! I remembered newlines at the end of BOTH files \o/