### PR TITLE
Update KWRocketry-2.7.0-community.ckan

### DIFF
--- a/KWRocketry/KWRocketry-2.7.0-community.ckan
+++ b/KWRocketry/KWRocketry-2.7.0-community.ckan
@@ -1,22 +1,19 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "KWRocketry",
     "license": "CC-BY-SA-3.0",
     "depends": [
-        {
-            "name": "ModuleAnimateEmissive"
-        },
         {
             "name": "KWRocketry-CommunityFixes"
         }
     ],
     "install": [
         {
-            "file": "KW Release Package v2.7 (Open this, don't extract it)/GameData/KWRocketry",
+            "find": "KWRocketry",
             "install_to": "GameData"
         }
     ],
-    "ksp_version": "1.0.4",
+    "ksp_version": "1.0.5",
     "name": "KW Rocketry",
     "abstract": "The comprehensive launch vehicle construction pack by Winston and Kickasskyle",
     "version": "2.7.0-community",


### PR DESCRIPTION
1. `ksp_version` change: there's `KWRocketry-CommunityFixes` version 0.4.0 for KSP 1.0.5.
2. `spec_version` and `install` change: simplify path
3. Dependency on `ModuleAnimateEmissive` revomed, as it fixed in 'community
fixes'.

BTW: Maybe it's worth to migrate to `ksp_version_min` and `ksp_version_max`?