### PR TITLE
Rewrite versions to be more specific!

### DIFF
--- a/AmbientLightAdjustment/AmbientLightAdjustment-1.4.2.1.ckan
+++ b/AmbientLightAdjustment/AmbientLightAdjustment-1.4.2.1.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71536",
         "kerbalstuff": "https://kerbalstuff.com/mod/421/Ambient%20Light%20Adjustment"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Ambient Light Adjustment",
     "abstract": "Allows to adjust the ambient lighting on the fly in the flight scene",
     "author": "timmers_uk",

--- a/AmpYearPowerManager/AmpYearPowerManager-v0.14.ckan
+++ b/AmpYearPowerManager/AmpYearPowerManager-v0.14.ckan
@@ -13,7 +13,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/108591-WIP-0-90-Pre-Release-AmpYear-Power-Manager-Reserve-Power-Ion-RCS-v0-12/",
         "kerbalstuff": "https://kerbalstuff.com/mod/630/AmpYear%20Power%20Manager%20+%20Reserve%20Power%20+%20Ion%20RCS"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "AmpYear Power Manager + Reserve Power + Ion RCS",
     "abstract": "AmpYear Power Manager, including reserve power, ION RCS and PPT RCS parts",
     "author": "JPLRepo",

--- a/AntennaRange/AntennaRange-1.8.ckan
+++ b/AntennaRange/AntennaRange-1.8.ckan
@@ -23,7 +23,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/56440",
         "kerbalstuff": "https://kerbalstuff.com/mod/254/AntennaRange"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "AntennaRange",
     "abstract": "Enforce and Encourage Antenna Diversity",
     "author": "toadicus",

--- a/AntennaRange/AntennaRange-1.8a.ckan
+++ b/AntennaRange/AntennaRange-1.8a.ckan
@@ -23,7 +23,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/56440",
         "kerbalstuff": "https://kerbalstuff.com/mod/254/AntennaRange"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "AntennaRange",
     "abstract": "Enforce and Encourage Antenna Diversity",
     "author": "toadicus",

--- a/BDArmory/BDArmory-v0.8.0.ckan
+++ b/BDArmory/BDArmory-v0.8.0.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/85209-BahamutoD-s-Armory-v0-4-0-Dev-Thread",
         "kerbalstuff": "https://kerbalstuff.com/mod/90/BahamutoD's%20Armory"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "BahamutoD's Armory",
     "abstract": "Adds gun turrets, missiles, bombs, etc. ",
     "author": "BahamutoD",

--- a/BaconLabs/BaconLabs-0.3.1.01.ckan
+++ b/BaconLabs/BaconLabs-0.3.1.01.ckan
@@ -30,7 +30,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/114769-0-90-Bacon-Labs-Stockalike-Ariane-and-More-Juno-V-WIP?p=1820908#post1820908",
         "kerbalstuff": "https://kerbalstuff.com/mod/688/Bacon%20Labs:%20Stockalike%20Ariane%20&%20More"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Bacon Labs: Stockalike Ariane & More",
     "abstract": "Adds in semi-stockalike Ariane 5, Ariane 6, Apollo CM, Little Joe II, and Vega.",
     "author": "_Augustus_",

--- a/BaconLabs/BaconLabs-0.3.1.ckan
+++ b/BaconLabs/BaconLabs-0.3.1.ckan
@@ -30,7 +30,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/114769-0-90-Bacon-Labs-Stockalike-Ariane-and-More-Juno-V-WIP?p=1820908#post1820908",
         "kerbalstuff": "https://kerbalstuff.com/mod/688/Bacon%20Labs:%20Stockalike%20Ariane%20&%20More"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Bacon Labs: Stockalike Ariane & More",
     "abstract": "Adds in semi-stockalike Ariane 5, Ariane 6, Apollo CM, Little Joe II, and Vega.",
     "author": "_Augustus_",

--- a/BaconLabs/BaconLabs-0.3.2.ckan
+++ b/BaconLabs/BaconLabs-0.3.2.ckan
@@ -30,7 +30,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/114769-0-90-Bacon-Labs-Stockalike-Ariane-and-More-Juno-V-WIP?p=1820908#post1820908",
         "kerbalstuff": "https://kerbalstuff.com/mod/688/Bacon%20Labs:%20Stockalike%20Ariane%20&%20More"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Bacon Labs: Stockalike Ariane & More",
     "abstract": "Adds in semi-stockalike Ariane 5, Ariane 6, Apollo CM, Little Joe II, and Vega.",
     "author": "_Augustus_",

--- a/Chatterer/Chatterer-0.9.0.ckan
+++ b/Chatterer/Chatterer-0.9.0.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92324-0-24-2-Chatterer-v-0-6-0-Aug-29-2014",
         "kerbalstuff": "https://kerbalstuff.com/mod/124/Chatterer"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Chatterer",
     "abstract": "A plugin for Kerbal Space Program from SQUAD, which adds some SSTV, beeps, and nonsensical radio chatter between your crewed command pods and Mission Control. There is also some environmental sounds as : wind in atmosphere, breathing on EVA and background noises inside space-crafts.",
     "author": "Athlonic",

--- a/ChopShop/ChopShop-0.7.0.ckan
+++ b/ChopShop/ChopShop-0.7.0.ckan
@@ -43,7 +43,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/84443",
         "kerbalstuff": "https://kerbalstuff.com/mod/709/Dr.%20Jet's%20Chop%20Shop"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Dr. Jet's Chop Shop",
     "abstract": "Properly oriented rover bodies, deployable skycranes, dual-axis solar panels, SpacePlane+ (Mk2) parts, blisters, structural hubs and other useful parts.",
     "author": "doktorjet",

--- a/CollisionFX/CollisionFX-3.0.1.ckan
+++ b/CollisionFX/CollisionFX-3.0.1.ckan
@@ -12,7 +12,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/101496",
         "kerbalstuff": "https://kerbalstuff.com/mod/381/Collision%20FX"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Collision FX",
     "abstract": "Adds bangs, sparks and skidding effects to parts.",
     "author": "pizzaoverhead",

--- a/CollisionFX/CollisionFX-3.0.ckan
+++ b/CollisionFX/CollisionFX-3.0.ckan
@@ -12,7 +12,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/101496",
         "kerbalstuff": "https://kerbalstuff.com/mod/381/Collision%20FX"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Collision FX",
     "abstract": "Adds bangs, sparks and skidding effects to parts.",
     "author": "pizzaoverhead",

--- a/ContractsWindowPlus/ContractsWindowPlus-5.0.ckan
+++ b/ContractsWindowPlus/ContractsWindowPlus-5.0.ckan
@@ -12,7 +12,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91034",
         "kerbalstuff": "https://kerbalstuff.com/mod/99/Contract%20Window%20+"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Contract Window +",
     "license": "MIT",
     "abstract": "A new, more flexible contract monitoring window.",

