### PR TITLE
Update FerramAerospaceResearch-3-0.15.5.3.ckan

### DIFF
--- a/FerramAerospaceResearch/FerramAerospaceResearch-3-0.15.5.3.ckan
+++ b/FerramAerospaceResearch/FerramAerospaceResearch-3-0.15.5.3.ckan
@@ -43,7 +43,7 @@
             "description": "FAR example craft"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/52/Ferram%20Aerospace%20Research/download/v0.15.5.3_vonHelmholtz",
-    "download_size": 709002,
+    "download": "https://kerbalstuff.com/mod/52/Ferram%20Aerospace%20Research/download/v0.15.5.3_von_Helmholtz",
+    "download_size": 709644,
     "x_generated_by": "netkan"
 }


### PR DESCRIPTION
Manually update FAR metadata from netkan since the download URL was deleted and anyone attempting to install the latest version will 404 until the next netkan run.