### PR TITLE
Update ApativeDockingNode

### DIFF
--- a/AdaptiveDockingNode/AdaptiveDockingNode-1.7.ckan
+++ b/AdaptiveDockingNode/AdaptiveDockingNode-1.7.ckan
@@ -14,5 +14,11 @@
     "version": "1.7",
     "ksp_version_min": "1.0.0",
     "ksp_version_max": "1.0.2",
-    "download": "http://ksp.hawkbats.com/AdaptiveDockingNode/AdaptiveDockingNode-1-7.zip"
+    "download": "http://ksp.hawkbats.com/AdaptiveDockingNode/AdaptiveDockingNode-1-7.zip",
+    "install": [
+        {
+            "file": "GameData/AdaptiveDockingNode",
+            "install_to": "GameData"
+        }
+    ]
 }

--- a/AdaptiveDockingNode/AdaptiveDockingNode-1.7.ckan
+++ b/AdaptiveDockingNode/AdaptiveDockingNode-1.7.ckan
@@ -1,0 +1,18 @@
+{
+    "spec_version": 1,
+    "identifier": "AdaptiveDockingNode",
+    "name": "AdaptiveDockingNode",
+    "abstract": "A creator-targeted plugin that facilitates multi-sized docking ports",
+    "author": "toadicus",
+    "license": "BSD-2-clause",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/79128"
+    },
+    "depends": [
+        { "name": "ModuleManager", "min_version": "2.6.3" }
+    ],
+    "version": "1.7",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.2",
+    "download": "http://ksp.hawkbats.com/AdaptiveDockingNode/AdaptiveDockingNode-1-7.zip"
+}


### PR DESCRIPTION
Few notable changes from the previous version:

- Updated `license` from `restricted` to [`BSD-2-clause`](http://opensource.org/licenses/BSD-2-Clause).
- Removed the `install` stanza, CKAN does the right thing by default.
- Added `ksp_version_*` (going to submit a PR for the previous .ckan file to fix its lack of KSP version)