### PR TITLE
Create KIS-1.2.0.ckan

### DIFF
--- a/KIS/KIS-1.2.0.ckan
+++ b/KIS/KIS-1.2.0.ckan
@@ -7,7 +7,7 @@
       "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
       "repository": "https://github.com/KospY/KIS"
     },
-    "download"       : "http://addons.curse.cursecdn.com/files/2246/556/KIS_v1.2.0.zip""
+    "download"       : "http://addons.curse.cursecdn.com/files/2246/556/KIS_v1.2.0.zip",
     "license"        : "restricted",
     "author"         : [ "KospY", "Winn75" ],
     "version"        : "1.2.0",

--- a/KIS/KIS-1.2.0.ckan
+++ b/KIS/KIS-1.2.0.ckan
@@ -1,16 +1,16 @@
 {
-    "spec_version"   : 1,
-    "name"           : "Kerbal Inventory System",
-    "identifier"     : "KIS",
-    "abstract"       : "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can..."
+    "spec_version"    : 1,
+    "name"            : "Kerbal Inventory System",
+    "identifier"      : "KIS",
+    "abstract"        : "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",
     "resources": {
-      "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-      "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
+        "repository": "https://github.com/KospY/KIS"
     },
-    "download"       : "http://addons.curse.cursecdn.com/files/2246/556/KIS_v1.2.0.zip",
-    "license"        : "restricted",
-    "author"         : [ "KospY", "Winn75" ],
-    "version"        : "1.2.0",
+    "download"        : "http://addons.curse.cursecdn.com/files/2246/556/KIS_v1.2.0.zip",
+    "license"         : "restricted",
+    "author"          : [ "KospY", "Winn75" ],
+    "version"         : "1.2.0",
     "ksp_version_min" : "1.0.3",
     "ksp_version_max" : "1.0.4"
 }

--- a/KIS/KIS-1.2.0.ckan
+++ b/KIS/KIS-1.2.0.ckan
@@ -1,0 +1,16 @@
+{
+    "spec_version"   : 1,
+    "name"           : "Kerbal Inventory System",
+    "identifier"     : "KIS",
+    "abstract"       : "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can..."
+    "resources": {
+      "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
+      "repository": "https://github.com/KospY/KIS"
+    },
+    "download"       : "http://addons.curse.cursecdn.com/files/2246/556/KIS_v1.2.0.zip""
+    "license"        : "restricted",
+    "author"         : [ "KospY", "Winn75" ],
+    "version"        : "1.2.0",
+    "ksp_version_min" : "1.0.3",
+    "ksp_version_max" : "1.0.4"
+}


### PR DESCRIPTION
Version 1.2.0 released 2015-07-11 
Changed version to 1.2.0, changed download link for 1.2.0 on curse, and changed ksp min to 1.0.3, leaving max 1.0.4 in place
Question: Any reason we aren't grabbing this from github (tag release) instead curse?