### PR TITLE
KJR 3.1.4 is compatible with KSP 1.0.4

### DIFF
--- a/KerbalJointReinforcement/KerbalJointReinforcement-v3.1.4.ckan
+++ b/KerbalJointReinforcement/KerbalJointReinforcement-v3.1.4.ckan
@@ -16,5 +16,5 @@
     "x_generated_by": "netkan",
     "download_size": 38385,
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.0.3"
+    "ksp_version_max": "1.0.4"
 }


### PR DESCRIPTION
As received from KerbalStuff:

Hi there! Thought you would like to know that ferram4 told us that version v3.1.4 of Kerbal Joint Reinforcement works great with Kerbal Space Program 1.0.4.

If you are already up-to-date, you don't need to do anything. Otherwise, you can grab the latest version here:

http://kerbalstuff.com/mod/53/Kerbal_Joint_Reinforcement

If you'd prefer us not to email you about this mod, you can hit "Unfollow" on this mod's page and you won't get them any more.