### PR TITLE
Change toolbar download links to mirror

### DIFF
--- a/Toolbar/Toolbar-1.7.10.ckan
+++ b/Toolbar/Toolbar-1.7.10.ckan
@@ -4,7 +4,7 @@
     "author"        	: "blizzy78",
     "identifier"    	: "Toolbar",
     "abstract"      	: "API for third-party plugins to provide toolbar buttons",
-    "download"      	: "http://blizzy.de/toolbar/Toolbar-1.7.10.zip",
+    "download"      	: "https://www.dropbox.com/s/pi979iex1rk1g3w/Toolbar-1.7.10.zip?dl=0",
     "license"       	: "BSD-2-clause",
     "version"       	: "1.7.10",
     "release_status"	: "stable",

--- a/Toolbar/Toolbar-1.7.10.ckan
+++ b/Toolbar/Toolbar-1.7.10.ckan
@@ -4,7 +4,7 @@
     "author"        	: "blizzy78",
     "identifier"    	: "Toolbar",
     "abstract"      	: "API for third-party plugins to provide toolbar buttons",
-    "download"      	: "https://www.dropbox.com/s/pi979iex1rk1g3w/Toolbar-1.7.10.zip?dl=0",
+    "download"      	: "https://www.dropbox.com/s/pi979iex1rk1g3w/Toolbar-1.7.10.zip?dl=1",
     "license"       	: "BSD-2-clause",
     "version"       	: "1.7.10",
     "release_status"	: "stable",

--- a/Toolbar/Toolbar-1.7.9.ckan
+++ b/Toolbar/Toolbar-1.7.9.ckan
@@ -4,7 +4,7 @@
     "author"        	: "blizzy78",
     "identifier"    	: "Toolbar",
     "abstract"      	: "API for third-party plugins to provide toolbar buttons",
-    "download"      	: "http://blizzy.de/toolbar/Toolbar-1.7.9.zip",
+    "download"      	: "https://www.dropbox.com/s/p69zo35tcakgbr6/Toolbar-1.7.9.zip?dl=0",
     "license"       	: "BSD-2-clause",
     "version"       	: "1.7.9",
     "release_status"	: "stable",

--- a/Toolbar/Toolbar-1.7.9.ckan
+++ b/Toolbar/Toolbar-1.7.9.ckan
@@ -4,7 +4,7 @@
     "author"        	: "blizzy78",
     "identifier"    	: "Toolbar",
     "abstract"      	: "API for third-party plugins to provide toolbar buttons",
-    "download"      	: "https://www.dropbox.com/s/p69zo35tcakgbr6/Toolbar-1.7.9.zip?dl=0",
+    "download"      	: "https://www.dropbox.com/s/p69zo35tcakgbr6/Toolbar-1.7.9.zip?dl=1",
     "license"       	: "BSD-2-clause",
     "version"       	: "1.7.9",
     "release_status"	: "stable",


### PR DESCRIPTION
It is my hope that this will "unblock" Jenkins and stop tests failing due to it not being able to download toolbar.