### PR TITLE
Create .ckan files for ModularFlightIntegrator and SmokeScreen

### DIFF
--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.1.1.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.1.1.ckan
@@ -1,0 +1,19 @@
+{
+    "spec_version": "v1.6",
+    "identifier": "ModularFlightIntegrator",
+    "name": "ModularFlightIntegrator",
+    "abstract": "This is an amazing addon that will Modularly Integrate your Flight Models.",
+    "license": "MIT",
+    "author": "Sarbian",
+    "resources": {
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/",
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/118088",
+        "repository": "https://github.com/sarbian/ModularFlightIntegrator"
+    },
+    "version": "1.1.1",
+    "download": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/9/artifact/ModularFlightIntegrator-1.1.1.0.zip",
+    "x_generated_by": "nyankan",
+    "download_size": 7097,
+    "ksp_version_min": "1.0.4",
+    "ksp_version_max": "1.0.4"
+}

--- a/SmokeScreen/SmokeScreen-2.6.5.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.5.ckan
@@ -1,0 +1,24 @@
+{
+    "spec_version": "v1.6",
+    "identifier": "SmokeScreen",
+    "name": "SmokeScreen - Extended FX Plugin",
+    "abstract": "SmokeScreen is a plugin that build on the engine FX added in .23 and adds new features to them. Most of the features ideas comes from Nothke.",
+    "license": "BSD-2-clause",
+    "author": "Sarbian",
+    "ksp_version": "1.0",
+    "resources": {
+        "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/",
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",
+        "repository": "https://github.com/sarbian/SmokeScreen/"
+    },
+    "install": [
+        {
+            "file": "GameData/SmokeScreen",
+            "install_to": "GameData"
+        }
+    ],
+    "version": "2.6.5",
+    "download": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/43/artifact/SmokeScreen-2.6.5.0.zip",
+    "x_generated_by": "nyankan",
+    "download_size": 26192
+}


### PR DESCRIPTION
Where's the automatic testing gone?
~~One of my test installs is not offering the upgrade to MFI, can someone please test that it does offer the upgrade properly.~~ Should be fine: the test install was still on 1.0.2.
Is
>"ksp_version": "1.0.4"

preferred to
>"ksp_version_min": "1.0.4",
>"ksp_version_max": "1.0.4"

as produced by netkan from the avc file?