### PR TITLE
RasterPropMonitor-Core promiscuous versions

### DIFF
--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.18.3.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.18.3.ckan
@@ -6,7 +6,7 @@
     "abstract": "A toolkit for creating interactive IVA experiences.",
     "comment": "This package contains the plugin, and the standard parts library.",
     "license": "GPL-3.0",
-    "ksp_version_min": "0.25.0",
+    "ksp_version": "0.25.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/57603",

--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.0.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.0.ckan
@@ -9,7 +9,7 @@
     "abstract": "A toolkit for creating interactive IVA experiences.",
     "comment": "This package contains the plugin, and the standard parts library.",
     "license": "GPL-3.0",
-    "ksp_version_min": "0.25.0",
+    "ksp_version": "1.0.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117471",

--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.1.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.1.ckan
@@ -9,7 +9,7 @@
     "abstract": "A toolkit for creating interactive IVA experiences.",
     "comment": "This package contains the plugin, and the standard parts library.",
     "license": "GPL-3.0",
-    "ksp_version_min": "1.0.0",
+    "ksp_version": "1.0.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117471",

--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.2.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.2.ckan
@@ -9,7 +9,7 @@
     "abstract": "A toolkit for creating interactive IVA experiences.",
     "comment": "This package contains the plugin, and the standard parts library.",
     "license": "GPL-3.0",
-    "ksp_version_min": "1.0.2",
+    "ksp_version": "1.0.2",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/117471",

--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.19.ckan
@@ -6,7 +6,7 @@
   "abstract": "A toolkit for creating interactive IVA experiences.",
   "comment": "This package contains the plugin, and the standard parts library. In Mihara's absence, MOARdv has kindly recompiled fixed versions of the RasterPropMonitor DLL for KSP 0.90.0",
   "license": "GPL-3.0",
-  "ksp_version_min": "0.90",
+  "ksp_version": "0.90",
   "release_status": "development",
   "resources": {
     "homepage": "http://forum.kerbalspaceprogram.com/threads/57603",


### PR DESCRIPTION
In the case of `v0.19.2` I only changed `ksp_version_min` to `ksp_version`, in all other cases I copied the `ksp_version` that was present in the equivalent RPM version.

More details see #623