--- a/CryoEngines/CryoEngines-0.1.2.ckan
+++ b/CryoEngines/CryoEngines-0.1.2.ckan
@@ -22,7 +22,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/717/Cryogenic%20Engines"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Cryogenic Engines",
     "abstract": "Liquid hydrogen fueled engines for enhanced possibilities",
     "author": "Nertea",

--- a/CryoEngines/CryoEngines-0.1.3.ckan
+++ b/CryoEngines/CryoEngines-0.1.3.ckan
@@ -22,7 +22,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/717/Cryogenic%20Engines"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Cryogenic Engines",
     "abstract": "Liquid hydrogen fueled engines for enhanced possibilities",
     "author": "Nertea",

--- a/CryoEngines/CryoEngines-0.1.4.ckan
+++ b/CryoEngines/CryoEngines-0.1.4.ckan
@@ -23,7 +23,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117766-1-0-Cryogenic-Engines-Pack-(high-Isp-chemical-rockets!)",
         "kerbalstuff": "https://kerbalstuff.com/mod/717/Cryogenic%20Engines"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Cryogenic Engines",
     "abstract": "Liquid hydrogen fueled engines for enhanced possibilities",
     "author": "Nertea",

--- a/CryoEngines/CryoEngines-0.1.5.ckan
+++ b/CryoEngines/CryoEngines-0.1.5.ckan
@@ -23,7 +23,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117766-1-0-Cryogenic-Engines-Pack-(high-Isp-chemical-rockets!)",
         "kerbalstuff": "https://kerbalstuff.com/mod/717/Cryogenic%20Engines"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Cryogenic Engines",
     "abstract": "Liquid hydrogen fueled engines for enhanced possibilities",
     "author": "Nertea",

--- a/CryoEngines/CryoEngines-0.1.5.repackaged0.ckan
+++ b/CryoEngines/CryoEngines-0.1.5.repackaged0.ckan
@@ -23,7 +23,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117766-1-0-Cryogenic-Engines-Pack-(high-Isp-chemical-rockets!)",
         "kerbalstuff": "https://kerbalstuff.com/mod/717/Cryogenic%20Engines"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Cryogenic Engines",
     "abstract": "Liquid hydrogen fueled engines for enhanced possibilities",
     "author": "Nertea",

--- a/DMagicOrbitalScience/DMagicOrbitalScience-1.0.2.ckan
+++ b/DMagicOrbitalScience/DMagicOrbitalScience-1.0.2.ckan
@@ -35,7 +35,7 @@
             "name": "CommunityTechTree"
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "DMagic Orbital Science",
     "abstract": "New science parts and experiments",
     "author": "DMagic",

--- a/DavonSupplyMod/DavonSupplyMod-013.ckan
+++ b/DavonSupplyMod/DavonSupplyMod-013.ckan
@@ -5,7 +5,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/430/Davon%20Supply%20Mod"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Davon Supply Mod",
     "license": "restricted",
     "abstract": "Davon Station Logistics Hub. The outsourcing solution for your resupply needs in the Kerbin locale. After transportation and proper activation of the Station Logistics Hub, it allows fuel resupply missions to the station to be undertaken by Davon industries on your request as part of Davon logistic services. Read manual before use. Limited to Kerbin and its moons. Delivery time may vary upon location. Terms of service apply. ",

--- a/DavonTCsystemsMod/DavonTCsystemsMod-075.ckan
+++ b/DavonTCsystemsMod/DavonTCsystemsMod-075.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/38069-0-25-Davon-Throttle-Control-systems-mod?p=484515&viewfull=1#post484515",
         "kerbalstuff": "https://kerbalstuff.com/mod/406/Davon%20Throttle%20Control%20systems"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Davon Throttle Control systems",
     "license": "GPL-2.0",
     "abstract": "Davon TC systems delivers advanced throttle control capabilities including additional throttles en blancing of thrust. ",

--- a/DistantObject-RealSolarSystem/DistantObject-RealSolarSystem-v1.5.3.ckan
+++ b/DistantObject-RealSolarSystem/DistantObject-RealSolarSystem-v1.5.3.ckan
@@ -27,7 +27,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/98943",
         "kerbalstuff": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "author": "MOARdV",
     "version": "v1.5.3",
     "download": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis/download/v1.5.3",

--- a/DistantObject-RealSolarSystem/DistantObject-RealSolarSystem-v1.5.4.ckan
+++ b/DistantObject-RealSolarSystem/DistantObject-RealSolarSystem-v1.5.4.ckan
@@ -27,7 +27,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/98943",
         "kerbalstuff": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "author": "MOARdV",
     "version": "v1.5.4",
     "download": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis/download/v1.5.4",

--- a/DistantObject-default/DistantObject-default-v1.5.3.ckan
+++ b/DistantObject-default/DistantObject-default-v1.5.3.ckan
@@ -32,7 +32,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/98943",
         "kerbalstuff": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "author": "MOARdV",
     "version": "v1.5.3",
     "download": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis/download/v1.5.3",

--- a/DistantObject-default/DistantObject-default-v1.5.4.ckan
+++ b/DistantObject-default/DistantObject-default-v1.5.4.ckan
@@ -32,7 +32,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/98943",
         "kerbalstuff": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "author": "MOARdV",
     "version": "v1.5.4",
     "download": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis/download/v1.5.4",

--- a/DistantObject/DistantObject-v1.5.3.ckan
+++ b/DistantObject/DistantObject-v1.5.3.ckan
@@ -20,7 +20,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/98943",
         "kerbalstuff": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "author": "MOARdV",
     "version": "v1.5.3",
     "download": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis/download/v1.5.3",

--- a/DistantObject/DistantObject-v1.5.4.ckan
+++ b/DistantObject/DistantObject-v1.5.4.ckan
@@ -20,7 +20,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/98943",
         "kerbalstuff": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "author": "MOARdV",
     "version": "v1.5.4",
     "download": "https://kerbalstuff.com/mod/403/Distant%20Object%20Enhancement%20bis/download/v1.5.4",

--- a/DraftTwitchViewers/DraftTwitchViewers-v1.0.4.1.ckan
+++ b/DraftTwitchViewers/DraftTwitchViewers-v1.0.4.1.ckan
@@ -5,7 +5,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/601/Draft%20Twitch%20Viewers"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Draft Twitch Viewers",
     "abstract": "A KSP mod that allows streamers to draft their viewers as Kerbals in-game!",
     "author": "Nifty255",

--- a/DraftTwitchViewers/DraftTwitchViewers-v1.0.4.ckan
+++ b/DraftTwitchViewers/DraftTwitchViewers-v1.0.4.ckan
@@ -5,7 +5,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/601/Draft%20Twitch%20Viewers"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Draft Twitch Viewers",
     "abstract": "A KSP mod that allows streamers to draft their viewers as Kerbals in-game!",
     "author": "Nifty255",

--- a/EVAManager/EVAManager-1.ckan
+++ b/EVAManager/EVAManager-1.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/726/EVAManager"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "EVAManager",
     "abstract": "Provides a configurable method for manipulating PartModules and PartResources in the kerbalEVA part.",
     "author": "toadicus",

