### PR TITLE
Making ModuleFixer.ckan 0.90 compatible

### DIFF
--- a/ModuleFixer/ModuleFixer.ckan
+++ b/ModuleFixer/ModuleFixer.ckan
@@ -1,7 +1,9 @@
 {
 	"spec_version": 1,
 	"identifier": "ModuleFixer",
-	"ksp_version": "0.25",
+	"ksp_version_min" : "0.25",
+	"ksp_version_max" : "0.90",
+	"comment"		: "Updated to 0.90 compatible by Daz based on 0.90 mods still using it",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/63109"

--- a/ModuleFixer/ModuleFixer.ckan
+++ b/ModuleFixer/ModuleFixer.ckan
@@ -8,6 +8,15 @@
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/63109"
 	},
+	"conflicts" : [ { "name" : "Karbonite" },
+					{ "name" : "KarbonitePlus" },
+					{ "name" : "Regolith" },
+					{ "name" : "USI-ART" },
+					{ "name" : "USI-EXP" },
+					{ "name" : "USI-FTT" },
+					{ "name" : "USI-SRV" },
+					{ "name" : "USITools" },
+					{ "name" : "UKS" } ],
 	"name": "Module Fixer",
 	"license": "GPL-3.0",
 	"abstract": "This fixes the problems of exploding/expanding parts in the VAB while hovering over some parts in some mods.",


### PR DESCRIPTION
Needed for https://github.com/KSP-CKAN/NetKAN/pull/960 and the version does not appear to have changed from the 0.25 one so as such I'll bump this to 0.90 and keep it alive for a little longer.