### PR TITLE
Making AJE more obviously deprecated

### DIFF
--- a/AJE/AJE-1.7a.ckan
+++ b/AJE/AJE-1.7a.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
-    "name"     : "Advanced Jet Engine (AJE)",
-    "abstract" : "Realistic jet engines for KSP",
+    "name"     : "Advanced Jet Engine (AJE) - Deprecated",
+    "abstract" : "Deprecated version of AJE, you want the other one.",
     "identifier": "AJE",
     "download" : "https://github.com/camlost2/AJE/archive/1.7a.zip",
     "license"  : "LGPL-2.1",


### PR DESCRIPTION
closes https://github.com/KSP-CKAN/CKAN-meta/issues/217

Doing what I can to make it obvious that this version of AJE is the incorrect one and shouldn't be used.