### PR TITLE
Update and rename ModuleFixer.ckan to ModuleFixer-3.ckan

### DIFF
--- a/ModuleFixer/ModuleFixer-3.ckan
+++ b/ModuleFixer/ModuleFixer-3.ckan
@@ -23,7 +23,6 @@
 	"author": "arsenic87",
 	"version": "3",
 	"download": "https://www.dropbox.com/s/ykqj3g0ilprg6b1/ModuleFixer.zip?dl=1",
-	"comment" : "Hand packaged by Felger, if anything's wrong, it's my fault.",
 	"install": [
         {
             "file"       : "ModuleFixer",

--- a/ModuleFixer/ModuleFixer-3.ckan
+++ b/ModuleFixer/ModuleFixer-3.ckan
@@ -22,7 +22,7 @@
 	"abstract": "This fixes the problems of exploding/expanding parts in the VAB while hovering over some parts in some mods.",
 	"author": "arsenic87",
 	"version": "3",
-	"download": "https://www.dropbox.com/s/ykqj3g0ilprg6b1/ModuleFixer.zip?dl=1",
+	"download": "https://www.dropbox.com/s/pllcpggs805zwmt/uploads_2013_12_Modulefixer3.zip",
 	"install": [
         {
             "file"       : "ModuleFixer",

--- a/ModuleFixer/ModuleFixer-3.ckan
+++ b/ModuleFixer/ModuleFixer-3.ckan
@@ -25,7 +25,7 @@
 	"download": "https://www.dropbox.com/s/pllcpggs805zwmt/uploads_2013_12_Modulefixer3.zip",
 	"install": [
         {
-            "file"       : "ModuleFixer",
+            "file"       : "Modulefixer.dll",
             "install_to" : "GameData"
         }
     ]

--- a/ModuleFixer/ModuleFixer-3.ckan
+++ b/ModuleFixer/ModuleFixer-3.ckan
@@ -22,7 +22,7 @@
 	"abstract": "This fixes the problems of exploding/expanding parts in the VAB while hovering over some parts in some mods.",
 	"author": "arsenic87",
 	"version": "3",
-	"download": "https://www.dropbox.com/s/pllcpggs805zwmt/uploads_2013_12_Modulefixer3.zip",
+	"download": "https://www.dropbox.com/s/pllcpggs805zwmt/uploads_2013_12_Modulefixer3.zip?dl=1",
 	"install": [
         {
             "file"       : "Modulefixer.dll",


### PR DESCRIPTION
Apart from making the filename match our given convention this also prepares this file for https://github.com/KSP-CKAN/CKAN/pull/1304 which has a dislike for multiple non-nested comments.