### PR TITLE
Restrict/impose ksp_version_max attributes to mods so that they're not compatible with 1.1.0.

### DIFF
--- a/ModularRocketSystem/ModularRocketSystem-1.3.2.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.3.2.ckan
@@ -19,5 +19,6 @@
   "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.3.2",
   "x_generated_by": "netkan",
   "download_size": 11834606,
-  "ksp_version_min": "0.25.0"
+  "ksp_version_min": "0.25.0",
+  "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.4.1.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.4.1.ckan
@@ -19,5 +19,6 @@
   "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.4.1",
   "x_generated_by": "netkan",
   "download_size": 11833958,
-  "ksp_version_min": "0.90.0"
+  "ksp_version_min": "0.90.0",
+  "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.4.2.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.4.2.ckan
@@ -19,5 +19,6 @@
   "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.4.2",
   "x_generated_by": "netkan",
   "download_size": 11834014,
-  "ksp_version_min": "0.90.0"
+  "ksp_version_min": "0.90.0",
+  "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.4.3.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.4.3.ckan
@@ -19,5 +19,6 @@
   "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.4.3",
   "x_generated_by": "netkan",
   "download_size": 11834392,
-  "ksp_version_min": "0.90.0"
+  "ksp_version_min": "0.90.0",
+  "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.4.4.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.4.4.ckan
@@ -19,5 +19,6 @@
     "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.4.4",
     "x_generated_by": "netkan",
     "download_size": 11841374,
-    "ksp_version_min": "0.90.0"
+    "ksp_version_min": "0.90.0",
+    "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.4.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.4.ckan
@@ -19,5 +19,6 @@
   "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.4",
   "x_generated_by": "netkan",
   "download_size": 11837126,
-  "ksp_version_min": "0.25.0"
+  "ksp_version_min": "0.25.0",
+  "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.5.1.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.5.1.ckan
@@ -19,5 +19,6 @@
     "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.5.1",
     "x_generated_by": "netkan",
     "download_size": 12181922,
-    "ksp_version_min": "0.90.0"
+    "ksp_version_min": "0.90.0",
+    "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.5.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.5.ckan
@@ -19,5 +19,6 @@
     "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.5",
     "x_generated_by": "netkan",
     "download_size": 12143700,
-    "ksp_version_min": "0.90.0"
+    "ksp_version_min": "0.90.0",
+    "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.6.1.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.6.1.ckan
@@ -19,5 +19,6 @@
     "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.6.1",
     "x_generated_by": "netkan",
     "download_size": 11450773,
-    "ksp_version_min": "1.0.0"
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.6.2.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.6.2.ckan
@@ -19,5 +19,6 @@
     "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.6.2",
     "x_generated_by": "netkan",
     "download_size": 10934118,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.6.3.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.6.3.ckan
@@ -19,5 +19,6 @@
     "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.6.3",
     "x_generated_by": "netkan",
     "download_size": 10934156,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.6.4.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.6.4.ckan
@@ -19,5 +19,6 @@
     "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.6.4",
     "x_generated_by": "netkan",
     "download_size": 10997122,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.6.5.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.6.5.ckan
@@ -19,5 +19,6 @@
     "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.6.5",
     "x_generated_by": "netkan",
     "download_size": 11001843,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.6.6.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.6.6.ckan
@@ -19,5 +19,6 @@
     "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.6.6",
     "x_generated_by": "netkan",
     "download_size": 11304472,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.7.1.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.7.1.ckan
@@ -19,5 +19,6 @@
     "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.7.1",
     "x_generated_by": "netkan",
     "download_size": 10796529,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.7.2.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.7.2.ckan
@@ -25,5 +25,6 @@
     "x_generated_by": "netkan",
     "x_screenshot": "https://kerbalstuff.com/content/NecroBones_1035/Modular_Rocket_Systems_-_Parts_Pack/Modular_Rocket_Systems_-_Parts_Pack.png",
     "download_size": 10797030,
-    "ksp_version_min": "1.0.3"
+    "ksp_version_min": "1.0.3",
+    "ksp_version_max": "1.0.5"
 }

