### PR TITLE
ModuleFixer conflict updates

### DIFF
--- a/ModuleFixer/ModuleFixer.ckan
+++ b/ModuleFixer/ModuleFixer.ckan
@@ -10,7 +10,7 @@
 	},
 	"conflicts" : [ { "name" : "Karbonite" },
 					{ "name" : "KarbonitePlus" },
-					{ "name" : "Regolith" },
+					{ "name" : "AlcubierreStandalone" },
 					{ "name" : "USI-ART" },
 					{ "name" : "USI-EXP" },
 					{ "name" : "USI-FTT" },


### PR DESCRIPTION
Changing this to no longer conflict with Regolith since that has extremely detrimental effects on RO which recommends both `ModuleFixer` and `UniversalStorage` where the latter depends on `Regolith`.

This change makes ModuleFixer maintain its conflict with all USI partmods but not with the regolith.dll which should appease all parties.