### PR TITLE
Add missing ModuleManager's

### DIFF
--- a/ModuleManager/ModuleManager-2.6.10.ckan
+++ b/ModuleManager/ModuleManager-2.6.10.ckan
@@ -1,0 +1,27 @@
+{
+    "spec_version": "v1.6",
+    "identifier": "ModuleManager",
+    "name": "Module Manager",
+    "abstract": "Modify KSP configs without conflict",
+    "author": [
+        "ialdabaoth",
+        "Sarbian"
+    ],
+    "license": "CC-BY-SA",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
+        "repository": "https://github.com/sarbian/ModuleManager",
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+    },
+    "version": "2.6.10",
+    "ksp_version": "1.0",
+    "install": [
+        {
+            "file": "ModuleManager.2.6.10.dll",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/97/artifact/ModuleManager-2.6.10.zip",
+    "download_size": 28000,
+    "x_generated_by": "netkan"
+}

--- a/ModuleManager/ModuleManager-2.6.11.ckan
+++ b/ModuleManager/ModuleManager-2.6.11.ckan
@@ -1,0 +1,27 @@
+{
+    "spec_version": "v1.6",
+    "identifier": "ModuleManager",
+    "name": "Module Manager",
+    "abstract": "Modify KSP configs without conflict",
+    "author": [
+        "ialdabaoth",
+        "Sarbian"
+    ],
+    "license": "CC-BY-SA",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
+        "repository": "https://github.com/sarbian/ModuleManager",
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+    },
+    "version": "2.6.11",
+    "ksp_version": "1.0",
+    "install": [
+        {
+            "file": "ModuleManager.2.6.11.dll",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/98/artifact/ModuleManager-2.6.11.zip",
+    "download_size": 28041,
+    "x_generated_by": "netkan"
+}

--- a/ModuleManager/ModuleManager-2.6.12.ckan
+++ b/ModuleManager/ModuleManager-2.6.12.ckan
@@ -1,0 +1,27 @@
+{
+    "spec_version": "v1.6",
+    "identifier": "ModuleManager",
+    "name": "Module Manager",
+    "abstract": "Modify KSP configs without conflict",
+    "author": [
+        "ialdabaoth",
+        "Sarbian"
+    ],
+    "license": "CC-BY-SA",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
+        "repository": "https://github.com/sarbian/ModuleManager",
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+    },
+    "version": "2.6.12",
+    "ksp_version": "1.0",
+    "install": [
+        {
+            "file": "ModuleManager.2.6.12.dll",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/99/artifact/ModuleManager-2.6.12.zip",
+    "download_size": 28052,
+    "x_generated_by": "netkan"
+}

--- a/ModuleManager/ModuleManager-2.6.4.ckan
+++ b/ModuleManager/ModuleManager-2.6.4.ckan
@@ -1,0 +1,27 @@
+{
+    "spec_version": "v1.6",
+    "identifier": "ModuleManager",
+    "name": "Module Manager",
+    "abstract": "Modify KSP configs without conflict",
+    "author": [
+        "ialdabaoth",
+        "Sarbian"
+    ],
+    "license": "CC-BY-SA",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
+        "repository": "https://github.com/sarbian/ModuleManager",
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+    },
+    "version": "2.6.4",
+    "ksp_version": "1.0",
+    "install": [
+        {
+            "file": "ModuleManager.2.6.4.dll",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/90/artifact/ModuleManager-2.6.4.zip",
+    "download_size": 26907,
+    "x_generated_by": "netkan"
+}

--- a/ModuleManager/ModuleManager-2.6.9.ckan
+++ b/ModuleManager/ModuleManager-2.6.9.ckan
@@ -1,0 +1,27 @@
+{
+    "spec_version": "v1.6",
+    "identifier": "ModuleManager",
+    "name": "Module Manager",
+    "abstract": "Modify KSP configs without conflict",
+    "author": [
+        "ialdabaoth",
+        "Sarbian"
+    ],
+    "license": "CC-BY-SA",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
+        "repository": "https://github.com/sarbian/ModuleManager",
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+    },
+    "version": "2.6.9",
+    "ksp_version": "1.0",
+    "install": [
+        {
+            "file": "ModuleManager.2.6.9.dll",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/96/artifact/ModuleManager-2.6.9.zip",
+    "download_size": 27989,
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
@sarbian, I saw that ModuleManager was updated to 2.6.12 on Jenkins. I also added an earlier version while I was at it.

* [x] ModuleManager 2.6.4
* [x] ModuleManager 2.6.9
* [x] ModuleManager 2.6.10
* [x] ModuleManager 2.6.11
* [x] ModuleManager 2.6.12