### PR TITLE
Add toolbar 1.7.9, stricter versioning on 1.7.8

### DIFF
--- a/Toolbar/Toolbar-1.7.9.ckan
+++ b/Toolbar/Toolbar-1.7.9.ckan
@@ -4,19 +4,19 @@
     "author"         : "blizzy78",
     "identifier"     : "Toolbar",
     "abstract"       : "API for third-party plugins to provide toolbar buttons",
-    "download"       : "http://blizzy.de/toolbar/Toolbar-1.7.8.zip",
+    "download"       : "http://blizzy.de/toolbar/Toolbar-1.7.9.zip",
     "license"        : "BSD-2-clause",
-    "version"        : "1.7.8",
+    "version"        : "1.7.9",
     "release_status" : "stable",
-    "ksp_version_min"    : "0.90",
-	"ksp_version_max"	: "1.0.2",
+    "ksp_version"    : "1.0.2",
+	"comment"		: "version.txt only defines 1.0.2, probably works for all ksp_version 1.0",
     "resources" : {
         "homepage"     : "http://forum.kerbalspaceprogram.com/threads/60863",
         "repository"   : "https://github.com/blizzy78/ksp_toolbar"
     },
     "install" : [
         {
-            "file"       : "Toolbar-1.7.8/GameData/000_Toolbar",
+            "file"       : "Toolbar-1.7.9/GameData/000_Toolbar",
             "install_to" : "GameData"
         }
     ]


### PR DESCRIPTION
made the versioning schema for 1.7.8 stricter but only strict enought to provide an upgrade path for users running ksp 1.0.2.

1.7.9 only seems to want to play nice with 1.0.2 so that's why it's set to only that version.