--- a/ModularRocketSystem/ModularRocketSystem-1.7.ckan
+++ b/ModularRocketSystem/ModularRocketSystem-1.7.ckan
@@ -19,5 +19,6 @@
     "download": "https://kerbalstuff.com/mod/148/Modular%20Rocket%20Systems%20-%20Parts%20Pack/download/1.7",
     "x_generated_by": "netkan",
     "download_size": 11374127,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/ReflectionPlugin/ReflectionPlugin-1.2.ckan
+++ b/ReflectionPlugin/ReflectionPlugin-1.2.ckan
@@ -7,6 +7,7 @@
 	"version"		:	"1.2",
 	"author"		:	[ "Starwaster", "Razchek" ],
 	"ksp_version_min" :	"0.24.2",
+    "ksp_version_max": "1.0.5",
 	"download"		:	"https://github.com/Starwaster/Reflection-Plugin-Continued/blob/Dev/ReflectionPlugin.DEV.1.2.zip?raw=true",
 	"install"		:	[ { "file"	:	"ReflectionPlugin.dll",
 							"install_to"	:	"GameData/FASA/Plugins"}],

--- a/ReflectionPlugin/ReflectionPlugin-1.2.ckan
+++ b/ReflectionPlugin/ReflectionPlugin-1.2.ckan
@@ -1,15 +1,15 @@
 {
-	"spec_version"	:	"v1.4",
-	"identifier"	:	"ReflectionPlugin",
-	"name"			:	"Reflection Plugin for KSP",
-	"license"		:	"public-domain",
-	"abstract"		:	"Make stuff shiny, plugin for modders",
-	"version"		:	"1.2",
-	"author"		:	[ "Starwaster", "Razchek" ],
-	"ksp_version_min" :	"0.24.2",
+    "spec_version"  :   "v1.4",
+    "identifier"    :   "ReflectionPlugin",
+    "name"          :   "Reflection Plugin for KSP",
+    "license"       :   "public-domain",
+    "abstract"      :   "Make stuff shiny, plugin for modders",
+    "version"       :   "1.2",
+    "author"        :   [ "Starwaster", "Razchek" ],
+    "ksp_version_min": "0.24.2",
     "ksp_version_max": "1.0.5",
-	"download"		:	"https://github.com/Starwaster/Reflection-Plugin-Continued/blob/Dev/ReflectionPlugin.DEV.1.2.zip?raw=true",
-	"install"		:	[ { "file"	:	"ReflectionPlugin.dll",
-							"install_to"	:	"GameData/FASA/Plugins"}],
-	"resources"		:	{ "homepage"  :  "http://forum.kerbalspaceprogram.com/threads/70089"}
+    "download"      :   "https://github.com/Starwaster/Reflection-Plugin-Continued/blob/Dev/ReflectionPlugin.DEV.1.2.zip?raw=true",
+    "install"       :   [ { "file"  :   "ReflectionPlugin.dll",
+                            "install_to"    :   "GameData/FASA/Plugins"}],
+    "resources"     :   { "homepage"  :  "http://forum.kerbalspaceprogram.com/threads/70089"}
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.10.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.10.ckan
@@ -13,5 +13,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.10",
     "x_generated_by": "netkan",
     "download_size": 11879062,
-    "ksp_version_min": "0.90.0"
+    "ksp_version_min": "0.90.0",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.11.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.11.ckan
@@ -13,5 +13,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.11",
     "x_generated_by": "netkan",
     "download_size": 11951343,
-    "ksp_version_min": "0.90.0"
+    "ksp_version_min": "0.90.0",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.12.1.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.12.1.ckan
@@ -13,5 +13,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.12.1",
     "x_generated_by": "netkan",
     "download_size": 11849214,
-    "ksp_version_min": "1.0.0"
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.12.2.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.12.2.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.12.2",
     "x_generated_by": "netkan",
     "download_size": 10816191,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.12.3.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.12.3.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.12.3",
     "x_generated_by": "netkan",
     "download_size": 16093613,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.12.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.12.ckan
@@ -13,5 +13,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.12",
     "x_generated_by": "netkan",
     "download_size": 11849295,
-    "ksp_version_min": "1.0.0"
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.13.1.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.13.1.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.13.1",
     "x_generated_by": "netkan",
     "download_size": 17215842,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.13.2.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.13.2.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.13.2",
     "x_generated_by": "netkan",
     "download_size": 17261327,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.13.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.13.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.13",
     "x_generated_by": "netkan",
     "download_size": 16898629,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.14.1.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.14.1.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.14.1",
     "x_generated_by": "netkan",
     "download_size": 17263329,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.14.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.14.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.14",
     "x_generated_by": "netkan",
     "download_size": 17261367,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.15.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.15.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.15",
     "x_generated_by": "netkan",
     "download_size": 17265365,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.16.1.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.16.1.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.16.1",
     "x_generated_by": "netkan",
     "download_size": 17061813,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.16.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.16.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.16",
     "x_generated_by": "netkan",
     "download_size": 17052918,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.17.1.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.17.1.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.17.1",
     "x_generated_by": "netkan",
     "download_size": 17176407,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.17.2.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.17.2.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.17.2",
     "x_generated_by": "netkan",
     "download_size": 17176935,
-    "ksp_version_min": "1.0.3"
+    "ksp_version_min": "1.0.3",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.17.3.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.17.3.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.17.3",
     "x_generated_by": "netkan",
     "download_size": 17179895,
-    "ksp_version_min": "1.0.4"
+    "ksp_version_min": "1.0.4",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.17.4.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.17.4.ckan
@@ -19,5 +19,6 @@
     "x_generated_by": "netkan",
     "x_screenshot": "https://kerbalstuff.com/content/NecroBones_1035/SpaceY_Heavy_Lifters_Parts_Pack/SpaceY_Heavy_Lifters_Parts_Pack.jpg",
     "download_size": 17177230,
-    "ksp_version_min": "1.0.4"
+    "ksp_version_min": "1.0.4",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.17.5.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.17.5.ckan
@@ -18,6 +18,7 @@
         "x_screenshot": "https://kerbalstuff.com/content/NecroBones_1035/SpaceY_Heavy_Lifters_Parts_Pack/SpaceY_Heavy_Lifters_Parts_Pack.jpg"
     },
     "ksp_version_min": "1.0.4",
