### PR TITLE
Fix KSP version range on old ModuleRCSFX versions

### DIFF
--- a/ModuleRCSFX/ModuleRCSFX-v4.0.ckan
+++ b/ModuleRCSFX/ModuleRCSFX-v4.0.ckan
@@ -9,7 +9,8 @@
         "NathanKell"
     ],
     "release_status": "stable",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92290",
         "repository": "https://github.com/NathanKell/ModuleRCSFX"

--- a/ModuleRCSFX/ModuleRCSFX-v4.1.ckan
+++ b/ModuleRCSFX/ModuleRCSFX-v4.1.ckan
@@ -14,7 +14,8 @@
         "repository": "https://github.com/NathanKell/ModuleRCSFX"
     },
     "version": "v4.1",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "download": "https://github.com/NathanKell/ModuleRCSFX/releases/download/v4.1/ModuleRCSFX_v4.1.zip",
     "download_size": 6831,
     "x_generated_by": "netkan"


### PR DESCRIPTION
ModuleRCSFX is obsolete as of KSP 1.0.5 Version 4.2 is marked as incompatible, but  4.0 and 4.1 have looser ksp_version data.