### PR TITLE
Update and rename ContractConfigurator-GrandTours-1.0.6.ckan to Contr…

### DIFF
--- a/ContractConfigurator-GrandTours/ContractConfigurator-GrandTours-0.1.6.ckan
+++ b/ContractConfigurator-GrandTours/ContractConfigurator-GrandTours-0.1.6.ckan
@@ -27,7 +27,7 @@
     "license": "CC-BY-NC-SA-4.0",
     "abstract": "A series of 12 Grand Tours of the system",
     "author": "linuxgurugamer",
-    "version": "1.0.6",
+    "version": "0.1.6",
     "download": "https://kerbalstuff.com/mod/689/Contract%20Pack:%20Grand%20Tours/download/1.0.6",
     "x_generated_by": "netkan",
     "download_size": 207893


### PR DESCRIPTION
…actConfigurator-GrandTours-0.1.6.ckan

Looking at the versioning over at KerbalStuffs changelog it would seem rather apperant that this version is an error and it's preventing the latest version (with crucial bugfixes) to reach users.

I'm not sure if this is the correct way of solving this issue or if we should bump epoch? How will this affect users in the downstream with 1.0.6 installed?