### PR TITLE
Uncompatible KSP version

### DIFF
--- a/CactEyeTelescopesContinued/CactEyeTelescopesContinued-0.6.10.ckan
+++ b/CactEyeTelescopesContinued/CactEyeTelescopesContinued-0.6.10.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/Angel-125/CactEye-2"
     },
     "version": "0.6.10",
-    "ksp_version": "1.0.4",
+    "ksp_version": "1.0.5",
     "conflicts": [
         {
             "name": "CactEye2"


### PR DESCRIPTION
The latest version of CactEyeTelescopesContinued is only compatible with KSP 1.0.5