### PR TITLE
Mark B9 Procedural Parts compatible with 1.0.5.

### DIFF
--- a/B9AerospaceProceduralParts/B9AerospaceProceduralParts-0.40.ckan
+++ b/B9AerospaceProceduralParts/B9AerospaceProceduralParts-0.40.ckan
@@ -12,7 +12,7 @@
         "x_screenshot": "https://kerbalstuff.com/content/bac9_821/B9_Aerospace_Procedural_Parts/B9_Aerospace_Procedural_Parts.jpg"
     },
     "version": "0.40",
-    "ksp_version": "1.0.4",
+    "ksp_version": "1.0.5",
     "depends": [
         {
             "name": "CrossFeedEnabler"


### PR DESCRIPTION
I spent a few hours building seaplanes with this, both with and without FAR.  No issues reported on the forum.  Seems to work fine in 1.0.5.