### PR TITLE
Extant RP-0 releases should be for KSP 0.90 only.

### DIFF
--- a/RP-0/RP-0-v0.02.ckan
+++ b/RP-0/RP-0-v0.02.ckan
@@ -40,5 +40,6 @@
   "version": "v0.02",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.02/RP-0-v0.02.zip",
   "x_generated_by": "netkan",
-  "download_size": 9055
+  "download_size": 9055,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.04.ckan
+++ b/RP-0/RP-0-v0.04.ckan
@@ -40,5 +40,6 @@
   "version": "v0.04",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.04/RP-0-v0.04.zip",
   "x_generated_by": "netkan",
-  "download_size": 13480
+  "download_size": 13480,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.05.ckan
+++ b/RP-0/RP-0-v0.05.ckan
@@ -40,5 +40,6 @@
   "version": "v0.05",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.05/RP-0-v0.05.zip",
   "x_generated_by": "netkan",
-  "download_size": 13514
+  "download_size": 13514,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.06.ckan
+++ b/RP-0/RP-0-v0.06.ckan
@@ -40,5 +40,6 @@
   "version": "v0.06",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.06/RP-0-v0.06.zip",
   "x_generated_by": "netkan",
-  "download_size": 13954
+  "download_size": 13954,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.07.ckan
+++ b/RP-0/RP-0-v0.07.ckan
@@ -40,5 +40,6 @@
   "version": "v0.07",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.07/RP-0-v0.07.zip",
   "x_generated_by": "netkan",
-  "download_size": 18797
+  "download_size": 18797,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.08.ckan
+++ b/RP-0/RP-0-v0.08.ckan
@@ -40,5 +40,6 @@
   "version": "v0.08",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.08/RP-0-v0.08.zip",
   "x_generated_by": "netkan",
-  "download_size": 18925
+  "download_size": 18925,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.09.ckan
+++ b/RP-0/RP-0-v0.09.ckan
@@ -40,5 +40,6 @@
   "version": "v0.09",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.09/RP-0-v0.09.zip",
   "x_generated_by": "netkan",
-  "download_size": 35288
+  "download_size": 35288,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.10.ckan
+++ b/RP-0/RP-0-v0.10.ckan
@@ -40,5 +40,6 @@
   "version": "v0.10",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.10/RP-0-v0.10.zip",
   "x_generated_by": "netkan",
-  "download_size": 35902
+  "download_size": 35902,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.11.ckan
+++ b/RP-0/RP-0-v0.11.ckan
@@ -40,5 +40,6 @@
   "version": "v0.11",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.11/RP-0-v0.11.zip",
   "x_generated_by": "netkan",
-  "download_size": 36402
+  "download_size": 36402,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.12.ckan
+++ b/RP-0/RP-0-v0.12.ckan
@@ -58,5 +58,6 @@
   "version": "v0.12",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.12/RP-0-v0.12.zip",
   "x_generated_by": "netkan",
-  "download_size": 39559
+  "download_size": 39559,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.13.ckan
+++ b/RP-0/RP-0-v0.13.ckan
@@ -58,5 +58,6 @@
   "version": "v0.13",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.13/RP-0-v0.13.zip",
   "x_generated_by": "netkan",
-  "download_size": 40798
+  "download_size": 40798,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.14.ckan
+++ b/RP-0/RP-0-v0.14.ckan
@@ -58,5 +58,6 @@
   "version": "v0.14",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.14/RP-0-v0.14.zip",
   "x_generated_by": "netkan",
-  "download_size": 41407
+  "download_size": 41407,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.15.ckan
+++ b/RP-0/RP-0-v0.15.ckan
@@ -58,5 +58,6 @@
   "version": "v0.15",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.15/RP-0-v0.15.zip",
   "x_generated_by": "netkan",
-  "download_size": 43810
+  "download_size": 43810,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.16.ckan
+++ b/RP-0/RP-0-v0.16.ckan
@@ -58,5 +58,6 @@
   "version": "v0.16",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.16/RP-0-v0.16.zip",
   "x_generated_by": "netkan",
-  "download_size": 44124
+  "download_size": 44124,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.17.ckan
+++ b/RP-0/RP-0-v0.17.ckan
@@ -58,5 +58,6 @@
   "version": "v0.17",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.17/RP-0-v0.17.zip",
   "x_generated_by": "netkan",
-  "download_size": 45430
+  "download_size": 45430,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.18.ckan
+++ b/RP-0/RP-0-v0.18.ckan
@@ -54,5 +54,6 @@
   "version": "v0.18",
   "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.18/RP-0-v0.18.zip",
   "x_generated_by": "netkan",
