### PR TITLE
Manual change so newest firespittercore shows in CKAN

### DIFF
--- a/FirespitterCore/FirespitterCore-7.0.5463.30802.ckan
+++ b/FirespitterCore/FirespitterCore-7.0.5463.30802.ckan
@@ -7,7 +7,7 @@
    "license" : "restricted",
    "release_status" : "stable",
    "version" : "7.0.5463.30802",
-   "ksp_version" : "0.90",
+   "ksp_version_min" : "0.90",
    "download" : "http://firespitter.s3.amazonaws.com/FirespitterCore-7.0.5463.30802.zip",
    "author" : "Snjo",
    "install" : [


### PR DESCRIPTION
A bucketload of mods depend on this. Right now the older version is showing up for 1.0 and if we assume the original author was right in it working for any ksp version, this will aswell.