### PR TITLE
Resolve conflict between OPTSpacePlaneParts and Mk3MiniExpansionPack …

### DIFF
--- a/Mk3MiniExpansionPack/Mk3MiniExpansionPack-V1.1.5.ckan
+++ b/Mk3MiniExpansionPack/Mk3MiniExpansionPack-V1.1.5.ckan
@@ -17,6 +17,9 @@
             "install_to": "Ships"
         }
     ],
+    "conflicts": [
+        { "name": "OPTSpacePlaneParts" }
+    ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/105063-0-90-Mk3-Mini-Expansion-Pack?p=1632752#post1632752",
         "kerbalstuff": "https://kerbalstuff.com/mod/449/Mk3%20Mini%20Expansion%20Pack"

--- a/OPTSpacePlaneParts/OPTSpacePlaneParts-V1.6.9.1.ckan
+++ b/OPTSpacePlaneParts/OPTSpacePlaneParts-V1.6.9.1.ckan
@@ -16,6 +16,9 @@
             "name": "ModuleManager"
         }
     ],
+    "conflicts": [
+        { "name": "Mk3MiniExpansionPack" }
+    ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/97525-0-90-WIP-DEV-OPT-V1-5-Mk3-Space-Shuttle-Expansions?p=1490754#post1490754",
         "kerbalstuff": "https://kerbalstuff.com/mod/340/OPT%20Space%20Plane%20Parts"


### PR DESCRIPTION
…(both versions locked to KSP 1.0.2)

Every file in Mk3MiniExpansionPack-V1.1.5.ckan is included in OPTSpacePlaneParts-V1.6.9.1.ckan

MiniExpansion is a subset of SpacePlanes. Added conflict relationship, closes  #592
