### PR TITLE
Remove ModuleManager Dependency from SmokeScreen

### DIFF
--- a/AerojetKerbodyne/AerojetKerbodyne-3.0.5.ckan
+++ b/AerojetKerbodyne/AerojetKerbodyne-3.0.5.ckan
@@ -17,6 +17,9 @@
         },
         {
             "name": "VirginKalactic-NodeToggle"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "recommends": [

--- a/AerojetKerbodyne/AerojetKerbodyne-3.04.ckan
+++ b/AerojetKerbodyne/AerojetKerbodyne-3.04.ckan
@@ -17,6 +17,9 @@
         },
         {
             "name": "VirginKalactic-NodeToggle"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "recommends": [

--- a/RealPlume/RealPlume-v7.0.4.ckan
+++ b/RealPlume/RealPlume-v7.0.4.ckan
@@ -11,6 +11,9 @@
     },
     {
       "name": "SmokeScreen"
+    },
+    {
+      "name": "ModuleManager"
     }
   ],
   "resources": {

--- a/RealPlume/RealPlume-v7.0.5.ckan
+++ b/RealPlume/RealPlume-v7.0.5.ckan
@@ -11,6 +11,9 @@
         },
         {
             "name": "SmokeScreen"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "resources": {

--- a/RealPlume/RealPlume-v7.0.6.ckan
+++ b/RealPlume/RealPlume-v7.0.6.ckan
@@ -11,6 +11,9 @@
         },
         {
             "name": "SmokeScreen"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "resources": {

--- a/RealPlume/RealPlume-v7.0.7.ckan
+++ b/RealPlume/RealPlume-v7.0.7.ckan
@@ -11,6 +11,9 @@
         },
         {
             "name": "SmokeScreen"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "resources": {

--- a/RealPlume/RealPlume-v8.0.0.ckan
+++ b/RealPlume/RealPlume-v8.0.0.ckan
@@ -11,6 +11,9 @@
         },
         {
             "name": "SmokeScreen"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "resources": {

--- a/RealPlume/RealPlume-v8.0.1.ckan
+++ b/RealPlume/RealPlume-v8.0.1.ckan
@@ -11,6 +11,9 @@
         },
         {
             "name": "SmokeScreen"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "resources": {

--- a/RealPlume/RealPlume-v8.1.0.ckan
+++ b/RealPlume/RealPlume-v8.1.0.ckan
@@ -11,6 +11,9 @@
         },
         {
             "name": "SmokeScreen"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "resources": {

--- a/RealPlume/RealPlume-v8.1.1.ckan
+++ b/RealPlume/RealPlume-v8.1.1.ckan
@@ -11,6 +11,9 @@
         },
         {
             "name": "SmokeScreen"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "resources": {

--- a/RealPlume/RealPlume-v8.2.0.ckan
+++ b/RealPlume/RealPlume-v8.2.0.ckan
@@ -11,6 +11,9 @@
         },
         {
             "name": "SmokeScreen"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "resources": {

--- a/RealPlume/RealPlume-v8.4.1.ckan
+++ b/RealPlume/RealPlume-v8.4.1.ckan
@@ -11,6 +11,9 @@
         },
         {
             "name": "SmokeScreen"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "conflicts": [

--- a/SmokeScreen/SmokeScreen-2.5.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.5.0.ckan
@@ -17,8 +17,5 @@
             "file"       : "GameData/SmokeScreen",
             "install_to" : "GameData"
         }
-    ],
-    "depends" : [
-        { "name" : "ModuleManager", "min_version" : "2.5.1" }
     ]
 }

--- a/SmokeScreen/SmokeScreen-2.5.3.ckan
+++ b/SmokeScreen/SmokeScreen-2.5.3.ckan
@@ -17,8 +17,5 @@
             "file"       : "GameData/SmokeScreen",
             "install_to" : "GameData"
         }
-    ],
-    "depends" : [
-        { "name" : "ModuleManager", "min_version" : "2.5.4" }
     ]
 }

--- a/SmokeScreen/SmokeScreen-2.6.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.0.ckan
@@ -18,12 +18,6 @@
             "install_to": "GameData"
         }
     ],
-    "depends": [
-        {
-            "name": "ModuleManager",
-            "min_version": "2.6.1"
-        }
-    ],
     "version": "2.6.0",
     "download": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/34/artifact/SmokeScreen-2.6.0.0.zip",
     "x_generated_by": "nyankan",

--- a/SmokeScreen/SmokeScreen-2.6.1.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.1.ckan
@@ -18,12 +18,6 @@
             "install_to": "GameData"
         }
     ],
-    "depends": [
-        {
-            "name": "ModuleManager",
-            "min_version": "2.6.1"
-        }
-    ],
     "version": "2.6.1",
     "download": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/35/artifact/SmokeScreen-2.6.1.0.zip",
     "x_generated_by": "nyankan",


### PR DESCRIPTION
This removes the `ModuleManager` dependency from `SmokeScreen`, since it's *not actually* a dependency for `SmokeScreen` itself.

However, we need to make sure no mod was implicitly depending on `SmokeScreen` to pull in `ModuleManager`. Of the mods which themselves depended on `SmokeScreen` here are their dispositions with regards to `ModuleManager`:

##### Already depended on `ModuleManager`
- `HotRockets`
- `CoolRockets`
- `RealEffects`
- `RetroFuture`
- `KerbinShuttleOrbiterSystem`
- `KerbalStockLauncherOverhaul`
- `RealismOverhaul`

##### Do not depend on `ModuleManager`
- `SpaceShuttleEngines`

##### Need to depend on `ModuleManager`
- `AerojetKerbodyne`
- `RealPlume`

This PR removes the dependency from `SmokeScreen` and backports the `ModuleManager` dependency to `AerojetKerbodyne` and `RealPlume`. KSP-CKAN/NetKAN#1446 adds those changes to those mod's respective netkan files.