### PR TITLE
Rename old mod to allow new one to use the `name` they share

### DIFF
--- a/FShangarExtender/FShangarExtender-2.0.ckan
+++ b/FShangarExtender/FShangarExtender-2.0.ckan
@@ -7,7 +7,7 @@
         "kerbalstuff": "https://kerbalstuff.com/mod/18/Hangar%20Extender"
     },
     "ksp_version": "0.24.2",
-    "name": "Hangar Extender",
+    "name": "FS Hangar Extender",
     "abstract": "Extends the usable area when building in the SPH or VAB, so you can build outside or above the building. Useful for building large aircraft carriers or tall rockets.",
     "author": "Snjo",
     "version": "2.0",

--- a/FShangarExtender/FShangarExtender-3.0.ckan
+++ b/FShangarExtender/FShangarExtender-3.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "FShangarExtender",
-    "name": "Hangar Extender",
+    "name": "FS Hangar Extender",
     "abstract": "Please use the other Hangar Extender mod, this is the wrong one",
     "author": "Snjo",
     "license": "CC-BY-4.0",


### PR DESCRIPTION
Part of a fix for https://github.com/KSP-CKAN/NetKAN/pull/2441 and https://github.com/KSP-CKAN/NetKAN/pull/2775

Second part is a ksp_version bump in the `HangarExtender` netkan