### PR TITLE
Restrict HotRocketsEmissivePatch to 0.90

### DIFF
--- a/HotRocketsEmissivePatch/HotRocketsEmissivePatch-7.9.ckan
+++ b/HotRocketsEmissivePatch/HotRocketsEmissivePatch-7.9.ckan
@@ -8,7 +8,7 @@
     "author"       : [ "Nazari1382" ],
     "version"      : "7.9",
     "release_status" : "stable",
-    "ksp_version_min"  : "0.90",
+    "ksp_version"  : "0.90",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/65754"
     },


### PR DESCRIPTION
This mod is actually hard to find info about, but the curseforge info on it says it's for 0.90, and since there's no mention of it anywhere else I'm confident saying we can lock it to that version.

Closes #761 