### PR TITLE
KAS-0.5.4 New Release - no dep on KIS anymore

### DIFF
--- a/KAS/KAS-0.5.4.ckan
+++ b/KAS/KAS-0.5.4.ckan
@@ -6,7 +6,7 @@
     "resources"      : {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92514"
     },
-    "download"       : "http://addons.curse.cursecdn.com/files/2249/712/KAS-v0.5.4.zip",
+    "download"       : "http://addons.curse.cursecdn.com/files/2249/712/KAS_v0.5.4.zip",
     "license"        : "restricted",
     "author"         : [ "KospY", "Winn75", "zzz", "Majiir", "a.g." ],
     "version"        : "0.5.4",

--- a/KAS/KAS-0.5.4.ckan
+++ b/KAS/KAS-0.5.4.ckan
@@ -1,0 +1,21 @@
+{
+    "spec_version"   : 1,
+    "name"           : "Kerbal Attachment System",
+    "identifier"     : "KAS",
+    "abstract"       : "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "resources"      : {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514"
+    },
+    "download"       : "http://addons.curse.cursecdn.com/files/2249/712/KAS-v0.5.4.zip",
+    "license"        : "restricted",
+    "author"         : [ "KospY", "Winn75", "zzz", "Majiir", "a.g." ],
+    "version"        : "0.5.4",
+    "ksp_version_min" : "1.0.3",
+    "ksp_version_max" : "1.0.4",
+    "depends" : [
+        { "name": "ModuleManager" },
+    ]
+    "recommends" : {
+      { "name": "KIS", "min_version": "1.3.0" }
+    }
+}

--- a/KAS/KAS-0.5.4.ckan
+++ b/KAS/KAS-0.5.4.ckan
@@ -13,9 +13,13 @@
     "ksp_version_min" : "1.0.3",
     "ksp_version_max" : "1.0.4",
     "depends" : [
-        { "name": "ModuleManager" }
+        {
+            "name": "ModuleManager"
+        }
     ],
-    "recommends" : {
-      { "name": "KIS" }
-    }
+    "recommends" : [
+        {
+            "name": "KIS"
+        }
+    ]
 }

--- a/KAS/KAS-0.5.4.ckan
+++ b/KAS/KAS-0.5.4.ckan
@@ -13,9 +13,9 @@
     "ksp_version_min" : "1.0.3",
     "ksp_version_max" : "1.0.4",
     "depends" : [
-        { "name": "ModuleManager" },
-    ]
+        { "name": "ModuleManager" }
+    ],
     "recommends" : {
-      { "name": "KIS", "min_version": "1.3.0" }
+      { "name": "KIS" }
     }
 }


### PR DESCRIPTION
New release. Remove dependency on KIS. Changed to recommends and new KIS versions