### PR TITLE
Tidy-up of not-quite-right URLs in resource metadata

### DIFF
--- a/BackgroundProcessing/BackgroundProcessing-0.2.3.ckan
+++ b/BackgroundProcessing/BackgroundProcessing-0.2.3.ckan
@@ -9,7 +9,6 @@
     }
   ],
   "resources": {
-    "homepage": "",
     "kerbalstuff": "https://kerbalstuff.com/mod/302/BackgroundProcessing"
   },
   "ksp_version": "0.25",

--- a/CommunityTechTree/CommunityTechTree-1.0.ckan
+++ b/CommunityTechTree/CommunityTechTree-1.0.ckan
@@ -14,7 +14,6 @@
     }
   ],
   "resources": {
-    "homepage": "",
     "kerbalstuff": "https://kerbalstuff.com/mod/345/Community%20Tech%20Tree"
   },
   "ksp_version": "0.25",

--- a/UniversalStorage-ECLSS/UniversalStorage-ECLSS-0.9.2.ckan
+++ b/UniversalStorage-ECLSS/UniversalStorage-ECLSS-0.9.2.ckan
@@ -18,7 +18,7 @@
     }
   ],
   "resources": {
-    "homepage": "ksp.kingtiger.co.uk",
+    "homepage": "http://ksp.kingtiger.co.uk/",
     "kerbalstuff": "https://kerbalstuff.com/mod/366/Universal%20Storage%20%5BECLSS%5D"
   },
   "ksp_version": "0.25",

--- a/UniversalStorage-IFI/UniversalStorage-IFI-0.9.0.ckan
+++ b/UniversalStorage-IFI/UniversalStorage-IFI-0.9.0.ckan
@@ -18,7 +18,7 @@
     }
   ],
   "resources": {
-    "homepage": "ksp.kingtiger.co.uk",
+    "homepage": "http://ksp.kingtiger.co.uk/",
     "kerbalstuff": "https://kerbalstuff.com/mod/367/Universal%20Storage%20%5BIFI%20PACK%5D"
   },
   "ksp_version": "0.25",

--- a/UniversalStorage-SNACKS/UniversalStorage-SNACKS-0.9.0.ckan
+++ b/UniversalStorage-SNACKS/UniversalStorage-SNACKS-0.9.0.ckan
@@ -18,7 +18,7 @@
     }
   ],
   "resources": {
-    "homepage": "ksp.kingtiger.co.uk",
+    "homepage": "http://ksp.kingtiger.co.uk/",
     "kerbalstuff": "https://kerbalstuff.com/mod/368/Universal%20Storage%20%5BSNACKS%20PACK%5D"
   },
   "ksp_version": "0.25",

--- a/UniversalStorage-TAC/UniversalStorage-TAC-0.9.2.ckan
+++ b/UniversalStorage-TAC/UniversalStorage-TAC-0.9.2.ckan
@@ -18,7 +18,7 @@
     }
   ],
   "resources": {
-    "homepage": "ksp.kingtiger.co.uk",
+    "homepage": "http://ksp.kingtiger.co.uk/",
     "kerbalstuff": "https://kerbalstuff.com/mod/364/Universal%20Storage%20%5BTAC%20PACK%5D"
   },
   "ksp_version": "0.25",

--- a/UniversalStorage/UniversalStorage-0.9.4.ckan
+++ b/UniversalStorage/UniversalStorage-0.9.4.ckan
@@ -22,7 +22,7 @@
     }
   ],
   "resources": {
-    "homepage": "ksp.kingtiger.co.uk",
+    "homepage": "http://ksp.kingtiger.co.uk/",
     "kerbalstuff": "https://kerbalstuff.com/mod/250/Universal%20Storage"
   },
   "ksp_version": "0.25",

--- a/UniversalStorage/UniversalStorage-1.0.0.ckan
+++ b/UniversalStorage/UniversalStorage-1.0.0.ckan
@@ -14,7 +14,7 @@
     }
   ],
   "resources": {
-    "homepage": "ksp.kingtiger.co.uk",
+    "homepage": "http://ksp.kingtiger.co.uk/",
     "kerbalstuff": "https://kerbalstuff.com/mod/250/Universal%20Storage"
   },
   "ksp_version": "0.90",

--- a/UniversalStorage/UniversalStorage-1.0.90.0.ckan
+++ b/UniversalStorage/UniversalStorage-1.0.90.0.ckan
@@ -14,7 +14,7 @@
     }
   ],
   "resources": {
-    "homepage": "ksp.kingtiger.co.uk",
+    "homepage": "http://ksp.kingtiger.co.uk/",
     "kerbalstuff": "https://kerbalstuff.com/mod/250/Universal%20Storage"
   },
   "ksp_version": "0.90",


### PR DESCRIPTION
This should hopefully be an easy merge. This stops the potential for us seeing warnings that we're got bad metadata in our repo.