### PR TITLE
Fix download link and fix versioning issue.

### DIFF
--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.0.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.0.ckan
@@ -32,7 +32,7 @@
         }
     ],
     "version": "v0.19.0",
-    "download": "https://github.com/Mihara/RasterPropMonitor/releases/download/v0.19.0/RasterPropMonitor.0.19.0.zip",
+    "download": "https://github.com/Mihara/RasterPropMonitor/releases/download/v0.19/RasterPropMonitor-dev19.zip",
     "x_generated_by": "netkan",
     "download_size": 593305
 }

--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.1.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.1.ckan
@@ -9,7 +9,7 @@
     "abstract": "A toolkit for creating interactive IVA experiences.",
     "comment": "This package contains the plugin, and the standard parts library.",
     "license": "GPL-3.0",
-    "ksp_version_min": "0.25.0",
+    "ksp_version_min": "1.0.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117471",

--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.2.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.2.ckan
@@ -9,7 +9,7 @@
     "abstract": "A toolkit for creating interactive IVA experiences.",
     "comment": "This package contains the plugin, and the standard parts library.",
     "license": "GPL-3.0",
-    "ksp_version_min": "0.25.0",
+    "ksp_version_min": "1.0.2",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117471",


### PR DESCRIPTION
See https://github.com/Mihara/RasterPropMonitor/issues/228
v0.19.0 does not seem to exist - use the version the author has said is for 0.90
If that is the version for 0.90 then the later ones allowing installs to 0.90 must be mistakes. 