### PR TITLE
Update ksp_version information for EPL ModuleManager tweaks

### DIFF
--- a/FLEET/EPL-ISRU-1.0.ckan
+++ b/FLEET/EPL-ISRU-1.0.ckan
@@ -6,7 +6,8 @@
   "abstract": "Replaces the EPL resource chain with one using the stock ISRU parts and resources.",
   "license": "MIT",
   "release_status": "stable",
-  "ksp_version": "1.0.2",
+  "ksp_version_min": "1.0.2",
+  "ksp_version_max": "1.0.4",
   "install": [
     {
       "file": "misc-d88c2d71d60cce9a8d286be12dc5a3b6b6df1cdd/EPL-ISRU.cfg",

--- a/FLEET/EPL-MKS-1.0.ckan
+++ b/FLEET/EPL-MKS-1.0.ckan
@@ -6,7 +6,8 @@
   "abstract": "Hides the EPL resources and parts. For use with MKS when you don't want the MKS parts cluttering the VAB.",
   "license": "MIT",
   "release_status": "stable",
-  "ksp_version": "1.0.2",
+  "ksp_version_min": "1.0.2",
+  "ksp_version_max": "1.0.4",
   "install": [
     {
       "file": "misc-d88c2d71d60cce9a8d286be12dc5a3b6b6df1cdd/EPL-MKS.cfg",

--- a/FLEET/EPL-fastbuild-1.0.ckan
+++ b/FLEET/EPL-fastbuild-1.0.ckan
@@ -6,7 +6,8 @@
   "abstract": "Makes all EPL builds complete instantly.",
   "license": "MIT",
   "release_status": "stable",
-  "ksp_version": "1.0.2",
+  "ksp_version_min": "1.0.2",
+  "ksp_version_max": "1.0.4",
   "install": [
     {
       "file": "misc-d88c2d71d60cce9a8d286be12dc5a3b6b6df1cdd/EPL-fastbuild.cfg",


### PR DESCRIPTION
No changes needed to the actual patches, but the metadata needed to be updated to signify 1.0.4 compatibility.