### PR TITLE
Update BoxSat and BoxSat-prototypes

### DIFF
--- a/BoxSat-prototypes/BoxSat-prototypes-A.02e.ckan
+++ b/BoxSat-prototypes/BoxSat-prototypes-A.02e.ckan
@@ -13,8 +13,7 @@
     "ksp_version": "1.0.2",
     "download": "http://addons-origin.cursecdn.com/files/2237/556/BoxSat%20vA.02e.zip",
     "depends" : [
-        { "name": "ModuleManager" },
-        { "name": "BoxSat" }
+        { "name": "ModuleManager" }
     ],
     "install": [
         {

--- a/BoxSat-prototypes/BoxSat-prototypes-A.02e.ckan
+++ b/BoxSat-prototypes/BoxSat-prototypes-A.02e.ckan
@@ -1,7 +1,8 @@
 {
     "spec_version": "v1.4",
-    "identifier": "BoxSat",
-    "name": "BoxSat",
+    "identifier": "BoxSat-prototypes",
+    "name": "BoxSat prototype parts",
+    "release_status": "development",
     "license": "restricted",
     "abstract": "A modular, stackable, serviceable, & customizable satellite in a box!",
     "author": [ "DasPenguin85", "orcmaul" ],
@@ -12,13 +13,14 @@
     "ksp_version": "1.0.2",
     "download": "http://addons-origin.cursecdn.com/files/2237/556/BoxSat%20vA.02e.zip",
     "depends" : [
-        { "name" : "ModuleManager" }
+        { "name": "ModuleManager" },
+        { "name": "BoxSat" }
     ],
     "install": [
         {
-            "find": "BoxSatAlpha",
+            "find": "BoxSatPrototypes",
             "install_to": "GameData",
             "filter_regexp": "\\.ddsified$"
         }
-    ]    
+    ]
 }

--- a/BoxSat/BoxSat-A.02e.ckan
+++ b/BoxSat/BoxSat-A.02e.ckan
@@ -1,0 +1,20 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "BoxSat",
+    "name": "BoxSat",
+    "license": "restricted",
+    "abstract": "A modular, stackable, serviceable, & customizable satellite in a box!",
+    "author": [ "DasPenguin85", "orcmaul" ],    
+    "resources": {
+        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat"
+    },
+    "version": "A.02e",
+    "ksp_version": "1.0.2",
+    "download": "http://addons-origin.cursecdn.com/files/2237/556/BoxSat%20vA.02e.zip",
+    "install": [
+        {
+            "find": "BoxSatAlpha",
+            "install_to": "GameData"
+        }
+    ]    
+}


### PR DESCRIPTION
BoxSat developers have [decided to no longer distribute via Kerbal Stuff](http://forum.kerbalspaceprogram.com/threads/91616?p=1924575#post1924575).

These are manual CKAN files for the newest release on Curse.

- Removed Kerbal Stuff resource
- Added dependencies on `ModuleManager`
- ~~Made `BoxSat-prototypes` dependent on `BoxSat`~~ Removed dependency until both are updated
- Filtered out `.ddsified` files that were not removed from the distribution