### PR TITLE
Treeloader should not show up in 1.0

### DIFF
--- a/TreeLoader/TreeLoader-1.1.5.ckan
+++ b/TreeLoader/TreeLoader-1.1.5.ckan
@@ -6,6 +6,7 @@
     "version"           : "1.1.5",
     "abstract"          : "Custom Career Tech-tree Loader",
     "ksp_version_min"   : "0.23.5",
+	"ksp_version_max"	: "0.90",
     "license"           : "unknown",
     "x_maintained_by"   : "distantcam",
 


### PR DESCRIPTION
Yay TechTree config files in a KSP 1.0 install near you, this mod was already deprecated by TechManager and now we're putting it to sleep in 0.90 land.