### PR TITLE
SETI-CommunityTechTree version fix.

### DIFF
--- a/SETI-CommunityTechTree/SETI-CommunityTechTree-0.9.1.4.ckan
+++ b/SETI-CommunityTechTree/SETI-CommunityTechTree-0.9.1.4.ckan
@@ -17,7 +17,7 @@
     ],
     "name": "SETI-CommunityTechTree",
     "abstract": "Start with probes and planes! Using the CommunityTechTree, this mod shifts parts around to provide a much better progression.",
-    "version": "0.9.1",
+    "version": "0.9.1.4",
     "author": "Yemo",
     "download": "https://kerbalstuff.com/mod/748/SETI-CommunityTechTree/download/0.9.1.4",
     "license": "restricted",

--- a/SETI-CommunityTechTree/SETI-CommunityTechTree-0.9.1.ckan
+++ b/SETI-CommunityTechTree/SETI-CommunityTechTree-0.9.1.ckan
@@ -1,0 +1,33 @@
+{
+    "spec_version": 1,
+    "identifier": "SETI-CommunityTechTree",
+    "depends": [
+        {
+            "name": "CommunityTechTree"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "install": [
+        {
+            "file": "SETIctt",
+            "install_to": "GameData"
+        }
+    ],
+    "name": "SETI-CommunityTechTree",
+    "abstract": "Start with probes and planes! Using the CommunityTechTree, this mod shifts parts around to provide a much better progression.",
+    "version": "0.9.1",
+    "author": "Yemo",
+    "download": "https://kerbalstuff.com/mod/748/SETI-CommunityTechTree/download/0.9.1.3",
+    "license": "restricted",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "kerbalstuff": "https://kerbalstuff.com/mod/748/SETI-CommunityTechTree",
+        "x_screenshot": "https://kerbalstuff.com/content/Yemo_5989/SETI-CommunityTechTree/SETI-CommunityTechTree-1435942242.7893255.png"
+    },
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
+    "download_size": 1069170,
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
The latest available version of SETI-CTT is 0.9.1.4 but it gets indexed as (And have overwritten) 0.9.1.

This moves the edited file to 0.9.1.4 so the upgrade path should work, and restores the 0.9.1 file.