### PR TITLE
Add SKY 2.0

### DIFF
--- a/SKY/SKY-2.0.ckan
+++ b/SKY/SKY-2.0.ckan
@@ -8,8 +8,8 @@
     "license"        : "CC-BY-NC-SA",
     "version"        : "2.0",
     "release_status" : "stable",
-    "min_ksp_version"    : "1.0.4",
-    "max_ksp_version"    : "1.0.5",
+    "ksp_version_min"    : "1.0.4",
+    "ksp_version_max"    : "1.0.5",
     "resources" : {
         "homepage"     : "http://forum.kerbalspaceprogram.com/threads/109753"
     },

--- a/SKY/SKY-2.0.ckan
+++ b/SKY/SKY-2.0.ckan
@@ -1,0 +1,25 @@
+{
+    "spec_version"   : 1,
+    "name"           : "SKY - Scale-up Kerbalism for You",
+    "abstract"       : "Rescale stock KSP planets (x3.7) and distances (x7)",
+    "identifier"     : "SKY",
+    "author"         : "SkyRex94",
+    "download"       : "https://www.dropbox.com/s/05g6p5all0sd7ol/SKY%20-%20Scale-up%20Kerbalism%20for%20You.zip?dl=1",
+    "license"        : "CC-BY-NC-SA",
+    "version"        : "2.0",
+    "release_status" : "stable",
+    "min_ksp_version"    : "1.0.4",
+    "max_ksp_version"    : "1.0.5",
+    "resources" : {
+        "homepage"     : "http://forum.kerbalspaceprogram.com/threads/109753"
+    },
+    "install" : [
+        {
+            "file"       : "SKY - Scale-up Kerbalism for You/SKY",
+            "install_to" : "GameData"
+        }
+    ],
+    "depends" : [
+        { "name" : "Kopernicus" }
+    ]
+}


### PR DESCRIPTION
This finally fixes pull #590. Now SKY does not include KSPswitcher, so the problem that was holding #590 back is fixed.

Edit: I fixed the min/max version syntax error.