### PR TITLE
Add Ground Proximity Warning System v0.3.beta-2 mod

### DIFF
--- a/GPWS/GPWS-0.3.2.0.ckan
+++ b/GPWS/GPWS-0.3.2.0.ckan
@@ -1,0 +1,34 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "GPWS",
+    "name": "Ground Proximity Warning System (GPWS)",
+    "abstract": "Warning System for Kerbal Space Program",
+    "author": "bssthu",
+    "license": "CC-BY-NC-SA-4.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/112420",
+        "repository": "https://github.com/bssthu/KSP_GPWS"
+    },
+    "version": "0.3.2.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "Toolbar"
+        }
+    ],
+    "install": [
+        {
+            "find": "GPWS",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/bssthu/KSP_GPWS/releases/download/v0.3-beta.2/GPWSv0.3-beta.2.zip",
+    "download_size": 291411
+}


### PR DESCRIPTION
Previous discussion: https://github.com/KSP-CKAN/NetKAN/pull/2412

This is a stop-gap solution to index GPWS since netKAN is not able to index mods on github that are released with the pre-release tag.

This closes KSP-CKAN/netKAN#2406.