### PR TITLE
Add ALCOR

### DIFF
--- a/ALCOR-capsule-IVA/ALCOR-capsule-IVA-0.9.2.3.ckan
+++ b/ALCOR-capsule-IVA/ALCOR-capsule-IVA-0.9.2.3.ckan
@@ -1,0 +1,31 @@
+{
+    "spec_version": "v1.4",
+    "identifier"  : "ALCOR-capsule-IVA",
+    "name"        : "ALCOR Capsule IVA",
+    "abstract"    : "Advanced Landing Capsule for Orbital Rendezvous - This module contains the IVA for the capsule. For full functionality all recommended mods should be installed.",
+    "author"      : "Alexustas",
+    "version"     : "0.9.2.3",
+    "ksp_version" : "1.0.2",
+    "license"     : "CC-BY-NC-SA-3.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/54925"
+    },
+    "depends": [
+        { "name": "ALCOR-capsule" },
+        { "name": "ALCOR-capsule-props" },
+        { "name": "RasterPropMonitor-Core", "max_version" : "0.20.0" }
+    ],
+    "recommends": [
+        { "name": "SCANsat" },
+        { "name": "MechJeb2" },
+        { "name": "VesselView" },
+        { "name": "DockingPortAlignmentIndicator"}
+    ],
+    "install": [
+        {
+            "find"       : "ASET",
+            "install_to" : "GameData"
+        }
+    ],
+    "download": "https://dl.dropboxusercontent.com/s/9hd1fk8kwzxadz8/ALCOR_IVA_Patch_0.9.2.3.zip"
+}

--- a/ALCOR-capsule-props/ALCOR-capsule-props-1.1.0.ckan
+++ b/ALCOR-capsule-props/ALCOR-capsule-props-1.1.0.ckan
@@ -1,0 +1,23 @@
+{
+    "spec_version": "v1.4",
+    "identifier"  : "ALCOR-capsule-props",
+    "name"        : "ALCOR Capsule IVA Props",
+    "abstract"    : "Advanced Landing Capsule for Orbital Rendezvous - This module contains props for the IVA. For full functionality all recommended mods should be installed.",
+    "author"      : "Alexustas",
+    "version"     : "1.1.0",
+    "ksp_version" : "1.0.2",
+    "license"     : "CC-BY-NC-SA-3.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/54925"
+    },
+    "depends": [
+        { "name": "ALCOR-capsule-IVA" }
+    ],
+    "install": [
+        {
+            "find"       : "ASET",
+            "install_to" : "GameData"
+        }
+    ],
+    "download": "https://dl.dropboxusercontent.com/s/9zjobe3jl3ampuk/ASET_Props_1.1.zip"
+}

--- a/ALCOR-capsule/ALCOR-capsule-0.9.2.3.ckan
+++ b/ALCOR-capsule/ALCOR-capsule-0.9.2.3.ckan
@@ -1,0 +1,23 @@
+{
+    "spec_version": "v1.4",
+    "identifier"  : "ALCOR-capsule",
+    "name"        : "ALCOR Capsule",
+    "abstract"    : "Advanced Landing Capsule for Orbital Rendezvous - This module contains the capsule. For full functionality all recommended mods should be installed.",
+    "author"      : "Alexustas",
+    "version"     : "0.9.2.3",
+    "ksp_version" : "1.0.2",
+    "license"     : "CC-BY-NC-SA-3.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/54925"
+    },
+    "depends": [
+        { "name": "ALCOR-capsule-IVA" }
+    ],
+    "install": [
+        {
+            "find"       : "ASET",
+            "install_to" : "GameData"
+        }
+    ],
+    "download": "https://dl.dropboxusercontent.com/s/1qqoq2s8lt9e0rp/ALCOR_Capsule_0.9.2.3.zip"
+}

