### PR TITLE
Add a repackaged version of ModularFlightIntegrator

### DIFF
--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.0.repackaged0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.0.repackaged0.ckan
@@ -1,0 +1,19 @@
+{
+    "spec_version": 1,
+    "identifier": "ModularFlightIntegrator",
+    "name": "ModularFlightIntegrator",
+    "abstract": "This is an amazing addon that will Modularly Integrate your Flight Models.",
+    "license": "MIT",
+    "author": "Sarbian",
+    "release_status": "stable",
+    "resources": {
+        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/",
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/118088",
+        "repository": "https://github.com/sarbian/ModularFlightIntegrator"
+    },
+    "version": "1.0.repackaged0",
+    "download": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/6/artifact/ModularFlightIntegrator-1.0.0.0.zip",
+    "x_generated_by": "nyankan",
+    "download_size": 7091,
+    "ksp_version": "1.0"
+}


### PR DESCRIPTION
Based on #577 I'm adding a manual update of this mod.

https://github.com/KSP-CKAN/CKAN-meta/commit/cffba41fb297d16c450ae47c8991dc35b1be8dcd should have probably triggered us to repackage this back then so if anyone is acctually using the version prior to that commit they might run into trouble.