### PR TITLE
DeadlyReentry version bumped to 1.0.0

### DIFF
--- a/DeadlyReentry/DeadlyReentry-v7.0.1.ckan
+++ b/DeadlyReentry/DeadlyReentry-v7.0.1.ckan
@@ -5,7 +5,7 @@
     "identifier": "DeadlyReentry",
     "license": "CC-BY-SA",
     "release_status": "stable",
-    "ksp_version": "0.90",
+    "ksp_version": "1.0.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54954",
         "repository": "https://github.com/Starwaster/DeadlyReentry"


### PR DESCRIPTION
'The Melificent Edition' is compatible with 1.0.0