### PR TITLE
Fix many version fields before 1.0

### DIFF
--- a/AIESAerospace-Unofficial/AIESAerospace-Unofficial-v1.5.1.ckan
+++ b/AIESAerospace-Unofficial/AIESAerospace-Unofficial-v1.5.1.ckan
@@ -2,6 +2,7 @@
 	"spec_version": 1,
 	"identifier": "AIESAerospace-Unofficial",
 	"ksp_version_min": "0.23",
+	"ksp_version_max": "0.90",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/35383-0-23-AIES-Aerospace-v1-5-1"

--- a/AstronomersPack-AtmosphericScattering/AstronomersPack-AtmosphericScattering-Interstellar-V2.ckan
+++ b/AstronomersPack-AtmosphericScattering/AstronomersPack-AtmosphericScattering-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack option",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-Auroras-4K/AstronomersPack-Auroras-4K-Interstellar-V2.ckan
+++ b/AstronomersPack-Auroras-4K/AstronomersPack-Auroras-4K-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack option",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-Auroras-8K/AstronomersPack-Auroras-8K-Interstellar-V2.ckan
+++ b/AstronomersPack-Auroras-8K/AstronomersPack-Auroras-8K-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack option",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-Clouds-High/AstronomersPack-Clouds-High-Interstellar-V2.ckan
+++ b/AstronomersPack-Clouds-High/AstronomersPack-Clouds-High-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack core EVE configuration, with high-resolution volumetric clouds.",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-Clouds-Low/AstronomersPack-Clouds-Low-Interstellar-V2.ckan
+++ b/AstronomersPack-Clouds-Low/AstronomersPack-Clouds-Low-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack core EVE configuration, with low-resolution volumetric clouds.",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-Clouds-Medium/AstronomersPack-Clouds-Medium-Interstellar-V2.ckan
+++ b/AstronomersPack-Clouds-Medium/AstronomersPack-Clouds-Medium-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack core EVE configuration, with medium-resolution volumetric clouds.",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-DistantObjectEnhancement/AstronomersPack-DistantObjectEnhancement-Interstellar-V2.ckan
+++ b/AstronomersPack-DistantObjectEnhancement/AstronomersPack-DistantObjectEnhancement-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Distant Object Enhancement Configuration from Astronomer's Pack.",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-Eve-Jool-Clouds-2K/AstronomersPack-Eve-Jool-Clouds-2K-Interstellar-V2.ckan
+++ b/AstronomersPack-Eve-Jool-Clouds-2K/AstronomersPack-Eve-Jool-Clouds-2K-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack option",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-Eve-Jool-Clouds-4K/AstronomersPack-Eve-Jool-Clouds-4K-Interstellar-V2.ckan
+++ b/AstronomersPack-Eve-Jool-Clouds-4K/AstronomersPack-Eve-Jool-Clouds-4K-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack option",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-Eve-Jool-Clouds-8K/AstronomersPack-Eve-Jool-Clouds-8K-Interstellar-V2.ckan
+++ b/AstronomersPack-Eve-Jool-Clouds-8K/AstronomersPack-Eve-Jool-Clouds-8K-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack option",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-Lightning/AstronomersPack-Lightning-Interstellar-V2.ckan
+++ b/AstronomersPack-Lightning/AstronomersPack-Lightning-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack option",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-PlanetShine/AstronomersPack-PlanetShine-Interstellar-V2.ckan
+++ b/AstronomersPack-PlanetShine/AstronomersPack-PlanetShine-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack PlanetShine configuration.",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-Sandstorms/AstronomersPack-Sandstorms-Interstellar-V2.ckan
+++ b/AstronomersPack-Sandstorms/AstronomersPack-Sandstorms-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack option",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-Snow/AstronomersPack-Snow-Interstellar-V2.ckan
+++ b/AstronomersPack-Snow/AstronomersPack-Snow-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack option",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack-SurfaceGlow/AstronomersPack-SurfaceGlow-Interstellar-V2.ckan
+++ b/AstronomersPack-SurfaceGlow/AstronomersPack-SurfaceGlow-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Astronomer's Pack option",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/AstronomersPack/AstronomersPack-Interstellar-V2.ckan
+++ b/AstronomersPack/AstronomersPack-Interstellar-V2.ckan
@@ -5,6 +5,7 @@
     "abstract": "Meta-package for Astronomer's Visual Pack and its options",
     "license": "restricted",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "http://kerbal.curseforge.com/ksp-mods/220335"
     },

