### PR TITLE
Manual additions of Tantares for 1.0

### DIFF
--- a/Tantares/Tantares-24.0.ckan
+++ b/Tantares/Tantares-24.0.ckan
@@ -1,0 +1,30 @@
+{
+    "spec_version": 1,
+    "name": "Tantares",
+    "identifier": "Tantares",
+    "author": "Beale",
+    "abstract": "Stockalike Soyuz and MIR",
+    "license": "CC-BY-NC-SA-4.0",
+    "release_status": "stable",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/81537",
+        "kerbalstuff": "https://kerbalstuff.com/mod/303"
+    },
+    "suggests": [
+        {
+            "name": "CommunityTechTree"
+        }
+    ],
+    "install": [
+        {
+            "file": "GameData/Tantares",
+            "install_to": "GameData"
+        }
+    ],
+    "x_maintained_by": "eagleshift",
+    "version": "24.0",
+    "download": "https://kerbalstuff.com/mod/303/Tantares%20-%20Stockalike%20Soyuz%20&%20More/download/24.0",
+    "x_generated_by": "netkan",
+    "download_size": 21803240
+}

--- a/TantaresLV/TantaresLV-9.0.ckan
+++ b/TantaresLV/TantaresLV-9.0.ckan
@@ -1,0 +1,32 @@
+{
+    "spec_version": 1,
+    "name": "Tantares LV",
+    "identifier": "TantaresLV",
+    "author": "Beale",
+    "abstract": "Stockalike Proton & More",
+    "license": "CC-BY-NC-SA-4.0",
+    "release_status": "stable",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/81537",
+        "kerbalstuff": "https://kerbalstuff.com/mod/362"
+    },
+    "suggests": [
+        {
+            "name": "Tantares"
+        },
+        {
+            "name": "CommunityTechTree"
+        }
+    ],
+    "install": [
+        {
+            "file": "GameData/TantaresLV",
+            "install_to": "GameData"
+        }
+    ],
+    "version": "9.0",
+    "download": "https://kerbalstuff.com/mod/362/Tantares%20LV%20-%20Stockalike%20Proton%20&%20More/download/9.0",
+    "x_generated_by": "netkan",
+    "download_size": 6010781
+}


### PR DESCRIPTION
Right now the mods are very old in CKAN and 1.0 is breaking them. This is causing grief to the mod author so I built these using the .netkan files we have indexed using an older netkan.exe (netkan 124 over at nightly builds).

If Jenkins approves (he works here since they are ksp_version_min 0.25) I'll add these.