### PR TITLE
prettify the console output of Jenkins to match NetKAN

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,12 @@ mono --debug ckan.exe update
 
 for f in ${COMMIT_CHANGES}
 do
-        cat $f | python -m json.tool
+	echo ----------------------------------------------
+	echo 
+	cat $f | python -m json.tool
+	echo ----------------------------------------------
+	echo 
+	echo Running ckan install -c $f
 	mono --debug ckan.exe install -c $f --headless
 done
 


### PR DESCRIPTION
an update to #548 to match https://github.com/KSP-CKAN/NetKAN/blob/master/build.sh#L88:L94 and have our builds generate similar output, because Daz likes it that way.