### PR TITLE
Add Infernal Robotics Model Rework part packs

### DIFF
--- a/IRPartsReworkCoreRobotics/IRPartsReworkCoreRobotics-0.1a.ckan
+++ b/IRPartsReworkCoreRobotics/IRPartsReworkCoreRobotics-0.1a.ckan
@@ -1,0 +1,30 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "IRPartsReworkCoreRobotics",
+    "license": "CC-BY-NC-ND-4.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/65365",
+        "kerbalstuff": "https://kerbalstuff.com/mod/675"
+    },
+    "install": [
+        {
+            "file": "GameData/MagicSmokeIndustries/Parts/Rework_Core/Probe/Robotic",
+			"install_to": "GameData/MagicSmokeIndustries/Parts/Rework_Core/Probe"
+        }
+    ],
+    "provides": [ "IR-Model-Rework-Core" ],
+    "conflicts": [ { "name": "IR-Model-Rework-Core" } ],
+    "depends": [
+        { "name": "InfernalRobotics" }
+    ],
+    "recommends": [
+        { "name": "IRPartsReworkCoreStructural" }
+    ],
+    "ksp_version": "0.90",
+    "name": "Magic Smoke Industries Infernal Robotics - Core Robotics parts pack",
+    "abstract": "This package contains the robotic parts from the Core pack in various sizes to give players a taste of what can be achieved with robotics.",
+    "author": [ "ZodiusInfuser" ],
+    "version": "0.1a",
+    "download": "https://kerbalstuff.com/mod/675/Infernal%20Robotics%20Model%20Rework%20-%20Core%20Pack/download/v01a"
+}

--- a/IRPartsReworkCoreStructural/IRPartsReworkCoreStructural-0.1a.ckan
+++ b/IRPartsReworkCoreStructural/IRPartsReworkCoreStructural-0.1a.ckan
@@ -1,0 +1,22 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "IRPartsReworkCoreStructural",
+    "license": "CC-BY-NC-ND-4.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/65365",
+        "kerbalstuff": "https://kerbalstuff.com/mod/675"
+    },
+    "install": [
+        {
+            "file": "GameData/MagicSmokeIndustries/Parts/Rework_Core/Probe/Structural",
+			"install_to": "GameData/MagicSmokeIndustries/Parts/Rework_Core/Probe"
+        }
+    ],
+    "ksp_version": "0.90",
+    "name": "Magic Smoke Industries Infernal Robotics - Core parts pack - structural parts",
+    "abstract": "This package contains the structural parts from the Core pack in various sizes to accompany the Core Robotics parts.",
+    "author": [ "ZodiusInfuser" ],
+    "version": "0.1a",
+    "download": "https://kerbalstuff.com/mod/675/Infernal%20Robotics%20Model%20Rework%20-%20Core%20Pack/download/v01a"
+}

--- a/IRPartsReworkExpansion/IRPartsReworkExpansion-0.1a.ckan
+++ b/IRPartsReworkExpansion/IRPartsReworkExpansion-0.1a.ckan
@@ -1,0 +1,27 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "IRPartsReworkExpansion",
+    "license": "CC-BY-NC-ND-4.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/65365",
+        "kerbalstuff": "https://kerbalstuff.com/mod/676"
+    },
+    "install": [
+        {
+            "file": "GameData/MagicSmokeIndustries/Parts/Rework_Expansion",
+			"install_to": "GameData/MagicSmokeIndustries/Parts"
+        }
+    ],
+    "depends": [
+        { "name": "InfernalRobotics" }
+    ],
+    "provides": [ "IR-Model-Rework-Expansion" ],
+    "conflicts": [ { "name": "IR-Model-Rework-Expansion" } ],
+    "ksp_version": "0.90",
+    "name": "Magic Smoke Industries Infernal Robotics - Expansion pack",
+    "abstract": "This pack contains specialist rotational robotics and structural parts to allow for more interesting craft designs than are possible with the Core Pack alone.",
+    "author": [ "ZodiusInfuser" ],
+    "version": "0.1a",
+    "download": "https://kerbalstuff.com/mod/676/Infernal%20Robotics%20Model%20Rework%20-%20Expansion%20Pack/download/v01a"
+}

