### PR TITLE
EditorExtensions 2.3 isn't *THAT* forward compatible.

### DIFF
--- a/EditorExtensions/EditorExtensions-2.3.ckan
+++ b/EditorExtensions/EditorExtensions-2.3.ckan
@@ -12,5 +12,5 @@
   "download": "https://github.com/MachXXV/EditorExtensions/releases/download/v2.3/EditorExtensions_v2.3.zip",
   "x_generated_by": "netkan",
   "download_size": 15724,
-  "ksp_version_min": "0.90.0"
+  "ksp_version": "0.90.0"
 }


### PR DESCRIPTION
Reported by @SkyMarshal in KSP-CKAN/CKAN#1184.