### PR TITLE
Add newlines in Jenkins output to almost match NetKAN output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,4 +47,4 @@ done
 echo "Installed mods:"
 mono --debug ckan.exe list --porcelain
 
-perl -e'@installed = `mono --debug ckan.exe list --porcelain`; foreach (@installed) { /^\S\s(?<mod>\S+)/ and system("mono --debug ckan.exe show $+{mod}\n\n"); } exit 0;'
+perl -e'@installed = `mono --debug ckan.exe list --porcelain`; foreach (@installed) { /^\S\s(?<mod>\S+)/ and system("mono --debug ckan.exe show $+{mod}"); print "\n\n"; } exit 0;'

--- a/build.sh
+++ b/build.sh
@@ -47,4 +47,4 @@ done
 echo "Installed mods:"
 mono --debug ckan.exe list --porcelain
 
-perl -e'@installed = `mono --debug ckan.exe list --porcelain`; foreach (@installed) { /^\S\s(?<mod>\S+)/ and system("mono --debug ckan.exe show $+{mod}"); } exit 0;'
+perl -e'@installed = `mono --debug ckan.exe list --porcelain`; foreach (@installed) { /^\S\s(?<mod>\S+)/ and system("mono --debug ckan.exe show $+{mod}\n\n"); } exit 0;'


### PR DESCRIPTION
After each 'mono --debug ckan show <identifier>' in Jenkins NetKAN console outputs we have an echo of --------------- 2 times to show that we're now showing another mod.

My hope is that this will do something similar, however I have never used perl in my life so this might aswell be asking it to delete the universe or just flat out be wrong.