--- a/IRPartsReworkRoboStruts/IRPartsReworkRoboStruts-0.1a.ckan
+++ b/IRPartsReworkRoboStruts/IRPartsReworkRoboStruts-0.1a.ckan
@@ -1,0 +1,27 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "IRPartsReworkRoboStruts",
+    "license": "CC-BY-NC-ND-4.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/65365",
+        "kerbalstuff": "https://kerbalstuff.com/mod/677"
+    },
+    "install": [
+        {
+            "file": "GameData/MagicSmokeIndustries/Parts/Rework_Utility/Probe/Struts",
+			"install_to": "GameData/MagicSmokeIndustries/Parts/Rework_Utility/Probe"
+        }
+    ],
+    "depends": [
+        { "name": "InfernalRobotics" },
+        { "name": "ActiveStruts" },
+        { "name": "TweakableEverything" }
+    ],
+    "ksp_version": "0.90",
+    "name": "Magic Smoke Industries Infernal Robotics - RoboStruts part pack",
+    "abstract": "This pack contains a number of struts for when using robotics parts from the other packs. These are usually distributed as a part of the Utility pack.",
+    "author": [ "ZodiusInfuser" ],
+    "version": "0.1a",
+    "download": "https://kerbalstuff.com/mod/677/Infernal%20Robotics%20Model%20Rework%20-%20Utility%20Pack/download/v01a"
+}

--- a/IRPartsReworkTweakScale/IRPartsReworkTweakScale-0.1a.ckan
+++ b/IRPartsReworkTweakScale/IRPartsReworkTweakScale-0.1a.ckan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "IRPartsReworkTweakScale",
+    "license": "CC-BY-NC-ND-4.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/65365"
+    },
+    "install": [
+        {
+            "file" : "GameData/MagicSmokeIndustries/Parts/Rework_TweakScale.cfg",
+			"install_to" : "GameData/MagicSmokeIndustries/Parts"
+        }
+    ],
+    "depends": [
+        { "name": "InfernalRobotics" },
+        { "name": "TweakScale" }
+    ],
+    "ksp_version": "0.90",
+    "name": "Magic Smoke Industries Infernal Robotics - TweakScale support",
+    "abstract": "This adds TweakScale support to the Core, Expansion and Utility packs",
+    "author": [ "ZodiusInfuser" ],
+    "version": "0.1a",
+    "download": "https://kerbalstuff.com/mod/675/Infernal%20Robotics%20Model%20Rework%20-%20Core%20Pack/download/v01a"
+}

--- a/IRPartsReworkUtility/IRPartsReworkUtility-0.1a.ckan
+++ b/IRPartsReworkUtility/IRPartsReworkUtility-0.1a.ckan
@@ -1,0 +1,31 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "IRPartsReworkUtility",
+    "license": "CC-BY-NC-ND-4.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/65365",
+        "kerbalstuff": "https://kerbalstuff.com/mod/677"
+    },
+    "install": [
+        {
+            "file": "GameData/MagicSmokeIndustries/Parts/Rework_Utility",
+			"install_to": "GameData/MagicSmokeIndustries/Parts",
+            "filter": "Struts"
+        }
+    ],
+    "depends": [
+        { "name": "InfernalRobotics" }
+    ],
+    "recommends": [
+        { "name": "KAS" }
+    ],
+    "provides": [ "IR-Model-Rework-Utility" ],
+    "conflicts": [ { "name": "IR-Model-Rework-Utility" } ],
+    "ksp_version": "0.90",
+    "name": "Magic Smoke Industries Infernal Robotics - Utility Pack",
+    "abstract": "This pack contains a number of non-robotic parts to offer more interesting gameplay when using robotics parts from the other packs.",
+    "author": [ "ZodiusInfuser" ],
+    "version": "0.1a",
+    "download": "https://kerbalstuff.com/mod/677/Infernal%20Robotics%20Model%20Rework%20-%20Utility%20Pack/download/v01a"
+}

