### PR TITLE
Fix Contract Configurator version 1.6.1 and 1.6.2

### DIFF
--- a/ContractConfigurator/ContractConfigurator-1.6.1.ckan
+++ b/ContractConfigurator/ContractConfigurator-1.6.1.ckan
@@ -29,9 +29,9 @@
         "repository": "https://github.com/jrossignol/ContractConfigurator"
     },
     "version": "1.6.1",
-    "download": "https://github.com/jrossignol/ContractConfigurator/releases/download/1.6.2/ContractConfigurator_1.6.2.zip",
+    "download": "https://github.com/jrossignol/ContractConfigurator/releases/download/1.6.1/ContractConfigurator_1.6.1.zip",
     "ksp_version_min": "1.0.2",
     "ksp_version_max": "1.0.4",
-    "download_size": 274210,
+    "download_size": 273761,
     "x_generated_by": "netkan"
 }

--- a/ContractConfigurator/ContractConfigurator-1.6.2.ckan
+++ b/ContractConfigurator/ContractConfigurator-1.6.2.ckan
@@ -1,0 +1,37 @@
+{
+    "spec_version": 1,
+    "identifier": "ContractConfigurator",
+    "name": "Contract Configurator",
+    "abstract": "A config-file based solution for creating new contracts!",
+    "license": "MIT",
+    "release_status": "stable",
+    "author": "nightingale",
+    "description": "A config-file based solution for creating new contracts!",
+    "suggests": [
+        {
+            "name": "CoherentContracts"
+        },
+        {
+            "name": "ContractsWindowPlus"
+        },
+        {
+            "name": "WaypointManager"
+        },
+        {
+            "name": "WiderContractsApp"
+        }
+    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/101604",
+        "bugtracker": "https://github.com/jrossignol/ContractConfigurator/issues",
+        "license": "https://raw.githubusercontent.com/jrossignol/ContractConfigurator/master/LICENSE.txt",
+        "manual": "https://github.com/jrossignol/ContractConfigurator/wiki",
+        "repository": "https://github.com/jrossignol/ContractConfigurator"
+    },
+    "version": "1.6.1",
+    "download": "https://github.com/jrossignol/ContractConfigurator/releases/download/1.6.2/ContractConfigurator_1.6.2.zip",
+    "ksp_version_min": "1.0.2",
+    "ksp_version_max": "1.0.4",
+    "download_size": 274210,
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
The CKAN bot made a mess of things by using 1.6.2 and checking it in over 1.6.1.  Now there are some users who are on CKAN version "1.6.1" that actually have the latest, but others who are on the real 1.6.1 release.