+    "ksp_version_max": "1.0.5",
     "download_size": 17177823,
     "x_generated_by": "netkan"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.17.6.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.17.6.ckan
@@ -18,6 +18,7 @@
         "x_screenshot": "https://kerbalstuff.com/content/NecroBones_1035/SpaceY_Heavy_Lifters_Parts_Pack/SpaceY_Heavy_Lifters_Parts_Pack.jpg"
     },
     "ksp_version_min": "1.0.4",
+    "ksp_version_max": "1.0.5",
     "download_size": 17177865,
     "x_generated_by": "netkan"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.17.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.17.ckan
@@ -18,5 +18,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.17",
     "x_generated_by": "netkan",
     "download_size": 17176357,
-    "ksp_version_min": "1.0.1"
+    "ksp_version_min": "1.0.1",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.3.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.3.ckan
@@ -13,5 +13,6 @@
   "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.3",
   "x_generated_by": "netkan",
   "download_size": 6655882,
-  "ksp_version_min": "0.25.0"
+  "ksp_version_min": "0.25.0",
+  "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.4.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.4.ckan
@@ -13,5 +13,6 @@
   "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.4",
   "x_generated_by": "netkan",
   "download_size": 7632045,
-  "ksp_version_min": "0.25.0"
+  "ksp_version_min": "0.25.0",
+  "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.5.1.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.5.1.ckan
@@ -13,5 +13,6 @@
   "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.5.1",
   "x_generated_by": "netkan",
   "download_size": 8325198,
-  "ksp_version_min": "0.90.0"
+  "ksp_version_min": "0.90.0",
+  "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.5.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.5.ckan
@@ -13,5 +13,6 @@
   "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.5",
   "x_generated_by": "netkan",
   "download_size": 8208426,
