### PR TITLE
ATM 5 does not work with KSP 0.90

### DIFF
--- a/ActiveTextureManagement-x86-Basic/ActiveTextureManagement-x86-Basic-5-0.ckan
+++ b/ActiveTextureManagement-x86-Basic/ActiveTextureManagement-x86-Basic-5-0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/rbray89/ActiveTextureManagement"
     },
     "version": "5-0",
-    "ksp_version_min": "0.90",
+    "ksp_version_min": "1.0",
     "ksp_version_max": "1.0.99",
     "provides": [
         "ActiveTextureManagement"


### PR DESCRIPTION
It produces lots of "Method not found: 'GameDatabase.TextureInfo..ctor'" errors in log and all parts in game are white.