--- a/BananaForScale-large/BananaForScale-large-1.0.ckan
+++ b/BananaForScale-large/BananaForScale-large-1.0.ckan
@@ -6,6 +6,7 @@
     "license"      : "restricted",
     "author"       : "JoePatrick1",
     "version"      : "1.0",
+	"ksp_version_max": "0.90",
     "conflicts": [
         { "name": "BananaForScale-small" }
     ],

--- a/BananaForScale-small/BananaForScale-small-1.0.ckan
+++ b/BananaForScale-small/BananaForScale-small-1.0.ckan
@@ -6,6 +6,7 @@
     "license"      : "restricted",
     "author"       : "JoePatrick1",
     "version"      : "1.0",
+	"ksp_version_max": "0.90",
     "conflicts": [
         { "name": "BananaForScale-large" }
     ],

--- a/DockingPortAlignmentIndicator/DockingPortAlignmentIndicator-4.0.ckan
+++ b/DockingPortAlignmentIndicator/DockingPortAlignmentIndicator-4.0.ckan
@@ -9,6 +9,7 @@
     "author"       : "NavyFish",
     "version"      : "4.0",
     "ksp_version_min"  : "0.25",
+	"ksp_version_max": "0.90",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/43901"
     },

--- a/EditorExtensions/EditorExtensions-2.2.ckan
+++ b/EditorExtensions/EditorExtensions-2.2.ckan
@@ -12,5 +12,5 @@
   "download": "https://github.com/MachXXV/EditorExtensions/releases/download/v2.2/EditorExtensions_v2.2.zip",
   "x_generated_by": "netkan",
   "download_size": 14814,
-  "ksp_version_min": "0.90.0"
+  "ksp_version": "0.90"
 }

--- a/EditorExtensions/EditorExtensions-2.3.ckan
+++ b/EditorExtensions/EditorExtensions-2.3.ckan
@@ -12,5 +12,5 @@
   "download": "https://github.com/MachXXV/EditorExtensions/releases/download/v2.3/EditorExtensions_v2.3.zip",
   "x_generated_by": "netkan",
   "download_size": 15724,
-  "ksp_version_min": "0.90.0"
+  "ksp_version": "0.90"
 }

--- a/EnvironmentalVisualEnhancements-HR/EnvironmentalVisualEnhancements-HR-7-4.ckan
+++ b/EnvironmentalVisualEnhancements-HR/EnvironmentalVisualEnhancements-HR-7-4.ckan
@@ -5,6 +5,7 @@
     "abstract": "Default configuration for EVE",
     "license": "MIT",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "https://github.com/rbray89/EnvironmentalVisualEnhancements"
     },

--- a/EnvironmentalVisualEnhancements-LR/EnvironmentalVisualEnhancements-LR-7-4.ckan
+++ b/EnvironmentalVisualEnhancements-LR/EnvironmentalVisualEnhancements-LR-7-4.ckan
@@ -5,6 +5,7 @@
     "abstract": "Default configuration for EVE",
     "license": "MIT",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "https://github.com/rbray89/EnvironmentalVisualEnhancements"
     },

--- a/EnvironmentalVisualEnhancements/EnvironmentalVisualEnhancements-7-4.ckan
+++ b/EnvironmentalVisualEnhancements/EnvironmentalVisualEnhancements-7-4.ckan
@@ -5,6 +5,7 @@
     "abstract": "City Lights for Kerbin and Clouds for Any planet you wish",
     "license": "MIT",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "https://github.com/rbray89/EnvironmentalVisualEnhancements"
     },

--- a/HyperEdit/HyperEdit-1.2.4.2.ckan
+++ b/HyperEdit/HyperEdit-1.2.4.2.ckan
@@ -16,6 +16,7 @@
   ],
   
   "ksp_version_min": "0.21.1",
+  "ksp_version_max": "0.90",
   "license": "restricted",
   "author": [ "khyperia", "Payo", "sirkut", "Ezriilc" ],
   "version": "1.2.4.2",

--- a/HyperEdit/HyperEdit-1.3.ckan
+++ b/HyperEdit/HyperEdit-1.3.ckan
@@ -15,7 +15,7 @@
     }
   ],
   
-  "ksp_version_min": "0.90.0",
+  "ksp_version": "0.90",
   "license": "restricted",
   "author": [ "khyperia", "Payo", "sirkut", "Ezriilc" ],
   "version": "1.3",

--- a/ImprovedChaseCamera/ImprovedChaseCamera-1.4.0.ckan
+++ b/ImprovedChaseCamera/ImprovedChaseCamera-1.4.0.ckan
@@ -14,6 +14,7 @@
     }
   ],
   "ksp_version_min": "0.24",