--- a/EditorExtensions/EditorExtensions-2.6.ckan
+++ b/EditorExtensions/EditorExtensions-2.6.ckan
@@ -7,7 +7,7 @@
         "homepage": "https://github.com/MachXXV/EditorExtensions",
         "kerbalstuff": "https://kerbalstuff.com/mod/442/Editor%20Extensions"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Editor Extensions",
     "license": "MIT",
     "author": "MachXXV",

--- a/EditorExtensions/EditorExtensions-2.7.ckan
+++ b/EditorExtensions/EditorExtensions-2.7.ckan
@@ -8,7 +8,7 @@
         "kerbalstuff": "https://kerbalstuff.com/mod/442/Editor%20Extensions"
     },
     "spec_version": 1,
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Editor Extensions",
     "license": "MIT",
     "author": "MachXXV",

--- a/FASA/FASA-5.30.ckan
+++ b/FASA/FASA-5.30.ckan
@@ -22,7 +22,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/24867-21-FASA-2-2-Wings!!!-Sept-4?highlight=fasa",
         "kerbalstuff": "https://kerbalstuff.com/mod/27/FASA"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "FASA",
     "abstract": "FASA has Kerbal style NASA space craft from Mercury to Apollo",
     "author": "frizzank",

--- a/FASA/FASA-5.31.ckan
+++ b/FASA/FASA-5.31.ckan
@@ -28,7 +28,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/24867-21-FASA-2-2-Wings!!!-Sept-4?highlight=fasa",
         "kerbalstuff": "https://kerbalstuff.com/mod/27/FASA"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "FASA",
     "abstract": "FASA has Kerbal style NASA space craft from Mercury to Apollo",
     "author": "frizzank",

--- a/FASALaunchClamps/FASALaunchClamps-5.30.ckan
+++ b/FASALaunchClamps/FASALaunchClamps-5.30.ckan
@@ -17,7 +17,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/24867-21-FASA-2-2-Wings!!!-Sept-4?highlight=fasa",
         "kerbalstuff": "https://kerbalstuff.com/mod/34/FASA%20Launch%20Clamps%20and%20Towers"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "FASA Launch Clamps and Towers",
     "abstract": "Just the Launch clamps from FASA",
     "author": "frizzank",

--- a/FTLDrive/FTLDrive-Rev_5.ckan
+++ b/FTLDrive/FTLDrive-Rev_5.ckan
@@ -12,7 +12,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/114401-0-90-FTL-Drive-(Updates-on-development)?p=1813747#post1813747",
         "kerbalstuff": "https://kerbalstuff.com/mod/666/FTL%20Drive"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "FTL Drive",
     "abstract": "A faster than light drive that allows one to jump instantly to a FTL beacon",
     "author": "krhe",

--- a/FairingWithMass/FairingWithMass-1.0.1.ckan
+++ b/FairingWithMass/FairingWithMass-1.0.1.ckan
@@ -6,7 +6,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/725/Fairing%20With%20Mass"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Fairing With Mass",
     "abstract": "Add mass to fairing.",
     "author": "Merill",

--- a/FairingWithMass/FairingWithMass-1.0.ckan
+++ b/FairingWithMass/FairingWithMass-1.0.ckan
@@ -6,7 +6,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/725/Fairing%20With%20Mass"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Fairing With Mass",
     "abstract": "Add mass to fairing.",
     "author": "Merill",

--- a/FairingWithMass/FairingWithMass-1.1.1.ckan
+++ b/FairingWithMass/FairingWithMass-1.1.1.ckan
@@ -6,7 +6,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/725/Fairing%20With%20Mass"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Fairing With Mass",
     "abstract": "Add mass to fairing.",
     "author": "Merill",

--- a/FairingWithMass/FairingWithMass-1.1.ckan
+++ b/FairingWithMass/FairingWithMass-1.1.ckan
@@ -6,7 +6,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/725/Fairing%20With%20Mass"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Fairing With Mass",
     "abstract": "Add mass to fairing.",
     "author": "Merill",

--- a/FairingWithMass/FairingWithMass-1.2.ckan
+++ b/FairingWithMass/FairingWithMass-1.2.ckan
@@ -6,7 +6,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/725/Fairing%20With%20Mass"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Fairing With Mass",
     "abstract": "Add mass to fairing, at the right place.",
     "author": "Merill",

--- a/FilterExtensions/FilterExtensions-1.12.ckan
+++ b/FilterExtensions/FilterExtensions-1.12.ckan
@@ -4,7 +4,7 @@
     "name": "Filter Extensions",
     "abstract": "Custom, configurable filters for the VAB/SPH.",
     "license": "CC-BY-4.0",
