### PR TITLE
manual addition of Workshop-0.7.3.ckan

### DIFF
--- a/Workshop/Workshop-0.7.3.ckan
+++ b/Workshop/Workshop-0.7.3.ckan
@@ -1,0 +1,34 @@
+{
+    "spec_version": 1,
+    "identifier": "Workshop",
+    "name": "OSE Workshop",
+    "abstract": "In flight part construction",
+    "author": "obivandamme",
+    "license": "CC-BY-NC-SA",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/108234",
+        "kerbalstuff": "https://kerbalstuff.com/mod/693/OSE%20Workshop"
+    },
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "KIS"
+        },
+        {
+            "name": "UKS"
+        }
+    ],
+    "install": [
+        {
+            "file": "GameData/Workshop",
+            "install_to": "GameData"
+        }
+    ],
+    "ksp_version": "1.0.2",
+    "version": "0.7.3",
+    "download": "https://kerbalstuff.com/mod/693/OSE%20Workshop/download/0.7.3",
+    "x_generated_by": "netkan",
+    "download_size": 116295
+}


### PR DESCRIPTION
Generated this file from Workshop.netkan over in the NetKAN repository. Manually adding it since indexing is currently down and this mod is linked to the new KIS version added in #562 aka players using OSE Workshop need this version to be able to use them with KIS 1.1.5.

This might seem like a minor thing but it's affecting me so I'm fixing it.