+  "ksp_version_max": "0.90",
   "name": "Improved Chase Cameras",
   "abstract": "This plugin gives you the option to make the chase camera follow your surface velocity vector, instead of being rigidly attached to your plane.",
   "author": "BahamutoD",

--- a/JSIPartUtilities/JSIPartUtilities-v0.2.ckan
+++ b/JSIPartUtilities/JSIPartUtilities-v0.2.ckan
@@ -5,6 +5,7 @@
     "name"         : "JSI Part Utilities",
     "abstract"     : "This is a collection of small and relatively simple PartModules",
     "license"      : "GPL-3.0",
+	"ksp_version_max": "0.90",
     "resources": {
         "repository": "https://github.com/Mihara/PartUtilities",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/88366"

--- a/KSP-AVC/KSP-AVC-1.1.5.0.ckan
+++ b/KSP-AVC/KSP-AVC-1.1.5.0.ckan
@@ -1,7 +1,7 @@
 {
 	"spec_version": 1,
 	"identifier": "KSP-AVC",
-	"ksp_version": "any",
+	"ksp_version_max": "0.90",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/79745",

--- a/KerbalFoundries/KerbalFoundries-Alpha_1.7c.ckan
+++ b/KerbalFoundries/KerbalFoundries-Alpha_1.7c.ckan
@@ -3,6 +3,7 @@
     "identifier": "KerbalFoundries",
     "license": "GPL-3.0",
     "ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
     "recommends": [
         {
             "name": "TweakScale"

--- a/Kopernicus-Config-Default/Kopernicus-Config-Default-pre-alpha-04.ckan
+++ b/Kopernicus-Config-Default/Kopernicus-Config-Default-pre-alpha-04.ckan
@@ -26,6 +26,6 @@
     "version": "pre-alpha-04",
     "download": "https://github.com/BryceSchroeder/Kopernicus/releases/download/pre-alpha-04/Kopernicus.0.0.4.zip",
     "x_generated_by": "netkan",
-    "download_size": 56884
-	"ksp_version_max": "0.90",
+    "download_size": 56884,
+	"ksp_version_max": "0.90"
 }

--- a/Kopernicus-Config-Default/Kopernicus-Config-Default-pre-alpha-04.ckan
+++ b/Kopernicus-Config-Default/Kopernicus-Config-Default-pre-alpha-04.ckan
@@ -27,4 +27,5 @@
     "download": "https://github.com/BryceSchroeder/Kopernicus/releases/download/pre-alpha-04/Kopernicus.0.0.4.zip",
     "x_generated_by": "netkan",
     "download_size": 56884
+	"ksp_version_max": "0.90",
 }

--- a/Kopernicus-Config-Default/Kopernicus-Config-Default-pre-alpha-06.ckan
+++ b/Kopernicus-Config-Default/Kopernicus-Config-Default-pre-alpha-06.ckan
@@ -26,6 +26,6 @@
     "version": "pre-alpha-06",
     "download": "https://github.com/BryceSchroeder/Kopernicus/releases/download/pre-alpha-06/Kopernicus.0.0.6.zip",
     "x_generated_by": "netkan",
-    "download_size": 56884
-	"ksp_version_max": "0.90",
+    "download_size": 56884,
+	"ksp_version_max": "0.90"
 }

--- a/Kopernicus-Config-Default/Kopernicus-Config-Default-pre-alpha-06.ckan
+++ b/Kopernicus-Config-Default/Kopernicus-Config-Default-pre-alpha-06.ckan
@@ -27,4 +27,5 @@
     "download": "https://github.com/BryceSchroeder/Kopernicus/releases/download/pre-alpha-06/Kopernicus.0.0.6.zip",
     "x_generated_by": "netkan",
     "download_size": 56884
+	"ksp_version_max": "0.90",
 }

--- a/LargeStructuralComponents/LargeStructuralComponents-10.ckan
+++ b/LargeStructuralComponents/LargeStructuralComponents-10.ckan
@@ -8,6 +8,7 @@
     "version"        : "10",
     "release_status" : "stable",
     "ksp_version_min"    : "0.20",
