### PR TITLE
EPL RegolithAdaptation/ExtendedPartPack split

### DIFF
--- a/ExtraPlanetaryLaunchpads-RegolithAdaptation/ExtraPlanetaryLaunchpads-RegolithAdaptation-30.ckan
+++ b/ExtraPlanetaryLaunchpads-RegolithAdaptation/ExtraPlanetaryLaunchpads-RegolithAdaptation-30.ckan
@@ -4,7 +4,7 @@
     "license": "GPL-3.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/89774",
+        "homepage": "https://kerbalstuff.com/mod/494/ExtraPlanetary%20Launchpads(EPL)->Regolith%20Adaptation",
         "kerbalstuff": "https://kerbalstuff.com/mod/494/ExtraPlanetary%20Launchpads(EPL)->Regolith%20Adaptation"
     },
     "depends": [

--- a/ExtraPlanetaryLaunchpads-RegolithAdaptation/ExtraPlanetaryLaunchpads-RegolithAdaptation-30.ckan
+++ b/ExtraPlanetaryLaunchpads-RegolithAdaptation/ExtraPlanetaryLaunchpads-RegolithAdaptation-30.ckan
@@ -4,8 +4,8 @@
     "license": "GPL-3.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/494/ExtraPlanetary%20Launchpads(EPL)->Regolith%20Adaptation",
-        "kerbalstuff": "https://kerbalstuff.com/mod/494/ExtraPlanetary%20Launchpads(EPL)->Regolith%20Adaptation"
+        "homepage": "https://kerbalstuff.com/mod/494/ExtraPlanetary%20Launchpads(EPL)-%3ERegolith%20Adaptation",
+        "kerbalstuff": "https://kerbalstuff.com/mod/494/ExtraPlanetary%20Launchpads(EPL)-%3ERegolith%20Adaptation"
     },
     "depends": [
         {

--- a/ExtraPlanetaryLaunchpadsExtendedPartPack/ExtraPlanetaryLaunchpadsExtendedPartPack.ckan
+++ b/ExtraPlanetaryLaunchpadsExtendedPartPack/ExtraPlanetaryLaunchpadsExtendedPartPack.ckan
@@ -1,0 +1,34 @@
+{
+    "spec_version": 1,
+    "identifier": "ExtraPlanetaryLaunchpadsExtendedPartPack",
+    "license": "GPL-3.0",
+    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/89774"
+    },
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "ExtraPlanetaryLaunchpads"
+        }
+    ],
+    "conflicts":[
+        {
+            "name": "ExtraPlanetaryLaunchpads-RegolithAdaptation"
+        }
+    ]
+    "install": [
+        {
+            "file": "GameData/WombatConversions",
+            "install_to": "GameData"
+        }
+    ],
+    "ksp_version": "1.0.2",
+    "name": "ExtraPlanetary LaunchPads Extended-Part Pack",
+    "abstract": "This pack is a part pack with new parts to work with Extraplanetary Launchpads.",
+    "author": "rabidninjawombat",
+    "version": "50",
+    "download": "https://dl.dropboxusercontent.com/u/19908938/EPL_Extended.zip"
+}

--- a/ExtraPlanetaryLaunchpadsExtendedPartPack/ExtraPlanetaryLaunchpadsExtendedPartPack.ckan
+++ b/ExtraPlanetaryLaunchpadsExtendedPartPack/ExtraPlanetaryLaunchpadsExtendedPartPack.ckan
@@ -18,7 +18,7 @@
         {
             "name": "ExtraPlanetaryLaunchpads-RegolithAdaptation"
         }
-    ]
+    ],
     "install": [
         {
             "file": "GameData/WombatConversions",


### PR DESCRIPTION
Closes #486 - See #486 for extra details on this change.

New name + new function = New mod

Homepage of 0.30 is changed to the KerbalStuff page since the forum thread is dedicated to the new mod.

I have the new mod (extended) conflict with the old (regolith) since the author is using a lot of the same files/file names.

I'm unclear on what to do with/about the CommunityResourcePack folder. It was ignored in the Regolith releases in terms of both install stanza as well as dependencies/recommendations.