### PR TITLE
Added KW Community fixes

### DIFF
--- a/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.1.0.ckan
+++ b/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.1.0.ckan
@@ -15,7 +15,7 @@
         }
     ],
     "ksp_version": "1.0.4",
-    "name": "KW Rocketry - Community Fixes",
+    "name": "KW Rocketry - Community Fixes - Interstage config",
     "abstract": "Optional config for KW Community Fixes. THIS IS CONVCEIVABLY CRAFT BREAKING! This file switches the interstage fairings over to omni decouplers and removes the finicky extra node on engines/shrouds.",
     "version": "0.1.0",
     "author": "linuxgurugamer",

--- a/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.1.0.ckan
+++ b/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.1.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.2",
     "identifier": "KWRocketry-CommunityFixes-interstage",
-    "license": "MIT",
+    "license": "GPL-3.0",
     "depends": [
         {
             "name": "KWRocketry-CommunityFixes",

--- a/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.1.0.ckan
+++ b/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.1.0.ckan
@@ -1,0 +1,29 @@
+{
+    "spec_version": "v1.2",
+    "identifier": "KWRocketry-CommunityFixes-interstage",
+    "license": "MIT",
+    "depends": [
+        {
+            "name": "KWRocketry-CommunityFixes",
+            "version": "0.1.0"
+        }
+    ],
+    "install": [
+        {
+            "file": "Gamedata/KWCommunityFixes/KWPatch-interstage.cfg",
+            "install_to": "GameData/KWCommunityFixes"
+        }
+    ],
+    "ksp_version": "1.0.4",
+    "name": "KW Rocketry - Community Fixes",
+    "abstract": "Optional config for KW Community Fixes. THIS IS CONVCEIVABLY CRAFT BREAKING! This file switches the interstage fairings over to omni decouplers and removes the finicky extra node on engines/shrouds.",
+    "version": "0.1.0",
+    "author": "linuxgurugamer",
+    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.1.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/129918-KW-Rocketry-Community-Fixes",
+        "kerbalstuff": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes",
+        "repository":"https://github.com/linuxgurugamer/KW-Rocketry-Community-Fixes",
+        "x_screenshot": "https://kerbalstuff.com/content/Winston_229/KW_Rocketry/KW_Rocketry-1431743324.7172647.jpg"
+    }
+}

--- a/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.1.0.ckan
+++ b/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.1.0.ckan
@@ -1,0 +1,38 @@
+{
+    "spec_version": 1,
+    "identifier": "KWRocketry-CommunityFixes",
+    "license": "MIT",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "KWRocketry",
+            "version": "2.7.1-community"
+        }
+    ],
+    "suggests": [
+        {
+          "name": "KWRocketry-CommunityFixes-interstage"
+        }
+    ],
+    "install": [
+        {
+            "file": "Gamedata/KWCommunityFixes",
+            "install_to": "GameData",
+            "filter": "KWPatch-interstage.cfg"
+        }
+    ],
+    "ksp_version": "1.0.4",
+    "name": "KW Rocketry - Community Fixes",
+    "abstract": "This is a set of patches created by the community to bring KW up to 1.0.4 compatibility.",
+    "version": "0.1.0",
+    "author": "linuxgurugamer",
+    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.1.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/129918-KW-Rocketry-Community-Fixes",
+        "kerbalstuff": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes",
+        "repository":"https://github.com/linuxgurugamer/KW-Rocketry-Community-Fixes",
+        "x_screenshot": "https://kerbalstuff.com/content/Winston_229/KW_Rocketry/KW_Rocketry-1431743324.7172647.jpg"
+    }
+}

--- a/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.1.0.ckan
+++ b/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.1.0.ckan
@@ -8,7 +8,7 @@
         },
         {
             "name": "KWRocketry",
-            "version": "2.7.1-community"
+            "version": "2.7.0-community"
         }
     ],
     "suggests": [

--- a/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.1.0.ckan
+++ b/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.1.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "KWRocketry-CommunityFixes",
-    "license": "MIT",
+    "license": "GPL-3.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/KWRocketry/KWRocketry-2.7.0-community.ckan
+++ b/KWRocketry/KWRocketry-2.7.0-community.ckan
@@ -20,7 +20,7 @@
     "ksp_version": "1.0.4",
     "name": "KW Rocketry",
     "abstract": "The comprehensive launch vehicle construction pack by Winston and Kickasskyle",
-    "version": "2.7.1-community",
+    "version": "2.7.0-community",
     "author": "Winston",
     "download": "https://kerbalstuff.com/mod/67/KW%20Rocketry/download/2.7",
     "resources": {

--- a/KWRocketry/KWRocketry-2.7.1-community.ckan
+++ b/KWRocketry/KWRocketry-2.7.1-community.ckan
@@ -1,0 +1,32 @@
+{
+    "spec_version": 1,
+    "identifier": "KWRocketry",
+    "license": "CC-BY-SA-3.0",
+    "depends": [
+        {
+            "name": "ModuleAnimateEmissive"
+        },
+        {
+            "name": "KWRocketry-CommunityFixes",
+            "version": "0.1.0"
+        }
+    ],
+    "install": [
+        {
+            "file": "KW Release Package v2.7 (Open this, don't extract it)/GameData/KWRocketry",
+            "install_to": "GameData"
+        }
+    ],
+    "ksp_version": "1.0.4",
+    "name": "KW Rocketry",
+    "abstract": "The comprehensive launch vehicle construction pack by Winston and Kickasskyle",
+    "version": "2.7.1-community",
+    "author": "Winston",
+    "download": "https://kerbalstuff.com/mod/67/KW%20Rocketry/download/2.7",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/51037-0-22-KW-Rocketry-v2-5-5-Avaliable-New-Sounds-New-Parts-11-11-2013",
+        "kerbalstuff": "https://kerbalstuff.com/mod/67/KW%20Rocketry",
+        "x_screenshot": "https://kerbalstuff.com/content/Winston_229/KW_Rocketry/KW_Rocketry-1431743324.7172647.jpg"
+    },
+    "download_size": 51656696
+}


### PR DESCRIPTION
by @linuxgurugamer
[Forum thread](http://forum.kerbalspaceprogram.com/threads/129918-KW-Rocketry-Community-Fixes)
I'm not sure what licence is this. At forum
>License is GPL  

however KS says MIT

This PR contains 3 packages
KWRocketry-2.7.1 - this is 2.7 but set to works on KSP 1.0.4 and depends on Community-Fixes
KWRocketry-CommunityFixes -  Community-Fixes :+1: 
KWRocketry-CommunityFixes-interstage - optional config. May break your crafts. 

Would be great if someone test it. Works for me.