### PR TITLE
Add 'v' to fix displaying wrong version

### DIFF
--- a/HangarExtender/HangarExtender-2.0.ckan
+++ b/HangarExtender/HangarExtender-2.0.ckan
@@ -16,7 +16,7 @@
     "name": "Hangar Extender",
     "abstract": "Extends the usable area when building in the SPH or VAB, so you can build outside or above the building. Useful for building large aircraft carriers or tall rockets.",
     "author": "Snjo",
-    "version": "2.0",
+    "version": "v2.0",
     "download": "https://kerbalstuff.com/mod/18/Hangar%20Extender/download/2.0",
     "x_generated_by": "netkan",
     "download_size": 6593

--- a/HangarExtender/HangarExtender-3.0.ckan
+++ b/HangarExtender/HangarExtender-3.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/snjo/FShangarExtender",
         "x_screenshot": "https://kerbalstuff.com/content/Snjo_48/Hangar_Extender/Hangar_Extender.png"
     },
-    "version": "3.0",
+    "version": "v3.0",
     "ksp_version": "0.90.0",
     "install": [
         {


### PR DESCRIPTION
CKAN is always showing `3.0` instead of `1:v3.4.6`. Adding a `v` before the version numbers fixes this problem.

Part of KSP-CKAN/NetKAN/pull/2775