### PR TITLE
Update KerbalPlanetaryBaseSystems-v0.2.7b.ckan

### DIFF
--- a/KerbalPlanetaryBaseSystems/KerbalPlanetaryBaseSystems-v0.2.7b.ckan
+++ b/KerbalPlanetaryBaseSystems/KerbalPlanetaryBaseSystems-v0.2.7b.ckan
@@ -10,7 +10,7 @@
         "kerbalstuff": "https://kerbalstuff.com/mod/991/Kerbal%20Planetary%20Base%20Systems",
         "x_screenshot": "https://kerbalstuff.com/content/Nils277_12637/Kerbal_Planetary_Base_Systems/Kerbal_Planetary_Base_Systems-1444728648.4033144.png"
     },
-    "version": "v0.2.7b",
+    "version": "0.2.7b",
     "ksp_version": "1.0.4",
     "install": [
         {


### PR DESCRIPTION
Inconsistent version number is preventing newer versions from loading. I hope Netkan won't overwrite this old ckan file?