### PR TITLE
Correct abstract and change license for Airlock

### DIFF
--- a/Airlock/Airlock-1.0.ckan
+++ b/Airlock/Airlock-1.0.ckan
@@ -1,6 +1,6 @@
 {
     "spec_version": 1,
-    "license": "MIT",
+    "license": "CC-BY-NC-ND-1.0",
     "identifier": "Airlock",
     "suggests": [
         {
@@ -16,7 +16,7 @@
     ],
     "ksp_version": "1.0.4",
     "name": "Airlock",
-    "abstract": "CC-NC-ND",
+    "abstract": "Require a small resource usage when leaving vessel on eva",
     "version": "1.0",
     "author": "anxcon",
     "download": "https://kerbalstuff.com/mod/1011/Airlock/download/1.0",


### PR DESCRIPTION
The mod's author listed the mod under MIT originally ([KerbalStuffBot's PR](https://github.com/KSP-CKAN/NetKAN/pull/1950/files)), but the abstract reflected the license he wanted (my error for not catching the abstract). I'm willing to give the author the benefit of the doubt that they simply chose the license incorrectly. This is why it's nice when mods have KSP forum threads and/or include the license in their package.

Closes  #762