### PR TITLE
Surfacemounted

### DIFF
--- a/SurfaceMountedLights/SurfaceMountedLights-1.1.ckan
+++ b/SurfaceMountedLights/SurfaceMountedLights-1.1.ckan
@@ -1,8 +1,8 @@
 {
     "spec_version": "v1.4",
     "identifier": "SurfaceMountedLights",
-    "name": "Surface Mounted Lights",
-    "abstract": "Small stock-alike lights that sit flush for lighting up you stations and ships.",
+    "name": "Surface Mounted Lights - deprecated",
+    "abstract": "Deprecated version of Surface Mounted Lights, you want the other one.",
     "author": "Why485",
     "license": "CC-BY-NC-ND-3.0",
     "resources": {

--- a/surfacelights/SurfaceLights-1.0.ckan
+++ b/surfacelights/SurfaceLights-1.0.ckan
@@ -4,7 +4,7 @@
   "name" : "Surface Lights",
   "author" : [ "Why485" ],
   "version" : "1.0",
-  "abstract" : "Surface Mounted Stock-Alike Lights for Self-Illumination",
+  "abstract" : "Surface mounted stock-alike lights for self-illumination",
   "license" : "CC-BY-NC-ND-3.0",
   "ksp_version_min": "0.24",
   "resources": {

--- a/surfacelights/surfacelights-1.1.ckan
+++ b/surfacelights/surfacelights-1.1.ckan
@@ -1,0 +1,29 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "surfacelights",
+    "name": "Surface Mounted Lights",
+    "abstract": "Small stock-alike lights that sit flush for lighting up you stations and ships.",
+    "author": "Why485",
+    "license": "CC-BY-NC-ND-3.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/57778-1-0-Surface-Mounted-Stock-Alike-Lights-for-Self-Illumination",
+        "kerbalstuff": "https://kerbalstuff.com/mod/1255/Surface%20Mounted%20Lights",
+        "x_screenshot": "https://kerbalstuff.com/content/Why485_16544/Surface_Mounted_Lights/Surface_Mounted_Lights-1447285176.1731143.png"
+    },
+    "version": "1.1",
+    "ksp_version": "1.0.5",
+    "conflicts": [
+        {
+            "name": "SurfaceMountedLights"
+        }
+    ],
+    "install": [
+        {
+            "find": "SurfaceLights",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://kerbalstuff.com/mod/1255/Surface%20Mounted%20Lights/download/1.1",
+    "download_size": 57368,
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
We're terminating the `SufaceMountedLights` identifier and giving the existing user base of `surfacelights` an upgrade path. We're making the deprecation of `SufaceMountedLights` clear to users.
Merge after https://github.com/KSP-CKAN/NetKAN/pull/2567