-  "download_size": 46187
+  "download_size": 46187,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.19.ckan
+++ b/RP-0/RP-0-v0.19.ckan
@@ -54,5 +54,6 @@
     "version": "v0.19",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.19/RP-0-v0.19.zip",
     "x_generated_by": "netkan",
-    "download_size": 48162
+    "download_size": 48162,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.20.ckan
+++ b/RP-0/RP-0-v0.20.ckan
@@ -54,5 +54,6 @@
     "version": "v0.20",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.20/RP-0-v0.20.zip",
     "x_generated_by": "netkan",
-    "download_size": 46528
+    "download_size": 46528,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.21.ckan
+++ b/RP-0/RP-0-v0.21.ckan
@@ -54,5 +54,6 @@
     "version": "v0.21",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.21/RP-0-v0.21.zip",
     "x_generated_by": "netkan",
-    "download_size": 50302
+    "download_size": 50302,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.22.ckan
+++ b/RP-0/RP-0-v0.22.ckan
@@ -54,5 +54,6 @@
     "version": "v0.22",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.22/RP-0-v0.22.zip",
     "x_generated_by": "netkan",
-    "download_size": 51102
+    "download_size": 51102,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.23.ckan
+++ b/RP-0/RP-0-v0.23.ckan
@@ -57,5 +57,6 @@
     "version": "v0.23",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.23/RP-0-v0.23.zip",
     "x_generated_by": "netkan",
-    "download_size": 51255
+    "download_size": 51255,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.24.ckan
+++ b/RP-0/RP-0-v0.24.ckan
@@ -66,5 +66,6 @@
     "version": "v0.24",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.24/RP-0-v0.24.zip",
     "x_generated_by": "netkan",
-    "download_size": 567380
+    "download_size": 567380,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.25.ckan
+++ b/RP-0/RP-0-v0.25.ckan
@@ -66,5 +66,6 @@
     "version": "v0.25",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.25/RP-0-v0.25.zip",
     "x_generated_by": "netkan",
-    "download_size": 569322
+    "download_size": 569322,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.26.ckan
+++ b/RP-0/RP-0-v0.26.ckan
@@ -66,5 +66,6 @@
     "version": "v0.26",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.26/RP-0-v0.26.zip",
     "x_generated_by": "netkan",
-    "download_size": 624882
+    "download_size": 624882,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.27.ckan
+++ b/RP-0/RP-0-v0.27.ckan
@@ -66,5 +66,6 @@
     "version": "v0.27",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.27/RP-0-v0.27.zip",
     "x_generated_by": "netkan",
-    "download_size": 624991
+    "download_size": 624991,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.28.ckan
+++ b/RP-0/RP-0-v0.28.ckan
@@ -66,5 +66,6 @@
     "version": "v0.28",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.28/RP-0-v0.28.zip",
     "x_generated_by": "netkan",
-    "download_size": 55878
+    "download_size": 55878,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.29.ckan
+++ b/RP-0/RP-0-v0.29.ckan
@@ -66,5 +66,6 @@
     "version": "v0.29",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.29/RP-0-v0.29.zip",
     "x_generated_by": "netkan",
-    "download_size": 56395
+    "download_size": 56395,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.30.ckan
+++ b/RP-0/RP-0-v0.30.ckan
@@ -66,5 +66,6 @@
     "version": "v0.30",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.30/RP-0-v0.30.zip",
     "x_generated_by": "netkan",
-    "download_size": 56375
+    "download_size": 56375,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.31.ckan
+++ b/RP-0/RP-0-v0.31.ckan
@@ -66,5 +66,6 @@
     "version": "v0.31",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.31/RP-0-v0.31.zip",
     "x_generated_by": "netkan",
-    "download_size": 56500
+    "download_size": 56500,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.32.ckan
+++ b/RP-0/RP-0-v0.32.ckan
@@ -66,5 +66,6 @@
     "version": "v0.32",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.32/RP-0-v0.32.zip",
     "x_generated_by": "netkan",
-    "download_size": 56825
+    "download_size": 56825,
+    "ksp_version": "0.90"
 }

--- a/RP-0/RP-0-v0.33.ckan
+++ b/RP-0/RP-0-v0.33.ckan
@@ -66,5 +66,6 @@
     "version": "v0.33",
     "download": "https://github.com/KSP-RO/RP-0/releases/download/v0.33/RP-0-v0.33.zip",
     "x_generated_by": "netkan",
-    "download_size": 56904
+    "download_size": 56904,
+    "ksp_version": "0.90"
 }


### PR DESCRIPTION
Attn @NathanKell.

Thanks to @magico13 and @Murdabenne for spotting this.

Thanks to Perl for making this easy:

    perl -i -pe's/("download_size":\s*\d+),?/$1,\n    "ksp_version": "0.90"/' *.ckan