### PR TITLE
Fix RealRoster to have the right ksp_version

### DIFF
--- a/RealRoster/RealRoster-v2.1.ckan
+++ b/RealRoster/RealRoster-v2.1.ckan
@@ -5,6 +5,7 @@
     "author": "enneract",
     "abstract": "RealRoster",
     "name": "RealRoster - Editor Crew Tab Fixed",
+	"ksp_version"	:	"0.25",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/87473",
         "repository": "https://github.com/fingerboxes/KSPRealRoster"


### PR DESCRIPTION
only available for 0.25, download currently dead but author is looking to rehost it. Keeping the mod around so if anyone acctually ever gets an error report for 0.25 well... check http://forum.kerbalspaceprogram.com/threads/87473-25-x-RealRoster-Editor-Crew-Tab-Fixed?p=1882939&viewfull=1#post1882939 and forward in hope a rehost.