### PR TITLE
Revert "Update HotRockets-7.9.ckan for KSP1.0"

### DIFF
--- a/HotRockets/HotRockets-7.9.ckan
+++ b/HotRockets/HotRockets-7.9.ckan
@@ -8,7 +8,7 @@
     "author"       : [ "Nazari1382" ],
     "version"      : "7.9",
     "release_status" : "stable",
-    "ksp_version"  : "1.0",
+    "ksp_version"  : "0.90",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/65754"
     },
@@ -19,7 +19,7 @@
         }
     ],
     "depends" : [
-        { "name" : "ModuleManager", "min_version" : "2.6.2" },
-		{ "name" : "SmokeScreen", "min_version" : "2.6.0" }
+        { "name" : "ModuleManager", "min_version" : "2.5.1" },
+		{ "name" : "SmokeScreen", "min_version" : "2.5.0" }
     ]
 }


### PR DESCRIPTION
Reverts KSP-CKAN/CKAN-meta#421

Just found a bug making some FX incompatible with the current KSP jet engines.
Sorry for the inconveniences.