-  "ksp_version_min": "0.90.0"
+  "ksp_version_min": "0.90.0",
+  "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.6.1.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.6.1.ckan
@@ -13,5 +13,6 @@
   "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.6.1",
   "x_generated_by": "netkan",
   "download_size": 8757828,
-  "ksp_version_min": "0.90.0"
+  "ksp_version_min": "0.90.0",
+  "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.6.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.6.ckan
@@ -13,5 +13,6 @@
   "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.6",
   "x_generated_by": "netkan",
   "download_size": 8757763,
-  "ksp_version_min": "0.90.0"
+  "ksp_version_min": "0.90.0",
+  "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.7.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.7.ckan
@@ -13,5 +13,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.7",
     "x_generated_by": "netkan",
     "download_size": 9206563,
-    "ksp_version_min": "0.90.0"
+    "ksp_version_min": "0.90.0",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.8.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.8.ckan
@@ -13,6 +13,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.8",
     "x_generated_by": "netkan",
     "download_size": 8948067,
-    "ksp_version_min": "0.90.0"
+    "ksp_version_min": "0.90.0",
     "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.8.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.8.ckan
@@ -14,4 +14,5 @@
     "x_generated_by": "netkan",
     "download_size": 8948067,
     "ksp_version_min": "0.90.0"
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.9.1.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.9.1.ckan
@@ -13,5 +13,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.9.1",
     "x_generated_by": "netkan",
     "download_size": 9576738,
-    "ksp_version_min": "0.90.0"
+    "ksp_version_min": "0.90.0",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-0.9.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-0.9.ckan
@@ -13,5 +13,6 @@
     "download": "https://kerbalstuff.com/mod/352/SpaceY%20Heavy%20Lifters%20Parts%20Pack/download/0.9",
     "x_generated_by": "netkan",
     "download_size": 9576457,
-    "ksp_version_min": "0.90.0"
+    "ksp_version_min": "0.90.0",
+    "ksp_version_max": "1.0.5"
 }

--- a/SpaceY-Lifters/SpaceY-Lifters-1.0.0.ckan
+++ b/SpaceY-Lifters/SpaceY-Lifters-1.0.0.ckan
@@ -18,6 +18,7 @@
         "x_screenshot": "https://kerbalstuff.com/content/NecroBones_1035/SpaceY_Heavy_Lifters_Parts_Pack/SpaceY_Heavy_Lifters_Parts_Pack.jpg"
     },
     "ksp_version_min": "1.0.4",
+    "ksp_version_max": "1.0.5",
     "download_size": 17652201,
     "x_generated_by": "netkan"
 }

--- a/TCShipInfo/ShipInfo-0.3.ckan
+++ b/TCShipInfo/ShipInfo-0.3.ckan
@@ -6,6 +6,7 @@
     "download": "https://docs.google.com/uc?export=download&id=0B1i-cKjnAQUHRTJxaDllS0NFMTQ",
     "identifier": "TCShipInfo",
     "ksp_version_min": "0.24.2",
+    "ksp_version_max": "1.0.5",
     "license": "public-domain",
     "name": "Resource Details in Tracking Center",
     "resources": {

--- a/surfacelights/SurfaceLights-1.0.ckan
+++ b/surfacelights/SurfaceLights-1.0.ckan
@@ -7,6 +7,7 @@
   "abstract" : "Surface mounted stock-alike lights for self-illumination",
   "license" : "CC-BY-NC-ND-3.0",
   "ksp_version_min": "0.24",
+  "ksp_version_max": "1.0.5",
   "resources": {
     "homepage": "http://forum.kerbalspaceprogram.com/threads/57778",
     "x_curse": "http://kerbal.curseforge.com/ksp-mods/220942-surfacelights-surface-mounted-stock-alike-lights"


### PR DESCRIPTION
Part of https://github.com/KSP-CKAN/CKAN-meta/issues/623. Good luck Jenkins.