### PR TITLE
Added kOS 0.17.2 pre-release to get 1.0.0 compat

### DIFF
--- a/kOS/kOS-0.17.2.ckan
+++ b/kOS/kOS-0.17.2.ckan
@@ -1,0 +1,42 @@
+{
+    "spec_version": 1,
+    "identifier": "kOS",
+    "license": "GPL-3.0",
+    "release_status": "testing",
+    "resources": {
+        "manual": "http://ksp-kos.github.io/KOS_DOC/",
+        "github": {
+            "url": "https://github.com/KSP-KOS/KOS",
+            "releases": true
+        },
+        "homepage": "http://ksp-kos.github.io/KOS_DOC/",
+        "kerbalstuff": "https://kerbalstuff.com/mod/86/kOS:%20Scriptable%20Autopilot%20System"
+    },
+    "install": [
+        {
+            "file": "GameData/kOS",
+            "install_to": "GameData"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.5.6",
+            "comment": "Earlier versions of MM have forward compatibility problems, according to the MM release notes."
+        }
+    ],
+    "suggests": [
+        {
+            "name": "RemoteTech",
+            "min_version": "1.5.1",
+            "comment": "RT gives incentive to having local control of craft, even unmanned ones"
+        }
+    ],
+    "ksp_version": "1.0.0",
+    "name": "kOS: Scriptable Autopilot System",
+    "abstract": "kOS is a scriptable autopilot Mod for Kerbal Space Program. It allows you write small programs that automate specific tasks.",
+    "author": "erendrake",
+    "version": "0.17.2",
+    "download": "https://github.com/KSP-KOS/KOS/releases/download/v0.17.2/kOS-v0.17.2.zip",
+    "download_size": 3198993
+}


### PR DESCRIPTION
Since 0.17.2 pre-release is only version that works with 1.0.0 and avaliable only on GitHub, I manually added ckan file for it. Tested it locally and it installs correctly.