### PR TITLE
Ugly fix to KAC not showing up in 1.0.2

### DIFF
--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.0.ckan
@@ -24,5 +24,5 @@
     "download": "https://github.com/TriggerAu/KerbalAlarmClock/releases/download/v3.3.0.0/KerbalAlarmClock_3.3.0.0.zip",
     "x_generated_by": "netkan",
     "download_size": 462217,
-    "ksp_version": "1.0.0"
+    "ksp_version": "1.0"
 }


### PR DESCRIPTION
closes #437 

3.3.0.1 is basically just an update fix to KerbalStuff metadata which contains no codechanges but it's also the latest version netkan-bot catches from github so by doing this we get the latest version (codewise) available in CKAN without the risk of our beloved bot overwriting the ksp_version field.

Author of KAC has been contacted and it would be good if this PR was reverted once https://github.com/KSP-CKAN/NetKAN/issues/1114 and/or https://github.com/TriggerAu/KerbalAlarmClock/issues/129 has been adressed as to ensure that the authors intended versioning is ensured.