### PR TITLE
Fix older versions of 0point fairings

### DIFF
--- a/ZeroPointInlineFairings-Lite/ZeroPointInlineFairings-Lite-0.8.ckan
+++ b/ZeroPointInlineFairings-Lite/ZeroPointInlineFairings-Lite-0.8.ckan
@@ -23,5 +23,6 @@
   "download": "https://kerbalstuff.com/mod/228/Zero-Point%20Inline%20Fairings%20Lite/download/0.8",
   "x_generated_by": "netkan",
   "download_size": 2750307,
-  "ksp_version_min": "0.25.0"
+  "ksp_version_min": "0.25.0",
+  "ksp_version_max": "0.90"
 }

--- a/ZeroPointInlineFairings-Lite/ZeroPointInlineFairings-Lite-0.9.ckan
+++ b/ZeroPointInlineFairings-Lite/ZeroPointInlineFairings-Lite-0.9.ckan
@@ -24,5 +24,6 @@
     "download": "https://kerbalstuff.com/mod/228/Zero-Point%20Inline%20Fairings%20Lite/download/0.9",
     "x_generated_by": "netkan",
     "download_size": 2744066,
-    "ksp_version_min": "0.90.0"
+    "ksp_version_min": "0.90.0",
+	"ksp_version_max": "0.90"
 }

--- a/ZeroPointInlineFairings/ZeroPointInlineFairings-0.8.1.ckan
+++ b/ZeroPointInlineFairings/ZeroPointInlineFairings-0.8.1.ckan
@@ -23,5 +23,6 @@
   "download": "https://kerbalstuff.com/mod/196/Zero%20Point%20Inline%20Fairings/download/0.8.1",
   "x_generated_by": "netkan",
   "download_size": 2813091,
-  "ksp_version_min": "0.25.0"
+  "ksp_version_min": "0.25.0",
+  "ksp_version_max": "0.90"
 }

--- a/ZeroPointInlineFairings/ZeroPointInlineFairings-0.9.1.ckan
+++ b/ZeroPointInlineFairings/ZeroPointInlineFairings-0.9.1.ckan
@@ -24,5 +24,6 @@
     "download": "https://kerbalstuff.com/mod/196/Zero%20Point%20Inline%20Fairings/download/0.9.1",
     "x_generated_by": "netkan",
     "download_size": 2807064,
-    "ksp_version_min": "0.90.0"
+    "ksp_version_min": "0.90.0",
+	"ksp_version_max": "0.90"
 }

--- a/ZeroPointInlineFairings/ZeroPointInlineFairings-0.9.ckan
+++ b/ZeroPointInlineFairings/ZeroPointInlineFairings-0.9.ckan
@@ -24,5 +24,6 @@
   "download": "https://kerbalstuff.com/mod/196/Zero%20Point%20Inline%20Fairings/download/0.9",
   "x_generated_by": "netkan",
   "download_size": 2806716,
-  "ksp_version_min": "0.90.0"
+  "ksp_version_min": "0.90.0",
+  "ksp_version_max": "0.90"
 }


### PR DESCRIPTION
Seems I forgot to fix the older versions of this mod in my last PR that update the newest ones.