### PR TITLE
MechJebFARExt requires *at least* FAR v0.15.2

### DIFF
--- a/MechJebFARExt/MechJebFARExt-1.0.0.ckan
+++ b/MechJebFARExt/MechJebFARExt-1.0.0.ckan
@@ -15,7 +15,7 @@
         },
         {
             "name": "FerramAerospaceResearch",
-            "version": "v0.15.2_Ferri"
+            "min_version": "v0.15.2_Ferri"
         }
     ],
     "install": [


### PR DESCRIPTION
This change means we're happy with any version of FAR from
v0.15.2 *or later*, rather than insisting on v0.15.2 *exactly*.

Attn @Sarbian in case we really *do* need an exact version (our
user reports say that current FAR releases have been working fine).