### PR TITLE
Update RCSBuildAid-v0.6.1.ckan

### DIFF
--- a/RCSBuildAid/RCSBuildAid-v0.6.1.ckan
+++ b/RCSBuildAid/RCSBuildAid-v0.6.1.ckan
@@ -1,7 +1,7 @@
 {
 	"spec_version": 1,
 	"identifier": "RCSBuildAid",
-	"ksp_version": "0.90",
+	"ksp_version_min": "0.90",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/35996"


### PR DESCRIPTION
It's working in 1.0.2 with minor issue.
m4v is not planning recompile it for 1.0
http://forum.kerbalspaceprogram.com/threads/35996-0-90-RCS-Build-Aid-v0-6-1-engine-gimbals?p=1880983&viewfull=1#post1880983