### PR TITLE
Added dependency on ModularFlightIntegrator.

### DIFF
--- a/FerramAerospaceResearch/FerramAerospaceResearch-v0.15_Euler.ckan
+++ b/FerramAerospaceResearch/FerramAerospaceResearch-v0.15_Euler.ckan
@@ -20,6 +20,9 @@
     "depends": [
         {
             "name": "ModuleManager"
+        },
+        {
+            "name": "ModularFlightIntegrator"
         }
     ],
     "install": [


### PR DESCRIPTION
FAR now seem to depend on ModularFlightIntegrator (It is present in the Euler zip file).