### PR TITLE
PartWizard 1.2.1 Added min-max KSP override for 1.0.4

### DIFF
--- a/PartWizard/PartWizard-1.2.1.ckan
+++ b/PartWizard/PartWizard-1.2.1.ckan
@@ -8,7 +8,8 @@
     "author"         : [ "ozraven" ],
     "version"        : "1.2.1",
     "release_status" : "stable",
-    "ksp_version"    : "1.0.2",
+    "ksp_version_min"    : "1.0.2",
+    "ksp_version_max"    : "1.0.4",
     "recommends" : [
         { "name" : "Toolbar" }
     ],


### PR DESCRIPTION
Changed static ksp_version to ksp_version_min and _max.