### PR TITLE
Force-update AJE 2.5.1 metadata

### DIFF
--- a/AdvancedJetEngine/AdvancedJetEngine-2.5.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.5.1.ckan
@@ -13,7 +13,7 @@
         "repository": "https://github.com/camlost2/AJE"
     },
     "version": "2.5.1",
-    "ksp_version": "1.0.4",
+    "ksp_version": "1.0.5",
     "depends": [
         {
             "name": "FerramAerospaceResearch"


### PR DESCRIPTION
Was marked 1.0.4, should be 1.0.5.