### PR TITLE
Put KSP version cap on old verison of PorkjetHabitats

### DIFF
--- a/PorkjetHabitats/PorkjetHabitats-0.4.ckan
+++ b/PorkjetHabitats/PorkjetHabitats-0.4.ckan
@@ -2,6 +2,7 @@
 	"spec_version": 1,
 	"identifier": "PorkjetHabitats",
 	"ksp_version_min": "0.25",
+    "ksp_version_max": "0.90",
 	"resources": 
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/64442"


### PR DESCRIPTION
This is going to fail the build because it's capping the KSP version to before the current one.