### PR TITLE
Update KSPInterstellarExtended-1.1.20.ckan

### DIFF
--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.20.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.20.ckan
@@ -19,10 +19,6 @@
             "min_version": "1.7.9"
         },
         {
-            "name": "InterstellarFuelSwitch",
-            "min_version": "1.7"
-        },
-        {
             "name": "TweakScale",
             "min_version": "2.1"
         },
@@ -34,7 +30,15 @@
     "recommends": [
         {
             "name": "FilterExtensions"
-        }
+        },
+        {
+            "name": "InterstellarFuelSwitch",
+            "min_version": "1.7"
+        },
+        {
+            "name": "RealFuels",
+            "min_version": "rf-v10.3.1"
+        },
     ],
     "suggests": [
         {


### PR DESCRIPTION
Allow user to choose between RealFuels and Interstellar Fuel Switch instead of requiring Interstellar Fuel Switch, which is currently marked as "Required" and conflicts with RealFuels

KSPI Extended supports RealFuels so it should not require a conflicting mod