### PR TITLE
Make MechJeb2 and KerbalEngineerRedux suggestions in MechJebForAll

### DIFF
--- a/MechJebForAll/MechJebForAll-1.2.0.0.ckan
+++ b/MechJebForAll/MechJebForAll-1.2.0.0.ckan
@@ -8,9 +8,9 @@
 "ksp_version" : "1.0",
 "license" : "GPL-3.0",
 "download": "http://addons-origin.cursecdn.com/files/2235/984/MechJebAndEngineerForAll-v1.2.0.0.zip",
-"depends": [
+"depends": [{ "name": "ModuleManager" }],
+"suggests":[
 { "name": "MechJeb2" },
-{ "name": "ModuleManager" },
 { "name": "KerbalEngineerRedux" }],
 "install": [ {"file": "MechJebAndEngineerForAll.cfg",
 			"install_to": "GameData" }

--- a/MechJebForAll/MechJebForAll-1.2.0.0.ckan
+++ b/MechJebForAll/MechJebForAll-1.2.0.0.ckan
@@ -9,7 +9,7 @@
 "license" : "GPL-3.0",
 "download": "http://addons-origin.cursecdn.com/files/2235/984/MechJebAndEngineerForAll-v1.2.0.0.zip",
 "depends": [{ "name": "ModuleManager" }],
-"suggests":[
+"recommends":[
 { "name": "MechJeb2" },
 { "name": "KerbalEngineerRedux" }],
 "install": [ {"file": "MechJebAndEngineerForAll.cfg",


### PR DESCRIPTION
This module will work with either installed, and will not break in the extreme case that neither are installed.

There's a strong argument to be made that these should be requirements instead of suggestions.  I'd be okay with that, too, but I went with the conservative approach.