### PR TITLE
Create Mk2Essentials-6.ckan

### DIFF
--- a/Mk2Essentials/Mk2Essentials-6.ckan
+++ b/Mk2Essentials/Mk2Essentials-6.ckan
@@ -7,7 +7,7 @@
 	"license" : "restricted",
 	"version" : "6",
 	"release_status" : "stable",
-	"ksp_version_min" : "1.0.2",
+	"ksp_version_min" : "0.90",
 	"ksp_version_max" : "1.0.5",
 	"resources" : 
 	{

--- a/Mk2Essentials/Mk2Essentials-6.ckan
+++ b/Mk2Essentials/Mk2Essentials-6.ckan
@@ -1,0 +1,25 @@
+{
+	"spec_version" : 1,
+	"identifier" : "Mk2Essentials",
+	"name" : "Mk 2 Essentials",
+	"abstract" : "Some Mk2 parts which I felt were missing from the game",
+	"author" : "JoePatrick1",
+	"license" : "restricted",
+	"version" : "6",
+	"release_status" : "stable",
+	"ksp_version_min" : "1.0.2",
+	"ksp_version_max" : "1.0.5",
+	"resources" : 
+	{
+		"homepage"	: "http://forum.kerbalspaceprogram.com/index.php?/topic/89875-104",
+		"x_curse"	: "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
+	},
+	"install" : [ 
+		{ 
+			"file" : "Mk2Essentials",  
+			"install_to" : "GameData",
+			"filter" : "Thumbs.db"
+		}
+	],
+	"download" : "http://kerbal.curseforge.com/projects/mk2-essentials/files/2255734/download"
+}


### PR DESCRIPTION
This new version has been out for months. I believe it works fine in 1.0.5; the previous version already seemed to.