### PR TITLE
Remove HotRockets recommendation in SmokeScreen

### DIFF
--- a/SmokeScreen/SmokeScreen-2.5.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.5.0.ckan
@@ -20,8 +20,5 @@
     ],
     "depends" : [
         { "name" : "ModuleManager", "min_version" : "2.5.1" }
-    ],
-	"recommends" : [
-        { "name" : "HotRockets" }
     ]
 }

--- a/SmokeScreen/SmokeScreen-2.5.3.ckan
+++ b/SmokeScreen/SmokeScreen-2.5.3.ckan
@@ -20,8 +20,5 @@
     ],
     "depends" : [
         { "name" : "ModuleManager", "min_version" : "2.5.4" }
-    ],
-	"recommends" : [
-        { "name" : "HotRockets" }
     ]
 }

--- a/SmokeScreen/SmokeScreen-2.6.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.0.ckan
@@ -23,7 +23,7 @@
             "name": "ModuleManager",
             "min_version": "2.6.1"
         }
-    ]
+    ],
     "version": "2.6.0",
     "download": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/34/artifact/SmokeScreen-2.6.0.0.zip",
     "x_generated_by": "nyankan",

--- a/SmokeScreen/SmokeScreen-2.6.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.0.ckan
@@ -23,12 +23,7 @@
             "name": "ModuleManager",
             "min_version": "2.6.1"
         }
-    ],
-    "recommends": [
-        {
-            "name": "HotRockets"
-        }
-    ],
+    ]
     "version": "2.6.0",
     "download": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/34/artifact/SmokeScreen-2.6.0.0.zip",
     "x_generated_by": "nyankan",


### PR DESCRIPTION
Prompted by #536.

SmokeScreen is a pure library, no user would really be installing it directly. It shouldn't be recommending any other mods (I think even `suggests` is too strong of a relationship).

With the `recommends`, users installing CoolRockets would receive HotRockets by default, which isn't likely what the user wants.