### PR TITLE
Common metadata repos can now download in .tar.gz format

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -2,42 +2,42 @@
     "repositories": [
         {
             "name":      "default",
-            "uri":       "https://github.com/KSP-CKAN/CKAN-meta/archive/master.zip",
+            "uri":       "https://github.com/KSP-CKAN/CKAN-meta/archive/master.tar.gz",
             "x_mirror":  true,
             "x_comment": "The well-known default CKAN metadata repository"
         },
 
         {
             "name":      "dev",
-            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/master.zip",
+            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/master.tar.gz",
             "x_mirror":  false,
             "x_comment": "Development ckans"
         },
 
         {
             "name":      "MechJeb2-dev",
-            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/MechJeb2-ci.zip",
+            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/MechJeb2-ci.tar.gz",
             "x_mirror":  false,
             "x_comment": "MechJeb2 Development (prerelease and Jenkins) ckans"
         },
 
         {
             "name":      "RemoteTech-pre",
-            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/RemoteTech-pre.zip",
+            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/RemoteTech-pre.tar.gz",
             "x_mirror":  false,
             "x_comment": "RemoteTech Development (prerelease and Jenkins) ckans"
         },
 
         {
             "name":      "SCANsat-pre",
-            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/SCANsat-pre.zip",
+            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/SCANsat-pre.tar.gz",
             "x_mirror":  false,
             "x_comment": "SCANsat Development (prerelease and Jenkins) ckans"
         },
 
         {
             "name":      "Trajectories-pre",
-            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/SCANsat-pre.zip",
+            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/SCANsat-pre.tar.gz",
             "x_mirror":  false,
             "x_comment": "Trajectories Development (prerelease and Jenkins) ckans"
         }


### PR DESCRIPTION
The client has been able to handle .tar.gz for a while. Recent releases (at least since v1.12) use it by default. This updates our list of repos to use the .tar.gz versions which require less bandwidth than their zippy counterparts.

(This is the file that users see when they go to the CKAN settings in the GUI, and check out available repos)