### PR TITLE
Update RemoteTech-Config-RSS-v8.1.1.ckan

### DIFF
--- a/RemoteTech-Config-RSS/RemoteTech-Config-RSS-v8.1.1.ckan
+++ b/RemoteTech-Config-RSS/RemoteTech-Config-RSS-v8.1.1.ckan
@@ -2,6 +2,7 @@
     "spec_version": "v1.2",
     "identifier": "RemoteTech-Config-RSS",
     "ksp_version_min": "0.25",
+    "ksp_version_max": "1.0.4",
     "resources":
     {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/99966"


### PR DESCRIPTION
RealSolarSystem now supports RemoteTech internally, so this config install is not required.