### PR TITLE
Create SmokeScreen-2.6.6.ckan

### DIFF
--- a/SmokeScreen/SmokeScreen-2.6.6.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.6.ckan
@@ -18,7 +18,5 @@
         }
     ],
     "version": "2.6.6",
-    "download": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/44/artifact/SmokeScreen-2.6.6.0.zip",
-    "x_generated_by": "nyankan",
-    "download_size": 26192
+    "download": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/44/artifact/SmokeScreen-2.6.6.0.zip"
 }

--- a/SmokeScreen/SmokeScreen-2.6.6.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.6.ckan
@@ -1,0 +1,24 @@
+{
+    "spec_version": "v1.6",
+    "identifier": "SmokeScreen",
+    "name": "SmokeScreen - Extended FX Plugin",
+    "abstract": "SmokeScreen is a plugin that build on the engine FX added in .23 and adds new features to them. Most of the features ideas comes from Nothke.",
+    "license": "BSD-2-clause",
+    "author": "Sarbian",
+    "ksp_version": "1.0",
+    "resources": {
+        "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/",
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",
+        "repository": "https://github.com/sarbian/SmokeScreen/"
+    },
+    "install": [
+        {
+            "file": "GameData/SmokeScreen",
+            "install_to": "GameData"
+        }
+    ],
+    "version": "2.6.6",
+    "download": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/44/artifact/SmokeScreen-2.6.6.0.zip",
+    "x_generated_by": "nyankan",
+    "download_size": 26192
+}


### PR DESCRIPTION
Buildbot doesn't seem to be passing for 2.6.6, need to get the fix out there.  

Download size is the same, leaving x_generated_by in to match other smokescreens, updated version and download link only.