--- a/SETI-Greenhouse/SETI-Greenhouse-0.9.0.ckan
+++ b/SETI-Greenhouse/SETI-Greenhouse-0.9.0.ckan
@@ -1,28 +1,24 @@
 {
-    "spec_version": 1,
     "identifier": "SETI-Greenhouse",
+    "spec_version": 1,
     "license": "CC-BY-NC-SA-3.0",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/114133-0-90-SETI-Greenhouse",
+        "kerbalstuff": "https://kerbalstuff.com/mod/663/SETI-Greenhouse/"
+    },
     "install": [
         {
             "file": "SETIgreenhouse",
             "install_to": "GameData"
         }
     ],
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/114133",
-        "kerbalstuff": "https://kerbalstuff.com/mod/663/SETI-Greenhouse"
-    },
+    "depends" : [
+    	{"name" : "ModuleManager"}
+    ],
     "ksp_version": "0.90",
     "name": "SETI-Greenhouse",
-    "abstract": "Provides two basic greenhouse parts and a range of compatibility configs eg for TAC Life Support & BackgroundProcessing. Without those mods, the parts just look nice on space stations!",
+    "abstract": "The SETI-Greenhouse is a spinoff from the SETI-BalanceMod.",
     "author": "Yemo",
     "version": "0.9.0",
-    "download": "https://kerbalstuff.com/mod/663/SETI-Greenhouse/download/0.9.0",
-    "x_generated_by": "netkan",
-    "download_size": 1843260
+    "download": "https://kerbalstuff.com/mod/663/SETI-Greenhouse/download/0.9.0"
 }

--- a/SETI-Greenhouse/SETI-Greenhouse-0.9.0.ckan
+++ b/SETI-Greenhouse/SETI-Greenhouse-0.9.0.ckan
@@ -1,24 +1,28 @@
 {
-    "identifier": "SETI-Greenhouse",
     "spec_version": 1,
+    "identifier": "SETI-Greenhouse",
     "license": "CC-BY-NC-SA-3.0",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/114133-0-90-SETI-Greenhouse",
-        "kerbalstuff": "https://kerbalstuff.com/mod/663/SETI-Greenhouse/"
-    },
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "install": [
         {
             "file": "SETIgreenhouse",
             "install_to": "GameData"
         }
     ],
-    "depends" : [
-    	{"name" : "ModuleManager"}
-    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/114133",
+        "kerbalstuff": "https://kerbalstuff.com/mod/663/SETI-Greenhouse"
+    },
     "ksp_version": "0.90",
     "name": "SETI-Greenhouse",
-    "abstract": "The SETI-Greenhouse is a spinoff from the SETI-BalanceMod.",
+    "abstract": "Provides two basic greenhouse parts and a range of compatibility configs eg for TAC Life Support & BackgroundProcessing. Without those mods, the parts just look nice on space stations!",
     "author": "Yemo",
     "version": "0.9.0",
-    "download": "https://kerbalstuff.com/mod/663/SETI-Greenhouse/download/0.9.0"
+    "download": "https://kerbalstuff.com/mod/663/SETI-Greenhouse/download/0.9.0",
+    "x_generated_by": "netkan",
+    "download_size": 1843260
 }


### PR DESCRIPTION
Manually generated IR Model Rework part packs.

Differs from regular distribution to be more dependency-friendly:
- Split off TweakScale support into own package, making it optional
- Split off Struts from Utility pack into their own package due to multiple dependencies
- Split the Core pack into a Robotics and a Structual package. Structural parts can now be installed without the need for IR

Unfortunately, the Struts pack is untested as the ActiveStruts download URL is currently broken