### PR TITLE
add Kappa Ray 0.3.3 to CKAN

### DIFF
--- a/kapparay/kapparay-0.3.3.ckan
+++ b/kapparay/kapparay-0.3.3.ckan
@@ -1,0 +1,24 @@
+{
+    "spec_version": 1,
+    "identifier"  : "kapparay",
+    "name"        : "Kappa Ray",
+    "author"      : [ "soundnfury" ],
+    "abstract"    : "Subject Kerbals and equipment to radiation",
+    "version"     : "0.3.3",
+    "ksp_version" : "1.0.5",
+    "license"     : "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/131575",
+    },
+    "download": "http://jttlov.no-ip.org/tar/kapparay-0.3.3.zip",
+    "depends": [
+        { "name": "ModuleManager" },
+    ],
+
+    "install": [
+        {
+            "file"       : "kapparay-0.3.3/GameData/kappa-ray",
+            "install_to" : "GameData",
+        },
+    ],
+}


### PR DESCRIPTION
The docs say I can't have a hyphen in <identifier>, so I've gone for 'kapparay' rather than 'kappa-ray' (the latter being the name of the folder under GameData).