### PR TITLE
Manual addition of USI-LS pre-release

### DIFF
--- a/USI-LS/USI-LS-0.1.0.ckan
+++ b/USI-LS/USI-LS-0.1.0.ckan
@@ -1,0 +1,25 @@
+{
+    "spec_version": 1,
+    "name": "USI Life Support",
+    "identifier": "USI-LS",
+    "author": "RoverDude",
+    "abstract": "UmbraSpaceIndustries take on life support",
+    "license": "CC-BY-NC-SA-4.0",
+    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
+        "repository": "https://github.com/BobPalmer/USI-LS"
+    },
+    "install": [
+        {
+            "file": "GameData/UmbraSpaceIndustries",
+            "install_to": "GameData"
+        }
+    ],
+    "version": "0.1.0",
+    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.1.0/USILS_0.1.0.zip",
+    "x_generated_by": "netkan",
+    "download_size": 294880,
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.0"
+}


### PR DESCRIPTION
Built with `netkan USI-LS.netkan --prerelease` from the .netkan file in https://github.com/KSP-CKAN/NetKAN/pull/1021 so once we have that one going this one will be consistent.