--- a/RFStockalike/RFStockalike-v2.1.7.ckan
+++ b/RFStockalike/RFStockalike-v2.1.7.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "RFStockalike",
-    "name": "RealFuels: Stockalike RF Configs",
+    "name": "Real Fuels: Stockalike RF Configs",
     "abstract": "Adds RealFuels configs to stock and many mods' engines, keeping engine role as designed to fit with stock and stock-aligned mods.",
     "license": "CC-BY-SA",
     "install": [

--- a/RealFuels/RealFuels-rf-v10.4.8.ckan
+++ b/RealFuels/RealFuels-rf-v10.4.8.ckan
@@ -1,0 +1,68 @@
+{
+    "spec_version": 1,
+    "name": "Real Fuels",
+    "abstract": "Real fuels and tanks for KSP",
+    "identifier": "RealFuels",
+    "license": "CC-BY-SA",
+    "author": [
+        "ialdabaoth",
+        "NathanKell",
+        "taniwha"
+    ],
+    "release_status": "stable",
+    "ksp_version": "1.0.4",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/64118",
+        "repository": "https://github.com/NathanKell/ModularFuelSystem"
+    },
+    "install": [
+        {
+            "file": "RealFuels",
+            "install_to": "GameData",
+            "filter": ".DS_Store"
+        }
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "RealFuels-Engine-Configs"
+        },
+        {
+            "name": "CommunityResourcePack"
+        },
+        {
+            "name": "SolverEngines"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "ModularFuelSystem"
+        },
+        {
+            "name": "ModularFuelTanks"
+        },
+        {
+            "name": "InterstellarFuelSwitch"
+        },
+        {
+            "name": "Fuelswitchtoeverytank"
+        },
+        {
+            "name": "StockFuelSwitch"
+        },
+        {
+            "name": "EngineIgnitor"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "CrossFeedEnabler"
+        }
+    ],
+    "version": "rf-v10.4.8",
+    "download": "https://github.com/NathanKell/ModularFuelSystem/releases/download/rf-v10.4.8/RealFuels_v10.4.8.zip",
+    "download_size": 283265,
+    "x_generated_by": "netkan"
+}

--- a/RealPlume/RealPlume-1-v0.4.1.ckan
+++ b/RealPlume/RealPlume-1-v0.4.1.ckan
@@ -1,0 +1,45 @@
+{
+    "spec_version": "v1.4",
+    "ksp_version": "1.0",
+    "name": "Real Plume",
+    "identifier": "RealPlume",
+    "abstract": "A set of effects and basic configs that can be attached to any engine as appropriate.  Requires secondary configs to function correctly.",
+    "license": "CC-BY-NC-SA",
+    "release_status": "stable",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "SmokeScreen"
+        },
+        {
+            "name": "RealPlumeConfigs"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "EngineLighting"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "HotRockets"
+        }
+    ],
+    "resources": {
+        "homepage": "https://github.com/KSP-RO/RealPlume/wiki",
+        "repository": "https://github.com/KSP-RO/RealPlume"
+    },
+    "install": [
+        {
+            "find": "RealPlume",
+            "install_to": "GameData"
+        }
+    ],
+    "version": "1:v0.4.1",
+    "author": "Felger",
+    "download": "https://github.com/KSP-RO/RealPlume/releases/download/v0.4.1/RealPlume_v0.4.1.zip",
+    "download_size": 25145593,
+    "x_generated_by": "netkan"
+}

--- a/WaypointManager/WaypointManager-2.4.1.ckan
+++ b/WaypointManager/WaypointManager-2.4.1.ckan
@@ -1,0 +1,28 @@
+{
+    "spec_version": 1,
+    "identifier": "WaypointManager",
+    "name": "Waypoint Manager",
+    "abstract": "Display waypoints while in flight, create custom waypoints.",
+    "license": "MIT",
+    "release_status": "stable",
+    "author": "nightingale",
+    "description": "Display waypoints while in flight, create custom waypoints.",
+    "install": [
+        {
+            "file": "GameData/WaypointManager",
+            "install_to": "GameData"
+        }
+    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/104758",
+        "bugtracker": "https://github.com/jrossignol/WaypointManager/issues",
+        "license": "https://raw.githubusercontent.com/jrossignol/WaypointManager/master/LICENSE.txt",
+        "repository": "https://github.com/jrossignol/WaypointManager"
+    },
+    "version": "2.4.1",
+    "download": "https://github.com/jrossignol/WaypointManager/releases/download/2.4.1/WaypointManager_2.4.1.zip",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
+    "download_size": 77463,
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
The capsule doesn't technically `depends` the IVA, but if not using the IVA the built-in Navigation, Dock port and Airlock lights won't work without an alternate mod library that we don't index (VNG Plugin). If someone wants to take up the mantle and include VNG Plugin then have VNG plugin and the IVA provide a virtual package and depend on that instead: by all means.