### PR TITLE
Update planet packs

### DIFF
--- a/KittopiaTech/KittopiaTech-0.192.ckan
+++ b/KittopiaTech/KittopiaTech-0.192.ckan
@@ -1,22 +1,30 @@
 {
-	"spec_version" 	: "v1.4",
-	"identifier"	: "KittopiaTech",
-	"name"			: "KittopiaTech",
-	"abstract"		: "An in game planet editor",
-	"license"		: "unknown",
-	"version"		: "0.192",
-	"comment"		: "Development halted until further notice",
-	"author"		: "KCreator",
-	"ksp_version"	: "0.90",
-	"resources"		: {
-						"repository"	: "https://github.com/KCreator/Kittopiatech_Planeteditor",
-						"homepage"		: "http://forum.kerbalspaceprogram.com/threads/68619"
-					},
-	"download"		: "https://dl.dropboxusercontent.com/u/80556647/PlanetaryEditingToolsUI.zip",
-	"install"		: [
-					{
-					"find" : "KittopiaSpace",
-					"install_to" : "GameData"
-					}
-			]
+    "spec_version": "v1.4",
+    "identifier"  : "KittopiaTech",
+    "name"        : "KittopiaTech",
+    "abstract"    : "An in game planet editor",
+    "license"     : "unknown",
+    "version"     : "0.192",
+    "comment"     : "Development halted until further notice",
+    "author"      : "KCreator",
+    "ksp_version" : "0.90",
+    "resources": {
+        "repository": "https://github.com/KCreator/Kittopiatech_Planeteditor",
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/68619"
+    },
+    "download": "https://dl.dropboxusercontent.com/u/80556647/PlanetaryEditingToolsUI.zip",
+    "install": [
+        {
+            "find": "KittopiaSpace",
+            "install_to": "GameData"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "KopernicusTech"
+        }
+    ]
 }

--- a/KopernicusTech/KopernicusTech-0.13.ckan
+++ b/KopernicusTech/KopernicusTech-0.13.ckan
@@ -1,44 +1,43 @@
 {
-	"spec_version" 	: "v1.4",
-	"identifier"	: "KopernicusTech",
-	"name"			: "KopernicusTech",
-	"abstract"		: "An attempt to integrate Kopernicus with KittopiaTech",
-	"license"		: "GPL-3.0",
-	"version"		: "0.13",
-	"author"		: "Gravitasi",
-	"ksp_version_min"	: "0.90",
-	"ksp_version_max"	: "1.0.99",
-	"resources"		: {
-						"homepage"		: "http://forum.kerbalspaceprogram.com/threads/109122"
-					},
-	"download"		: "https://www.dropbox.com/s/7b999gme8p7cgfr/KopernicusTech_v0.13.zip?dl=1",
-	"install"		: [
-					{
-					"find" : "KittopiaSpace",
-					"install_to" : "GameData",
-					"filter" : "Textures"
-					},
-					{
-					"find" : "Kopernicus",
-					"install_to" : "GameData"
-					}
-			],
-	"depends"		: [
-					{
-					"name" : "ModuleManager"
-					}
-			],
-	"suggests"		: [
-					{
-					"name" : "DDSLoader"
-					}
-			],
-	"conflicts"		: [
-					{
-					"name" : "Kopernicus"
-					},
-					{
-					"name" : "KittopiaTech"
-					}
-			]
+    "spec_version": "v1.4",
+    "identifier"  : "KopernicusTech",
+    "name"        : "KopernicusTech",
+    "abstract"    : "An attempt to integrate Kopernicus with KittopiaTech",
+    "license"     : "GPL-3.0",
+    "version"     : "0.13",
+    "author"      : "Gravitasi",
+    "ksp_version" : "0.90",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/109122"
+    },
+    "download": "https://www.dropbox.com/s/7b999gme8p7cgfr/KopernicusTech_v0.13.zip?dl=1",
+    "install": [
+        {
+            "find": "KittopiaSpace",
+            "install_to": "GameData",
+            "filter": "Textures"
+        },
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "DDSLoader"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "KittopiaTech"
+        }
+    ]
 }


### PR DESCRIPTION
Let KittopiaTech and KopernicusTech conflict with each other and with the new Kopernicus.

Part of the PlanetPack overhaul