### PR TITLE
Update RasterPropMonitor-v0.19.2.ckan

### DIFF
--- a/RasterPropMonitor/RasterPropMonitor-v0.19.2.ckan
+++ b/RasterPropMonitor/RasterPropMonitor-v0.19.2.ckan
@@ -44,5 +44,5 @@
     "download": "https://github.com/Mihara/RasterPropMonitor/releases/download/v0.19.2/RasterPropMonitor.0.19.2.1.zip",
     "x_generated_by": "netkan",
     "download_size": 593963,
-    "ksp_version": "1.0.0"
+    "ksp_version_min": "0.25"
 }


### PR DESCRIPTION
Updated RPM CKAN metadata to be in line with RPM core CKAN metadata. The RPM core mod filters out the RPM capsule patches but the RPM mod does.