### PR TITLE
Add HGR 1.875m mod pack

### DIFF
--- a/HGR-Props/HGR-Props-1.2.1.ckan
+++ b/HGR-Props/HGR-Props-1.2.1.ckan
@@ -1,0 +1,22 @@
+{
+    "spec_version"   : "v1.4",
+    "name"           : "HGR Props",
+    "author"         : ["Orionkermin"],
+    "abstract"       : "Common props for HGR packs",
+    "identifier"     : "HGR-Props",
+    "license"        : "restricted",
+    "version"        : "1.2.1",
+    "release_status" : "stable",
+    "ksp_version"    : "1.0.2",
+    "resources" : {
+        "homepage"     : "http://forum.kerbalspaceprogram.com/threads/70008",
+        "x_curse"      : "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
+    },
+    "download"       : "http://addons-origin.cursecdn.com/files/2237/481/HGR_V1.2.1.zip",
+    "install" : [
+        {
+            "find"     : "HGR/Props",
+            "install_to" : "GameData/HGR"
+        }
+    ]
+}

--- a/HGR/HGR-1.2.1.ckan
+++ b/HGR/HGR-1.2.1.ckan
@@ -1,0 +1,30 @@
+{
+    "spec_version"   : "v1.4",
+    "name"           : "HGR 1.875m parts",
+    "author"         : ["Orionkermin"],
+    "abstract"       : "Stock alike command pods and an 1.875m diameter of parts",
+    "identifier"     : "HGR",
+    "license"        : "restricted",
+    "version"        : "1.2.1",
+    "release_status" : "stable",
+    "ksp_version"    : "1.0.2",
+    "resources" : {
+        "homepage"     : "http://forum.kerbalspaceprogram.com/threads/70008",
+        "x_curse"      : "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
+    },
+    "download"       : "http://addons-origin.cursecdn.com/files/2237/481/HGR_V1.2.1.zip",
+    "install" : [
+        {
+            "find"       : "HGR",
+            "filter"     : "Props",
+            "install_to" : "GameData"
+        },
+        {
+            "find"       : "HGR_Redux",
+            "install_to" : "GameData"
+        }
+    ],
+    "depends"  : [
+        { "name" : "HGR-Props" }
+    ]
+}


### PR DESCRIPTION
These are two hand-written ckan files for the Home Grown Rockets 1.875m part pack. I split the pack in the actual 1.875m parts package and the props package, which is used by HGR's Corvus package.

DO-NOT-MERGE until we have explicit permission from the mod author to index and distribute the mod through CKAN.