### PR TITLE
Update ModularFuelTanks-5.6.0.ckan

### DIFF
--- a/ModularFuelTanks/ModularFuelTanks-5.6.0.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.6.0.ckan
@@ -5,7 +5,7 @@
     "identifier"     : "ModularFuelTanks",
     "download"       : "http://taniwha.org/~bill/ModularFuelTanks_v5.6.0.zip",
     "license"        : "CC-BY-SA",
-    "version"        : "5.5.2",
+    "version"        : "5.6.0",
     "release_status" : "stable",
     "ksp_version"    : "1.0",
     "author"         : ["taniwha", "NathanKell", "Swamp Ig", "ChestBurster", "ialdabaoth"],


### PR DESCRIPTION
Updating the version is important for a new version.