+	"ksp_version_max": "0.90",
 	"author" : "udk_lethal_d0se",
 	"description" : " This project is on hold and was not updated until KSP 0.20 but still works and looks awsome",
     "resources" : {

--- a/NavBallTextureExport/NavBallTextureExport-1.3.ckan
+++ b/NavBallTextureExport/NavBallTextureExport-1.3.ckan
@@ -10,6 +10,7 @@
     "author": "xEvilReeperx",
     "release_status": "stable",
     "ksp_version_min": "0.24",
+	"ksp_version_max" : "0.90",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/69540-Making-high-contrast-nav-ball!?p=969741&viewfull=1#post969741",
         "repository": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger",

--- a/PorkjetHabitats/PorkjetHabitats-v0.4.ckan
+++ b/PorkjetHabitats/PorkjetHabitats-v0.4.ckan
@@ -2,6 +2,7 @@
 	"spec_version": 1,
 	"identifier": "PorkjetHabitats",
 	"ksp_version_min": "0.25",
+	"ksp_version_max":	"0.90",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/64442-Habitat-Pack"

--- a/ProceduralParts-Textures-SCCKSCS/ProceduralParts-Textures-SCCKSCS-v0.ckan
+++ b/ProceduralParts-Textures-SCCKSCS/ProceduralParts-Textures-SCCKSCS-v0.ckan
@@ -2,6 +2,7 @@
 	"spec_version": 1,
 	"identifier": "ProceduralParts-Textures-SCCKSCS",
 	"ksp_version_min": "0.23.5",
+	"ksp_version_max":	"0.90",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/68892"

--- a/ProceduralParts-Textures-SaturnNova/ProceduralParts-Textures-SaturnNova-v1.ckan
+++ b/ProceduralParts-Textures-SaturnNova/ProceduralParts-Textures-SaturnNova-v1.ckan
@@ -2,6 +2,7 @@
 	"spec_version": 1,
 	"identifier": "ProceduralParts-Textures-SaturnNova",
 	"ksp_version_min": "0.23.5",
+	"ksp_version_max":	"0.90",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/70676"

--- a/PunishTheLazy/PunishTheLazy-0.01.ckan
+++ b/PunishTheLazy/PunishTheLazy-0.01.ckan
@@ -8,6 +8,7 @@
     "version"  : "0.01",
     "release_status" : "stable",
     "ksp_version_min" : "0.24.2",
+	"ksp_version_max":	"0.90",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/87659",
         "github"   : {

--- a/RCSLandAid/RCSLandAid-2.1.ckan
+++ b/RCSLandAid/RCSLandAid-2.1.ckan
@@ -5,7 +5,7 @@
   "abstract": "Kill your horizontal velocity to land, or hover over a specific point on the ground",
   "license": "GPL-3.0",
   "release_status": "stable",
-  "ksp_version": "any",
+  "ksp_version_max":	"0.90",
   "author": "Diazo",
   "suggests": [
     {

--- a/ResetSAS/ResetSAS-0.01.ckan
+++ b/ResetSAS/ResetSAS-0.01.ckan
@@ -7,7 +7,7 @@
     "license"  : "MIT",
     "version"  : "0.01",
     "release_status" : "stable",
-    "ksp_version_min" : "0.90.0",
+    "ksp_version" : "0.90",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/106487",
         "github"   : {

--- a/RocketdyneF-1/RocketdyneF-1-1.2.ckan
+++ b/RocketdyneF-1/RocketdyneF-1-1.2.ckan
@@ -2,6 +2,7 @@
 	"spec_version": 1,
 	"identifier": "RocketdyneF-1",
 	"ksp_version_min": "0.25",
+	"ksp_version_max":	"0.90",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/47892"

--- a/Service-Compartments-6S/Service-Compartments-6S-1.2.ckan
+++ b/Service-Compartments-6S/Service-Compartments-6S-1.2.ckan
@@ -2,6 +2,7 @@
 	"spec_version": 1,
 	"identifier": "Service-Compartments-6S",
 	"ksp_version_min": "0.25",
+	"ksp_version_max":	"0.90",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/61040-0-23-6S-Service-Compartment-Tubes-Design-smooth!"

--- a/Service-Compartments-6S/Service-Compartments-6S-1.3.ckan
+++ b/Service-Compartments-6S/Service-Compartments-6S-1.3.ckan
@@ -12,6 +12,7 @@
 	"author": "nothke",
 	"download": "http://addons.cursecdn.com/files/2221/294/Nothke_SerCom_v1.3.zip",
 	"ksp_version_min": "0.25",
+	"ksp_version_max":	"0.90",
 	"x_maintained_by" : "Hand packaged by hakan42, if anything's wrong, it's my fault.",
 	"install": [
         {

--- a/SpaceFactory-Unofficial/SpaceFactory-Voskhod-v1-unofficial.ckan
+++ b/SpaceFactory-Unofficial/SpaceFactory-Voskhod-v1-unofficial.ckan
@@ -2,6 +2,7 @@
 	"spec_version": 1,
 	"identifier": "SpaceFactory-Voskhod-unofficial",
 	"ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/47765"

--- a/SpaceFactory-Unofficial/SpaceFactory-Vostok-v1-unofficial.ckan
+++ b/SpaceFactory-Unofficial/SpaceFactory-Vostok-v1-unofficial.ckan
@@ -2,6 +2,7 @@
 	"spec_version": 1,
 	"identifier": "SpaceFacotry-Vostok-unofficial",
 	"ksp_version_min": "0.25",
+	"ksp_version_max": "0.90",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/47765"

--- a/SwitchVessel/SwitchVessel-0.4.ckan
+++ b/SwitchVessel/SwitchVessel-0.4.ckan
@@ -10,7 +10,7 @@
     ],
     "download": "https://docs.google.com/uc?export=download&id=0B1i-cKjnAQUHYXNjb2RxcDhSd0U",
     "identifier": "SwitchVessel",
-    "ksp_version_min": "0.90",
+    "ksp_version": "0.90",
     "license": "BSD-2-clause",
     "name": "Switch Active Vessel",
     "resources": {

--- a/TCShipInfo/ShipInfo-0.3.ckan
+++ b/TCShipInfo/ShipInfo-0.3.ckan
@@ -6,6 +6,7 @@
     "download": "https://docs.google.com/uc?export=download&id=0B1i-cKjnAQUHRTJxaDllS0NFMTQ",
     "identifier": "TCShipInfo",
     "ksp_version_min": "0.24.2",
+	"ksp_version_max": "0.90",
     "license": "public-domain",
     "name": "Resource Details in Tracking Center",
     "resources": {

--- a/Toolbar/Toolbar-1.7.8.ckan
+++ b/Toolbar/Toolbar-1.7.8.ckan
@@ -8,7 +8,7 @@
     "license"        : "BSD-2-clause",
     "version"        : "1.7.8",
     "release_status" : "stable",
-    "ksp_version_min"    : "0.90",
+    "ksp_version"    : "0.90",
     "resources" : {
         "homepage"     : "http://forum.kerbalspaceprogram.com/threads/60863",
         "repository"   : "https://github.com/blizzy78/ksp_toolbar"

--- a/TreeLoader/TreeLoader-1.1.5.ckan
+++ b/TreeLoader/TreeLoader-1.1.5.ckan
@@ -6,6 +6,7 @@
     "version"           : "1.1.5",
     "abstract"          : "Custom Career Tech-tree Loader",
     "ksp_version_min"   : "0.23.5",
+	"ksp_version_max": "0.90",
     "license"           : "unknown",
     "x_maintained_by"   : "distantcam",
 

--- a/VNG-Parachute-EVALoading/VNG-Parachute-EVALoading-1.0.ckan
+++ b/VNG-Parachute-EVALoading/VNG-Parachute-EVALoading-1.0.ckan
@@ -9,6 +9,7 @@
     "comment"        : "actual licensing wording was more like WTFPL",
     "version"        : "1.0",
     "release_status" : "stable",
+	"ksp_version_max": "0.90",
     "author"         : "Fel",
     "resources" : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/threads/25305?p=442982&viewfull=1#post442982"

--- a/surfacelights/SurfaceLights-1.0.ckan
+++ b/surfacelights/SurfaceLights-1.0.ckan
@@ -7,6 +7,7 @@
   "abstract" : "Surface Mounted Stock-Alike Lights for Self-Illumination",
   "license" : "CC-BY-NC-ND-3.0",
   "ksp_version_min": "0.24",
+	"ksp_version_max": "0.90",
   "resources": {
     "homepage": "http://forum.kerbalspaceprogram.com/threads/57778",
     "x_curse": "http://kerbal.curseforge.com/ksp-mods/220942-surfacelights-surface-mounted-stock-alike-lights"


### PR DESCRIPTION
I faked a 1.0 install to see what would show up in CKAN. This is a first batch of fixed version fields in .ckan files handpackaged for CKAN-meta or in some cases older files generated from NetKAN.

Since some of them tell me who to blame I'll throw some blame on @Felger and @hakan42 for doing mistakes anyone could have done! Or maybe I'm the one doing mistakes by marking mods not working for 1.0 when in reality they'll be fine?

Basically I'm changing mods to stop their compatibility at 0.90 instead of being compatibile for "any" version or just anything from version X through the usage of `ksp_version_min`.

This is related to https://github.com/KSP-CKAN/NetKAN/issues/1002

TL;DR: I'm adding a metric tonne of `"ksp_version_max" : "0.90",` lines