### PR TITLE
Confine the old RSS-Textures to 0.90 and below

### DIFF
--- a/RSSTextures2048/RealSolarSystemTextures_2048-1.0.ckan
+++ b/RSSTextures2048/RealSolarSystemTextures_2048-1.0.ckan
@@ -11,7 +11,7 @@
     "download"       : "https://ksp.sarbian.com/nathankell/RealSolarSystem/Textures//2048.zip",
     "license"        : "CC-BY-NC-SA",
     "version"        : "1.0",
-    "ksp_version"    : "any",
+    "ksp_version_max"    : "0.90",
     "release_status" : "stable",
     "depends" : [
         { "name" : "RealSolarSystem" }

--- a/RSSTextures4096/RealSolarSystemTextures_4096-1.0.ckan
+++ b/RSSTextures4096/RealSolarSystemTextures_4096-1.0.ckan
@@ -11,7 +11,7 @@
     "download"       : "https://ksp.sarbian.com/nathankell/RealSolarSystem/Textures//4096.zip",
     "license"        : "CC-BY-NC-SA",
     "version"        : "1.0",
-    "ksp_version"    : "any",
+    "ksp_version_max"    : "0.90",
     "release_status" : "stable",
     "depends" : [
         { "name" : "RealSolarSystem" }

--- a/RSSTextures8192/RealSolarSystemTextures_8192-1.0.ckan
+++ b/RSSTextures8192/RealSolarSystemTextures_8192-1.0.ckan
@@ -11,7 +11,7 @@
     "download"       : "https://ksp.sarbian.com/nathankell/RealSolarSystem/Textures//8192.zip",
     "license"        : "CC-BY-NC-SA",
     "version"        : "1.0",
-    "ksp_version"    : "any",
+    "ksp_version_max"    : "0.90",
     "release_status" : "stable",
     "depends" : [
         { "name" : "RealSolarSystem" }

--- a/RSSTexturesDDS2048/RSSTexturesDDS2048-1.0.ckan
+++ b/RSSTexturesDDS2048/RSSTexturesDDS2048-1.0.ckan
@@ -11,7 +11,7 @@
     "download"       : "https://ksp.sarbian.com/nathankell/RealSolarSystem/Textures//RSSTextures2048DDS.zip",
     "license"        : "CC-BY-NC-SA",
     "version"        : "1.0",
-    "ksp_version"    : "any",
+    "ksp_version_max"    : "0.90",
     "release_status" : "stable",
     "depends" : [
         { "name" : "RealSolarSystem", "min_version" : "v8.3" },

--- a/RSSTexturesDDS4096/RSSTexturesDDS4096-1.0.ckan
+++ b/RSSTexturesDDS4096/RSSTexturesDDS4096-1.0.ckan
@@ -11,7 +11,7 @@
     "download"       : "https://ksp.sarbian.com/nathankell/RealSolarSystem/Textures//RSSTextures4096DDS.zip",
     "license"        : "CC-BY-NC-SA",
     "version"        : "1.0",
-    "ksp_version"    : "any",
+    "ksp_version_max"    : "0.90",
     "release_status" : "stable",
     "depends" : [
         { "name" : "RealSolarSystem", "min_version" : "v8.3" },

--- a/RSSTexturesDDS8192/RSSTexturesDDS8192-1.0.ckan
+++ b/RSSTexturesDDS8192/RSSTexturesDDS8192-1.0.ckan
@@ -11,7 +11,7 @@
     "download"       : "https://ksp.sarbian.com/nathankell/RealSolarSystem/Textures//RSSTextures8192DDS.zip",
     "license"        : "CC-BY-NC-SA",
     "version"        : "1.0",
-    "ksp_version"    : "any",
+    "ksp_version_max"    : "0.90",
     "release_status" : "stable",
     "depends" : [
         { "name" : "RealSolarSystem", "min_version" : "v8.3" },


### PR DESCRIPTION
Based on https://github.com/KSP-CKAN/NetKAN/pull/1522

I've also elected not to rewrite the malformed naming on these files since there is a slight chance that would make new generated files from the referenced NetKAN PR overwrite these ones.

Basically I'm hiding all past sins by confining them to 0.90.

This PR will fail because Jenkins is running KSP 1.0.2.