### PR TITLE
Bring current versions in line with what netkans

### DIFF
--- a/CrewManifest/CrewManifest-0.6.1.0.ckan
+++ b/CrewManifest/CrewManifest-0.6.1.0.ckan
@@ -13,7 +13,7 @@
         "repository": "https://github.com/sarbian/CrewManifest/",
         "x_ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/"
     },
-    "version": "0.6.1",
+    "version": "0.6.1.0",
     "ksp_version": "1.0",
     "install": [
         {

--- a/CustomBarnKit/CustomBarnKit-1.1.3.0.ckan
+++ b/CustomBarnKit/CustomBarnKit-1.1.3.0.ckan
@@ -12,7 +12,7 @@
         "repository": "https://github.com/sarbian/CustomBarnKit",
         "x_ci": "https://ksp.sarbian.com/jenkins/job/CustomBarnKit/"
     },
-    "version": "1.1.3",
+    "version": "1.1.3.0",
     "ksp_version": "1.0.5",
     "download": "https://ksp.sarbian.com/jenkins/job/CustomBarnKit/10/artifact/CustomBarnKit-1.1.3.0.zip",
     "download_size": 13095,

--- a/GCMonitor/GCMonitor-1.2.8.0.ckan
+++ b/GCMonitor/GCMonitor-1.2.8.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/sarbian/GCMonitor/",
         "ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
     },
-    "version": "1.2.8",
+    "version": "1.2.8.0",
     "ksp_version": "1.0",
     "install": [
         {

--- a/MechJeb2/MechJeb2-2.5.5.0.ckan
+++ b/MechJeb2/MechJeb2-2.5.5.0.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/124336",
         "repository": "https://github.com/MuMech/MechJeb2/"
     },
-    "version": "2.5.5",
+    "version": "2.5.5.0",
     "ksp_version": "1.0.5",
     "install": [
         {

--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.1.0.0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.1.0.0.ckan
@@ -1,17 +1,18 @@
 {
-    "spec_version": "v1.6",
+    "spec_version": 1,
     "identifier": "ModularFlightIntegrator",
     "name": "ModularFlightIntegrator",
     "abstract": "This is an amazing addon that will Modularly Integrate your Flight Models.",
     "license": "MIT",
     "author": "Sarbian",
+    "release_status": "stable",
     "resources": {
-        "ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/",
+        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/118088",
         "repository": "https://github.com/sarbian/ModularFlightIntegrator"
     },
-    "version": "1.1.2",
-    "download": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/10/artifact/ModularFlightIntegrator-1.1.2.0.zip",
-    "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.0.5"
+    "version": "1.1.0.0",
+    "download": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/8/artifact/ModularFlightIntegrator-1.1.0.0.zip",
+    "download_size": 7104,
+    "ksp_version": "1.0.4"
 }

--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.1.2.0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.1.2.0.ckan
@@ -1,18 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.6",
     "identifier": "ModularFlightIntegrator",
     "name": "ModularFlightIntegrator",
     "abstract": "This is an amazing addon that will Modularly Integrate your Flight Models.",
     "license": "MIT",
     "author": "Sarbian",
-    "release_status": "stable",
     "resources": {
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/",
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/118088",
         "repository": "https://github.com/sarbian/ModularFlightIntegrator"
     },
-    "version": "1.1",
-    "download": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/8/artifact/ModularFlightIntegrator-1.1.0.0.zip",
-    "download_size": 7104,
-    "ksp_version": "1.0.4"
+    "version": "1.1.2.0",
+    "download": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/10/artifact/ModularFlightIntegrator-1.1.2.0.zip",
+    "ksp_version_min": "1.0.5",
+    "ksp_version_max": "1.0.5"
 }

--- a/SmokeScreen/SmokeScreen-2.6.9.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.9.0.ckan
@@ -17,7 +17,7 @@
             "install_to": "GameData"
         }
     ],
-    "version": "2.6.9",
+    "version": "2.6.9.0",
     "download": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/49/artifact/SmokeScreen-2.6.9.0.zip",
     "download_size": 26407,
     "x_generated_by": "nyankan"


### PR DESCRIPTION
Merge before https://github.com/KSP-CKAN/NetKAN/pull/2837

This will set up current .ckans to allow a smooth transition to netkan automation. It should also avoid any potential versioning awkwardness.