### PR TITLE
Add min_version for KAS's KIS dependency

### DIFF
--- a/KAS/KAS-0.5.1.ckan
+++ b/KAS/KAS-0.5.1.ckan
@@ -12,7 +12,7 @@
     "version"        : "0.5.1",
     "ksp_version"    : "1.0.2",
     "depends" : [
-        { "name": "ModuleManager"},
-        { "name": "KIS" }
+        { "name": "ModuleManager" },
+        { "name": "KIS", "min_version": "1.1.4" }
     ]
 }


### PR DESCRIPTION
Using previous versions b0rks hard.