### PR TITLE
Update HotRocketsCommunityConfigs-7.25.ckan

### DIFF
--- a/HotRocketsCommunityConfigs/HotRocketsCommunityConfigs-7.25.ckan
+++ b/HotRocketsCommunityConfigs/HotRocketsCommunityConfigs-7.25.ckan
@@ -9,7 +9,6 @@
     "version"      : "7.25",
     "release_status" : "stable",
     "ksp_version_min"  : "0.25",
-	"ksp_version_max"	: "0.90",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/65754"
     },
@@ -20,6 +19,6 @@
         }
     ],
     "depends" : [
-        { "name" : "HotRockets", "max_version" : "7.25" }
+        { "name" : "HotRockets" }
     ]
 }


### PR DESCRIPTION
Tested in 1.0, the configs work fine.  

Removed ksp_version_max, since they're just config files, ksp version doesn't affect them.
Also removed the max version flag for HotRockets, since unless Nazari removes the FX available, nothing should break.  If anything, they should be dependent on a SmokeScreen version, but probably shouldn't, unless Sarbian breaks some functionality in a future release.