-    "ksp_version": "0.90",
+    "ksp_version": "0.90.0",
     "install": [
         {
             "file": "GameData/000_FilterExtensions",

--- a/FilterExtensions/FilterExtensions-1.13.ckan
+++ b/FilterExtensions/FilterExtensions-1.13.ckan
@@ -4,7 +4,7 @@
     "name": "Filter Extensions",
     "abstract": "Custom, configurable filters for the VAB/SPH.",
     "license": "CC-BY-4.0",
-    "ksp_version": "0.90",
+    "ksp_version": "0.90.0",
     "install": [
         {
             "file": "GameData/000_FilterExtensions",

--- a/FilterExtensions/FilterExtensions-1.14.ckan
+++ b/FilterExtensions/FilterExtensions-1.14.ckan
@@ -4,7 +4,7 @@
     "name": "Filter Extensions",
     "abstract": "Custom, configurable filters for the VAB/SPH.",
     "license": "CC-BY-4.0",
-    "ksp_version": "0.90",
+    "ksp_version": "0.90.0",
     "install": [
         {
             "file": "GameData/000_FilterExtensions",

--- a/FilterExtensions/FilterExtensions-1.15.1.ckan
+++ b/FilterExtensions/FilterExtensions-1.15.1.ckan
@@ -4,7 +4,7 @@
     "name": "Filter Extensions",
     "abstract": "Custom, configurable filters for the VAB/SPH.",
     "license": "CC-BY-4.0",
-    "ksp_version": "0.90",
+    "ksp_version": "0.90.0",
     "install": [
         {
             "file": "GameData/000_FilterExtensions",

--- a/FilterExtensions/FilterExtensions-1.15.2.ckan
+++ b/FilterExtensions/FilterExtensions-1.15.2.ckan
@@ -4,7 +4,7 @@
     "name": "Filter Extensions",
     "abstract": "Custom, configurable filters for the VAB/SPH.",
     "license": "CC-BY-4.0",
-    "ksp_version": "0.90",
+    "ksp_version": "0.90.0",
     "install": [
         {
             "file": "GameData/000_FilterExtensions",

--- a/FilterExtensions/FilterExtensions-1.15.ckan
+++ b/FilterExtensions/FilterExtensions-1.15.ckan
@@ -4,7 +4,7 @@
     "name": "Filter Extensions",
     "abstract": "Custom, configurable filters for the VAB/SPH.",
     "license": "CC-BY-4.0",
-    "ksp_version": "0.90",
+    "ksp_version": "0.90.0",
     "install": [
         {
             "file": "GameData/000_FilterExtensions",

--- a/FilterExtensions/FilterExtensions-1.8.ckan
+++ b/FilterExtensions/FilterExtensions-1.8.ckan
@@ -4,7 +4,7 @@
   "name": "Filter Extensions",
   "abstract": "Custom, configurable filters for the VAB/SPH.",
   "license": "CC-BY-4.0",
-  "ksp_version": "0.90",
+  "ksp_version": "0.90.0",
   "install": [
     {
       "file": "GameData/Filter Extensions",

--- a/FinalFrontier/FinalFrontier-0.7.4-870.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.4-870.ckan
@@ -17,7 +17,7 @@
             ]
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
     "author": "Nereid",

--- a/FinalFrontier/FinalFrontier-0.7.5-933.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.5-933.ckan
@@ -17,7 +17,7 @@
             ]
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
     "author": "Nereid",

--- a/FinalFrontier/FinalFrontier-0.7.6-949.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.6-949.ckan
@@ -17,7 +17,7 @@
             ]
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
     "author": "Nereid",

--- a/FinalFrontier/FinalFrontier-0.7.7-956.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.7-956.ckan
@@ -17,7 +17,7 @@
             ]
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
     "author": "Nereid",

--- a/FinalFrontier/FinalFrontier-0.7.8-969.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.8-969.ckan
@@ -17,7 +17,7 @@
             ]
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
     "author": "Nereid",

--- a/FinalFrontier/FinalFrontier-0.7.9-972.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.9-972.ckan
@@ -17,7 +17,7 @@
             ]
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
     "author": "Nereid",

--- a/ForScienceContinued/ForScienceContinued-0.27.1.ckan
+++ b/ForScienceContinued/ForScienceContinued-0.27.1.ckan
@@ -18,7 +18,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106004-0-90-ForScience-Continued",
         "kerbalstuff": "https://kerbalstuff.com/mod/477/ForScience%20Continued!"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "ForScience Continued!",
     "abstract": "Build upon the ForScience mod by WaveFunctionP. This version adds an interface and exciting new features to it.",
     "author": "SpaceTiger",

--- a/ForScienceContinued/ForScienceContinued-0.27.ckan
+++ b/ForScienceContinued/ForScienceContinued-0.27.ckan
@@ -13,7 +13,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106004-0-90-ForScience-Continued",
         "kerbalstuff": "https://kerbalstuff.com/mod/477/ForScience%20Continued!"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "ForScience Continued!",
     "abstract": "Build upon the ForScience mod by WaveFunctionP. This version adds an interface and exciting new features to it.",
     "author": "SpaceTiger",

--- a/FuelTanksPlus/FuelTanksPlus-0.8.ckan
+++ b/FuelTanksPlus/FuelTanksPlus-0.8.ckan
@@ -7,7 +7,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/108238",
         "kerbalstuff": "https://kerbalstuff.com/mod/529/Fuel%20Tanks%20Plus"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Fuel Tanks Plus",
     "abstract": "Longer fuel tanks in a variety of styles, with assocaited fueled nose cones. Stand-alone, or companion to Color Coded Canisters.",
     "author": "NecroBones",

--- a/GlassPanesandEnclosures/GlassPanesandEnclosures-1.0.5.ckan
+++ b/GlassPanesandEnclosures/GlassPanesandEnclosures-1.0.5.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/727/Glass%20Panes%20and%20Enclosures%20(GPE)"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Glass Panes and Enclosures (GPE)",
     "abstract": "This mod provides a very good part collection for extraordinary contraptions, sci-fi 60's style space stations, and ground bases. One can even use for underwater bases!",
     "author": "2001kraft",

--- a/GlassPanesandEnclosures/GlassPanesandEnclosures-1.0.6.ckan
+++ b/GlassPanesandEnclosures/GlassPanesandEnclosures-1.0.6.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/727/Glass%20Panes%20and%20Enclosures%20(GPE)"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Glass Panes and Enclosures (GPE)",
     "abstract": "This mod provides a very good part collection for extraordinary contraptions, sci-fi 60's style space stations, and ground bases. One can even use for underwater bases!",
     "author": "2001kraft",

--- a/HullcamVDS/HullcamVDS-0.34.ckan
+++ b/HullcamVDS/HullcamVDS-0.34.ckan
@@ -14,7 +14,7 @@
             "install_to": "GameData"
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",
     "author": "Albert_VDS",

--- a/InfernalRobotics-Sequencer/InfernalRobotics-Sequencer-0.2.ckan
+++ b/InfernalRobotics-Sequencer/InfernalRobotics-Sequencer-0.2.ckan
@@ -20,7 +20,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116076",
         "kerbalstuff": "https://kerbalstuff.com/mod/708/Sequencer%20for%20Infernal%20Robotics"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Sequencer for Infernal Robotics",
     "abstract": "With this mod you can create and play sequences of servo movement commands and special commands, like GoTo, Toggle ActionGroup, Delay and Wait.",
     "author": "Ziw",

--- a/InfernalRobotics/InfernalRobotics-0.21.1.ckan
+++ b/InfernalRobotics/InfernalRobotics-0.21.1.ckan
@@ -26,7 +26,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116064-1-0-Magic-Smoke-Industries-Infernal-Robotics-0-21-0",
         "kerbalstuff": "https://kerbalstuff.com/mod/8/Magic%20Smoke%20Industries%20Infernal%20Robotics"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Magic Smoke Industries Infernal Robotics",
     "abstract": "Making stuff move.",
     "author": "sirkut",

--- a/InfernalRobotics/InfernalRobotics-0.21.1_a.ckan
+++ b/InfernalRobotics/InfernalRobotics-0.21.1_a.ckan
@@ -26,7 +26,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116064-1-0-Magic-Smoke-Industries-Infernal-Robotics-0-21-0",
         "kerbalstuff": "https://kerbalstuff.com/mod/8/Magic%20Smoke%20Industries%20Infernal%20Robotics"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Magic Smoke Industries Infernal Robotics",
     "abstract": "Making stuff move.",
     "author": "sirkut",

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-0.2.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-0.2.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117932-1-0-Interstellar-Fuel-Switch-0-2",
         "kerbalstuff": "https://kerbalstuff.com/mod/718/Interstellar%20Fuel%20Switch"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Interstellar Fuel Switch",
     "abstract": "Interstellar Fuel Switch",
     "author": "FreeThinker",

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-0.3.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-0.3.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117932-1-0-Interstellar-Fuel-Switch-0-2",
         "kerbalstuff": "https://kerbalstuff.com/mod/718/Interstellar%20Fuel%20Switch"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Interstellar Fuel Switch",
     "abstract": "Interstellar Fuel Switch",
     "author": "FreeThinker",

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-0.4.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-0.4.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117932-1-0-Interstellar-Fuel-Switch-0-2",
         "kerbalstuff": "https://kerbalstuff.com/mod/718/Interstellar%20Fuel%20Switch"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Interstellar Fuel Switch",
     "abstract": "Interstellar Fuel Switch",
     "author": "FreeThinker",

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-0.5.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-0.5.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117932-1-0-Interstellar-Fuel-Switch-0-2",
         "kerbalstuff": "https://kerbalstuff.com/mod/718/Interstellar%20Fuel%20Switch"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Interstellar Fuel Switch",
     "abstract": "Interstellar Fuel Switch",
     "author": "FreeThinker",

--- a/K2CommandPod/K2CommandPod-1.2.ckan
+++ b/K2CommandPod/K2CommandPod-1.2.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/445/K2%20Command%20Pod"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "K2 Command Pod",
     "license": "MIT",
     "abstract": "2-Kerbal pod in a \"stock-alike\" style, but inspired by the Gemini capsule.",

--- a/KIS/KIS-1.1.0.ckan
+++ b/KIS/KIS-1.1.0.ckan
@@ -12,5 +12,5 @@
     "author"         : [ "KospY", "Winn75" ],
     "version"        : "1.1.0",
     "release_status" : "stable",
-    "ksp_version"    : "1.0"
+    "ksp_version"    : "1.0.0"
 }

--- a/KIS/KIS-1.1.1.ckan
+++ b/KIS/KIS-1.1.1.ckan
@@ -12,5 +12,5 @@
     "author"         : [ "KospY", "Winn75" ],
     "version"        : "1.1.1",
     "release_status" : "stable",
-    "ksp_version"    : "1.0"
+    "ksp_version"    : "1.0.0"
 }

--- a/KSPIRC/KSPIRC-0.9.0.1.ckan
+++ b/KSPIRC/KSPIRC-0.9.0.1.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/101868",
         "kerbalstuff": "https://kerbalstuff.com/mod/422/KSPIRC"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "KSPIRC",
     "abstract": "Use Internet Relay Chat (IRC) from within KSP",
     "author": "timmers_uk",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.0.ckan
@@ -24,5 +24,5 @@
     "download": "https://github.com/TriggerAu/KerbalAlarmClock/releases/download/v3.3.0.0/KerbalAlarmClock_3.3.0.0.zip",
     "x_generated_by": "netkan",
     "download_size": 462217,
-    "ksp_version": "1.0"
+    "ksp_version": "1.0.0"
 }

--- a/KerboKatzSmallUtilities/KerboKatzSmallUtilities-1.1.1.ckan
+++ b/KerboKatzSmallUtilities/KerboKatzSmallUtilities-1.1.1.ckan
@@ -17,7 +17,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116034",
         "kerbalstuff": "https://kerbalstuff.com/mod/704/KerboKatz%20-%20SmallUtilities"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "KerboKatz - SmallUtilities",
     "abstract": "Adds small and usefull tools to kerbal. Read the forum post for more information :)",
     "author": "SpaceTiger",

--- a/KerboKatzSmallUtilities/KerboKatzSmallUtilities-1.1.2.ckan
+++ b/KerboKatzSmallUtilities/KerboKatzSmallUtilities-1.1.2.ckan
@@ -17,7 +17,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116034",
         "kerbalstuff": "https://kerbalstuff.com/mod/704/KerboKatz%20-%20SmallUtilities"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "KerboKatz - SmallUtilities",
     "abstract": "Adds small and usefull tools to kerbal. Read the forum post for more information :)",
     "author": "SpaceTiger",

--- a/KerboKatzSmallUtilities/KerboKatzSmallUtilities-1.1.3.ckan
+++ b/KerboKatzSmallUtilities/KerboKatzSmallUtilities-1.1.3.ckan
@@ -17,7 +17,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116034",
         "kerbalstuff": "https://kerbalstuff.com/mod/704/KerboKatz%20-%20SmallUtilities"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "KerboKatz - SmallUtilities",
     "abstract": "Adds small and usefull tools to kerbal. Read the forum post for more information :)",
     "author": "SpaceTiger",

--- a/KerboKatzSmallUtilities/KerboKatzSmallUtilities-1.1.ckan
+++ b/KerboKatzSmallUtilities/KerboKatzSmallUtilities-1.1.ckan
@@ -17,7 +17,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116034",
         "kerbalstuff": "https://kerbalstuff.com/mod/704/KerboKatz%20-%20SmallUtilities"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "KerboKatz - SmallUtilities",
     "abstract": "Adds small and usefull tools to kerbal. Read the forum post for more information :)",
     "author": "SpaceTiger",

--- a/KerboKatzUtilities/KerboKatzUtilities-1.2.1.ckan
+++ b/KerboKatzUtilities/KerboKatzUtilities-1.2.1.ckan
@@ -20,7 +20,7 @@
         "homepage": "https://github.com/Xarun/KerboKatzUtilities",
         "kerbalstuff": "https://kerbalstuff.com/mod/600/KerboKatzUtilities"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "KerboKatzUtilities",
     "abstract": "Utilities used in all of my mods",
     "author": "SpaceTiger",

--- a/MechJeb2/MechJeb2-2.5.0.ckan
+++ b/MechJeb2/MechJeb2-2.5.0.ckan
@@ -1,7 +1,7 @@
 {
 	"spec_version": 1,
 	"identifier": "MechJeb2",
-	"ksp_version": "1.0",
+	"ksp_version": "1.0.0",
 	"resources":
 	{
 		"homepage": "http://forum.kerbalspaceprogram.com/threads/12384",

--- a/MissionController2/MissionController2-1.12.1.ckan
+++ b/MissionController2/MissionController2-1.12.1.ckan
@@ -12,7 +12,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/43645-Mission-Controller-2-Preview-Version-3-(KSP-24-2)-(New-Agena-Mini-Story)",
         "kerbalstuff": "https://kerbalstuff.com/mod/93/Mission%20Controller%202"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Mission Controller 2",
     "abstract": "Mission Controller 2 Adds New Economy Adjustments and Contracts to Kerbal Space Program.",
     "author": "Malkuth74",

--- a/MissionController2/MissionController2-1.12.2.ckan
+++ b/MissionController2/MissionController2-1.12.2.ckan
@@ -12,7 +12,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/43645-Mission-Controller-2-Preview-Version-3-(KSP-24-2)-(New-Agena-Mini-Story)",
         "kerbalstuff": "https://kerbalstuff.com/mod/93/Mission%20Controller%202"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Mission Controller 2",
     "abstract": "Mission Controller 2 Adds New Economy Adjustments and Contracts to Kerbal Space Program.",
     "author": "Malkuth74",

--- a/ModularRocketSystemsLITE/ModularRocketSystemsLITE-1.6.1.ckan
+++ b/ModularRocketSystemsLITE/ModularRocketSystemsLITE-1.6.1.ckan
@@ -13,7 +13,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/93067",
         "kerbalstuff": "https://kerbalstuff.com/mod/584/Modular%20Rocket%20Systems%20LITE"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Modular Rocket Systems LITE",
     "abstract": "Reduced version of MRS containing only the more unique/interesting parts.",
     "author": "NecroBones",

--- a/NanoGauges/NanoGauges-0.7.3-854.ckan
+++ b/NanoGauges/NanoGauges-0.7.3-854.ckan
@@ -17,7 +17,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/84409-0-90-0-NanoGauges-tiny-ana1og-gauges-for-kerbalnauts-0-5-21-236",
         "kerbalstuff": "https://kerbalstuff.com/mod/429/NanoGauges"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "NanoGauges",
     "abstract": "tiny analog gauges",
     "author": "Nereid",

--- a/NanoGauges/NanoGauges-0.7.6-859.ckan
+++ b/NanoGauges/NanoGauges-0.7.6-859.ckan
@@ -17,7 +17,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/84409-0-90-0-NanoGauges-tiny-ana1og-gauges-for-kerbalnauts-0-5-21-236",
         "kerbalstuff": "https://kerbalstuff.com/mod/429/NanoGauges"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "NanoGauges",
     "abstract": "tiny analog gauges",
     "author": "Nereid",

--- a/NanoGauges/NanoGauges-0.7.7-912.ckan
+++ b/NanoGauges/NanoGauges-0.7.7-912.ckan
@@ -17,7 +17,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/84409-0-90-0-NanoGauges-tiny-ana1og-gauges-for-kerbalnauts-0-5-21-236",
         "kerbalstuff": "https://kerbalstuff.com/mod/429/NanoGauges"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "NanoGauges",
     "abstract": "tiny analog gauges",
     "author": "Nereid",

--- a/NearFutureConstruction/NearFutureConstruction-0.5.0.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.5.0.ckan
@@ -19,7 +19,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/52042-0-21",
         "kerbalstuff": "https://kerbalstuff.com/mod/348/Near%20Future%20Construction"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Near Future Construction",
     "abstract": "Construction parts for large craft including trusses, docking ports and adapters. ",
     "author": "Nertea",

--- a/NearFutureConstruction/NearFutureConstruction-0.5.1.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.5.1.ckan
@@ -19,7 +19,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/52042-0-21",
         "kerbalstuff": "https://kerbalstuff.com/mod/348/Near%20Future%20Construction"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Near Future Construction",
     "abstract": "Construction parts for large craft including trusses, docking ports and adapters. ",
     "author": "Nertea",

--- a/NearFutureSolar/NearFutureSolar-0.5.0.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.5.0.ckan
@@ -11,7 +11,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/52042-0-21",
         "kerbalstuff": "https://kerbalstuff.com/mod/346/Near%20Future%20Solar"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Near Future Solar",
     "abstract": "A pack of futuristic stockalike solar panels",
     "author": "Nertea",

--- a/NearFutureSolar/NearFutureSolar-0.5.1.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.5.1.ckan
@@ -11,7 +11,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/52042-0-21",
         "kerbalstuff": "https://kerbalstuff.com/mod/346/Near%20Future%20Solar"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Near Future Solar",
     "abstract": "A pack of futuristic stockalike solar panels",
     "author": "Nertea",

--- a/NearFutureSpacecraft/NearFutureSpacecraft-0.4.0.ckan
+++ b/NearFutureSpacecraft/NearFutureSpacecraft-0.4.0.ckan
@@ -25,7 +25,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/52042-0-21",
         "kerbalstuff": "https://kerbalstuff.com/mod/350/Near%20Future%20Spacecraft%20Parts"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Near Future Spacecraft Parts",
     "abstract": "Stockalike parts for constructing futuristic spacecraft",
     "author": "Nertea",

--- a/NearFutureSpacecraft/NearFutureSpacecraft-0.4.1.ckan
+++ b/NearFutureSpacecraft/NearFutureSpacecraft-0.4.1.ckan
@@ -25,7 +25,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/52042-0-21",
         "kerbalstuff": "https://kerbalstuff.com/mod/350/Near%20Future%20Spacecraft%20Parts"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Near Future Spacecraft Parts",
     "abstract": "Stockalike parts for constructing futuristic spacecraft",
     "author": "Nertea",

--- a/OuterPlanetsMod/OuterPlanetsMod-1.6.5.ckan
+++ b/OuterPlanetsMod/OuterPlanetsMod-1.6.5.ckan
@@ -83,7 +83,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/104280-0-90-Outer-Planet-Mods-Expands-the-Kerbol-system-with-new-planets-based-on-Saturn",
         "kerbalstuff": "https://kerbalstuff.com/mod/437/Outer%20Planets%20Mod"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Outer Planets Mod",
     "abstract": "Expands the Kerbol system with new planets and moons based on Saturn, Uranus, Neptune and their moons",
     "author": "CaptRobau",

--- a/PilotAssistant/PilotAssistant-1.5.5.ckan
+++ b/PilotAssistant/PilotAssistant-1.5.5.ckan
@@ -4,7 +4,7 @@
     "name": "Pilot Assistant",
     "abstract": "Helpful tool wich controls planes' altitude and heading via autopilot or custom SAS",
     "license": "CC-BY-4.0",
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/100073",
         "repository": "https://github.com/Crzyrndm/Pilot-Assistant"

--- a/PlaneMode/PlaneMode-0.4.1.ckan
+++ b/PlaneMode/PlaneMode-0.4.1.ckan
@@ -11,7 +11,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106934",
         "kerbalstuff": "https://kerbalstuff.com/mod/493/Plane%20Mode"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Plane Mode",
     "license": "MIT",
     "abstract": "Swap Yaw/Roll in Flight",

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.2.2.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.2.2.ckan
@@ -26,7 +26,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/96497",
         "kerbalstuff": "https://kerbalstuff.com/mod/266/PlanetShine"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",
     "author": "Valerian",
     "version": "0.2.2.2",

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.2.3.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.2.3.ckan
@@ -26,7 +26,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/96497",
         "kerbalstuff": "https://kerbalstuff.com/mod/266/PlanetShine"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",
     "author": "Valerian",
     "version": "0.2.2.3",

--- a/ProceduralParts/ProceduralParts-v0.9.19.ckan
+++ b/ProceduralParts/ProceduralParts-v0.9.19.ckan
@@ -4,7 +4,7 @@
   "name": "Procedural Parts",
   "abstract": "ProceduralParts allows you to procedurally generate a number of different parts in a range of sizes and shapes.",
   "license": "CC-BY-3.0",
-  "ksp_version": "0.25",
+  "ksp_version": "0.25.0",
   "resources": {
     "repository": "https://github.com/Swamp-Ig/ProceduralParts"
   },

--- a/ProceduralParts/ProceduralParts-v0.9.20.ckan
+++ b/ProceduralParts/ProceduralParts-v0.9.20.ckan
@@ -4,7 +4,7 @@
   "name": "Procedural Parts",
   "abstract": "ProceduralParts allows you to procedurally generate a number of different parts in a range of sizes and shapes.",
   "license": "CC-BY-3.0",
-  "ksp_version": "0.25",
+  "ksp_version": "0.25.0",
   "suggests": [
     {
       "name": "PPTextures"

--- a/QuickContracts/QuickContracts-v1.00.ckan
+++ b/QuickContracts/QuickContracts-v1.00.ckan
@@ -12,7 +12,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/95168",
         "kerbalstuff": "https://kerbalstuff.com/mod/539/QuickContracts"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "QuickContracts",
     "abstract": "QuickContracts is a plugin which adds the possibility to have keyboard's shortcuts on the mission control.",
     "author": "malah",

--- a/QuickGoTo/QuickGoTo-v1.00.ckan
+++ b/QuickGoTo/QuickGoTo-v1.00.ckan
@@ -12,7 +12,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/95168",
         "kerbalstuff": "https://kerbalstuff.com/mod/653/QuickGoTo"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "QuickGoTo",
     "abstract": "QuickGoTo is a small plugin which add the possibility to go to an other scene from anywhere (VAB, SPH, Tracking Station ...).",
     "author": "malah",

--- a/QuickIVA/QuickIVA-v1.02.ckan
+++ b/QuickIVA/QuickIVA-v1.02.ckan
@@ -18,7 +18,7 @@
             "name": "RasterPropMonitor"
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "QuickIVA",
     "abstract": "QuickIVA is a small plugin which adds a switch to the IVA at the loading or the launch of a vessel.",
     "author": "malah",

--- a/QuickMute/QuickMute-v1.02.ckan
+++ b/QuickMute/QuickMute-v1.02.ckan
@@ -17,7 +17,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/95168",
         "kerbalstuff": "https://kerbalstuff.com/mod/509/QuickMute"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "QuickMute",
     "abstract": "QuickMute is a plugin which adds the possibility to mute all the KSP sounds.",
     "author": "malah",

--- a/QuickScroll/QuickScroll-v1.21.ckan
+++ b/QuickScroll/QuickScroll-v1.21.ckan
@@ -13,7 +13,7 @@
             "name": "PartCatalog"
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "QuickScroll",
     "abstract": "QuickScroll is a small plugin which adds the possibility to scroll the parts pages, the categories and the filters on the editor with the mouse wheel and with keyboard shortcuts.",
     "author": "malah",

--- a/QuickSearch/QuickSearch-v1.11.ckan
+++ b/QuickSearch/QuickSearch-v1.11.ckan
@@ -13,7 +13,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/95168#QuickSearch",
         "kerbalstuff": "https://kerbalstuff.com/mod/472/QuickSearch"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "QuickSearch",
     "abstract": "QuickSearch is a small plugin which adds the possibility to search parts on the editor.",
     "author": "malah",

--- a/RasterPropMonitor/RasterPropMonitor-v0.19.3.ckan
+++ b/RasterPropMonitor/RasterPropMonitor-v0.19.3.ckan
@@ -35,7 +35,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117471",
         "kerbalstuff": "https://kerbalstuff.com/mod/734/RasterPropMonitor"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "RasterPropMonitor",
     "abstract": "RasterPropMonitor is a plugin and toolkit that provides functional props within your IVA.",
     "version": "v0.19.3",

--- a/Rejector/Rejector-1.0.6.ckan
+++ b/Rejector/Rejector-1.0.6.ckan
@@ -7,7 +7,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/108316-Rejector",
         "kerbalstuff": "https://kerbalstuff.com/mod/531/Rejector"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Rejector",
     "abstract": "A simple plugin to automatically reject contracts that you do not like (specified in the in game window).",
     "author": "rreeggkk",

--- a/RocketWatch/RocketWatch-1.1.0.ckan
+++ b/RocketWatch/RocketWatch-1.1.0.ckan
@@ -13,7 +13,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/111882-(0-90)-RocketWatch-0-1-Orbital-Timekeeping-for-KSA-Fashion-approved-crafts-(2-26-15)",
         "kerbalstuff": "https://kerbalstuff.com/mod/616/RocketWatch"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "RocketWatch",
     "abstract": "A rocket-sized wristwatch, for all your orbital time-keeping needs! The very simple RocketWatch mod contains a single part and plugin. When the game detects that the active craft has the RocketWatch part on it, it adds a small window just beneath the Mission clock, which shows the current real-world time.",
     "author": "gkorgood",

--- a/SafeChute/SafeChute-1.6.ckan
+++ b/SafeChute/SafeChute-1.6.ckan
@@ -8,7 +8,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/100855",
         "kerbalstuff": "https://kerbalstuff.com/mod/360/SafeChute"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "SafeChute",
     "abstract": "SafeChute takes you out of time warp when your parachutes deploy, and also just above landing. You can restart time warp manually after SafeChute stops it.",
     "author": "hab136",

--- a/Scatterer/Scatterer-0.014_Experimental.ckan
+++ b/Scatterer/Scatterer-0.014_Experimental.ckan
@@ -13,7 +13,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/115408",
         "kerbalstuff": "https://kerbalstuff.com/mod/700/Scatterer"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Scatterer",
     "abstract": "Atmospheric scattering shaders",
     "author": "blackrack",

--- a/ScienceAlert/ScienceAlert-1.8.5.ckan
+++ b/ScienceAlert/ScienceAlert-1.8.5.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/76793",
         "kerbalstuff": "https://kerbalstuff.com/mod/424/ScienceAlert"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "ScienceAlert",
     "abstract": "Audio and visual feedback when a science experiment is available",
     "author": "xEvilReeperx",

--- a/ScienceAlert/ScienceAlert-1.8.6.ckan
+++ b/ScienceAlert/ScienceAlert-1.8.6.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/76793",
         "kerbalstuff": "https://kerbalstuff.com/mod/424/ScienceAlert"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "ScienceAlert",
     "abstract": "Audio and visual feedback when a science experiment is available",
     "author": "xEvilReeperx",

--- a/SensibleScreenshot/SensibleScreenshot-1.0.ckan
+++ b/SensibleScreenshot/SensibleScreenshot-1.0.ckan
@@ -13,7 +13,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/107663-Magico13-s-Modlets",
         "kerbalstuff": "https://kerbalstuff.com/mod/716/Sensible%20Screenshot"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Sensible Screenshot",
     "abstract": "Screenshots with a unique and sensible naming scheme",
     "author": "magico13",

--- a/ShipManifest/ShipManifest-4.1.4.4.ckan
+++ b/ShipManifest/ShipManifest-4.1.4.4.ckan
@@ -20,7 +20,7 @@
             "name": "ModuleManager"
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",
     "author": "Papa_Joe",

--- a/SimpleOrbitCalculator/SimpleOrbitCalculator-v1.1.1.ckan
+++ b/SimpleOrbitCalculator/SimpleOrbitCalculator-v1.1.1.ckan
@@ -6,7 +6,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/115990",
         "kerbalstuff": "https://kerbalstuff.com/mod/712/SOC:%20Simple%20Orbit%20Calculator"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "SOC: Simple Orbit Calculator",
     "abstract": "An in-game orbit calculator.",
     "author": "stevehead",

--- a/StarTrekEngines/StarTrekEngines-1.6.ckan
+++ b/StarTrekEngines/StarTrekEngines-1.6.ckan
@@ -27,7 +27,7 @@
             "comment": "The KSPI MM Configs"
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Star-Trek Style Engines for KSPI",
     "abstract": "KSPI-compatible engine configs using Simian Endeavors Star-Trek style radial engines",
     "author": "ABZB",

--- a/StationPartsExpansion/StationPartsExpansion-0.3.0.ckan
+++ b/StationPartsExpansion/StationPartsExpansion-0.3.0.ckan
@@ -25,7 +25,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91814",
         "kerbalstuff": "https://kerbalstuff.com/mod/351/Stockalike%20Station%20Parts%20Expansion"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Stockalike Station Parts Expansion",
     "abstract": "Expand space and surface stations with this purpose-built collection of stockalike parts",
     "author": "Nertea",

--- a/StationPartsExpansion/StationPartsExpansion-0.3.1.ckan
+++ b/StationPartsExpansion/StationPartsExpansion-0.3.1.ckan
@@ -25,7 +25,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91814",
         "kerbalstuff": "https://kerbalstuff.com/mod/351/Stockalike%20Station%20Parts%20Expansion"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Stockalike Station Parts Expansion",
     "abstract": "Expand space and surface stations with this purpose-built collection of stockalike parts",
     "author": "Nertea",

--- a/TACLS-Config-Stock/TACLS-Config-Stock-0.11.1.20.ckan
+++ b/TACLS-Config-Stock/TACLS-Config-Stock-0.11.1.20.ckan
@@ -29,7 +29,7 @@
         "homepage": "https://github.com/taraniselsu/TacLifeSupport/wiki",
         "kerbalstuff": "https://kerbalstuff.com/mod/733/TAC%20Life%20Support"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "author": "TaranisElsu",
     "version": "0.11.1.20",
     "download": "https://kerbalstuff.com/mod/733/TAC%20Life%20Support/download/0.11.1.20",

--- a/TextureReplacer/TextureReplacer-2.4.1.ckan
+++ b/TextureReplacer/TextureReplacer-2.4.1.ckan
@@ -8,7 +8,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/107471",
         "kerbalstuff": "https://kerbalstuff.com/mod/150/TextureReplacer"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "TextureReplacer",
     "abstract": "Kerbal personalisation, IVA suits on Kerbin and texture replacement and improvements.",
     "author": "shaw",

--- a/Thermometer/Thermometer-1.0.0.ckan
+++ b/Thermometer/Thermometer-1.0.0.ckan
@@ -18,7 +18,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/118087-Thermometer",
         "kerbalstuff": "https://kerbalstuff.com/mod/719/Thermometer"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Thermometer",
     "abstract": "Display the Temperature of parts in their right click menu.",
     "author": "rreeggkk",

--- a/Thermometer/Thermometer-1.0.2.ckan
+++ b/Thermometer/Thermometer-1.0.2.ckan
@@ -18,7 +18,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/118087-Thermometer",
         "kerbalstuff": "https://kerbalstuff.com/mod/719/Thermometer"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Thermometer",
     "abstract": "Display the Temperature of parts in their right click menu.",
     "author": "rreeggkk",

--- a/ToadicusTools/ToadicusTools-10.ckan
+++ b/ToadicusTools/ToadicusTools-10.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/470/ToadicusTools"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "ToadicusTools",
     "abstract": "A library of tools for KSP mods.",
     "author": "toadicus",

--- a/ToadicusTools/ToadicusTools-12.ckan
+++ b/ToadicusTools/ToadicusTools-12.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/470/ToadicusTools"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "ToadicusTools",
     "abstract": "A library of tools for KSP mods.",
     "author": "toadicus",

--- a/ToadicusTools/ToadicusTools-8a.ckan
+++ b/ToadicusTools/ToadicusTools-8a.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/470/ToadicusTools"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "ToadicusTools",
     "abstract": "A library of tools for KSP mods.",
     "author": "toadicus",

--- a/TriggerAu-Flags/TriggerAu-Flags-2.7.0.0.ckan
+++ b/TriggerAu-Flags/TriggerAu-Flags-2.7.0.0.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData/TriggerTech"
         }
     ],
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "version": "2.7.0.0",
     "download": "https://kerbalstuff.com/mod/195/Alternate%20Resource%20Panel/download/2.7.0.0",
     "x_generated_by": "netkan",

--- a/TweakScale/TweakScale-v2.0.1.ckan
+++ b/TweakScale/TweakScale-v2.0.1.ckan
@@ -18,7 +18,7 @@
         "repository": "https://github.com/pellinor0/TweakScale",
         "kerbalstuff": "https://kerbalstuff.com/mod/344/TweakScale%20-%20Rescale%20Everything!"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "TweakScale - Rescale Everything!",
     "abstract": "TweakScale lets you change the size of a part. Not just that, but it will figure out how much fuel is in the resized part. And if it's an engine, it will become more powerful by scaling it bigger, or weaker by scaling it smaller.",
     "version": "v2.0.1",

--- a/UniversalStorage/UniversalStorage-1.1.0.1.ckan
+++ b/UniversalStorage/UniversalStorage-1.1.0.1.ckan
@@ -34,7 +34,7 @@
         "homepage": "http://ksp.kingtiger.co.uk",
         "kerbalstuff": "https://kerbalstuff.com/mod/250/Universal%20Storage"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Universal Storage",
     "abstract": "Modular resource and processor parts to build custom service modules.",
     "author": "Paul_Kingtiger",

--- a/VOID/VOID-0.18.1.ckan
+++ b/VOID/VOID-0.18.1.ckan
@@ -17,7 +17,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54533",
         "kerbalstuff": "https://kerbalstuff.com/mod/253/VOID"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "VOID",
     "abstract": "Vessel Orbital Informational Display",
     "author": "toadicus",

--- a/VesselView/VesselView-0.7.ckan
+++ b/VesselView/VesselView-0.7.ckan
@@ -19,7 +19,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80581-0-90-Vessel-Viewer",
         "kerbalstuff": "https://kerbalstuff.com/mod/731/Vessel%20Viewer"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.0.0",
     "name": "Vessel Viewer",
     "abstract": "Adds a handy-dandy window/RPM tab with a 3D model of your craft + color-coded readouts.",
     "author": "PeteTimesSix",


### PR DESCRIPTION
As discussed in KSP-CKAN/CKAN#1156, sometimes we see older versions of
mods that have "generic" KSP versions (eg: 1.0), even though newer
versions of those same mods have specific versions (eg 1.0.1). These has
been a side-effect of how KS returns KSP version numbers to us.

This patch adds ".0" to version numbers if and only if we see a later
version of the same mod that has a specific version number in the same
sequence (eg: 1.0 and 1.0.3 causes a rewrite, but 0.24 and 1.0.3 does
not).

Source code coming soon. I haven't checked it into CKAN-meta because
it's not really a place where lots of code should be hanging out.

Also attn @dbent, who identified this issue in the first place.