### PR TITLE
Add KSP version to AdaptiveDockingNode-1.6

### DIFF
--- a/AdaptiveDockingNode/AdaptiveDockingNode-1.6.ckan
+++ b/AdaptiveDockingNode/AdaptiveDockingNode-1.6.ckan
@@ -15,5 +15,6 @@
 						}
 				],
 	"depends" 		: [{ "name": "ModuleManager" }],
-	"download"		: "http://ksp.hawkbats.com/AdaptiveDockingNode/AdaptiveDockingNode-1-6.zip"
+	"download"		: "http://ksp.hawkbats.com/AdaptiveDockingNode/AdaptiveDockingNode-1-6.zip",
+	"ksp_version"	: "0.90"
 }


### PR DESCRIPTION
Adds `ksp_version` to `AdaptiveDockingNode-1.6` to prevent it from showing up for future versions of KSP.

This should be mergeable when the NetKarmgeddon (#558) is resolved and fbdbad944f8e0cbe33f86a25a7b9aa0c9dffaa3c is reverted.