### PR TITLE
Update FantomWorksKAXPartPack-0.2.ckan

### DIFF
--- a/FantomWorksKAXPartPack/FantomWorksKAXPartPack-0.2.ckan
+++ b/FantomWorksKAXPartPack/FantomWorksKAXPartPack-0.2.ckan
@@ -17,7 +17,7 @@
     "name": "FantomWorks KAX+ Part Pack",
     "abstract": "New aircraft parts in the style of KAX.",
     "author": "FreddyPhantom",
-    "version": "0.2",
+    "version": "0.20",
     "download": "https://kerbalstuff.com/mod/565/FantomWorks%20KAX+%20Part%20Pack/download/0.2",
     "x_generated_by": "netkan",
     "download_size": 2825395


### PR DESCRIPTION
CKAN doesn't recognize 0.2 is higher then 0.16 (0.1.6).