### PR TITLE
Update Smokescreen 2.6.* to limit KSP version

### DIFF
--- a/SmokeScreen/SmokeScreen-2.6.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.0.ckan
@@ -6,7 +6,8 @@
     "license": "BSD-2-clause",
     "author": "sarbian",
     "release_status": "stable",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "resources": {
         "x_ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",

--- a/SmokeScreen/SmokeScreen-2.6.1.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.1.ckan
@@ -6,7 +6,8 @@
     "license": "BSD-2-clause",
     "author": "sarbian",
     "release_status": "stable",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "resources": {
         "x_ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",

--- a/SmokeScreen/SmokeScreen-2.6.2.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.2.ckan
@@ -6,7 +6,8 @@
     "license": "BSD-2-clause",
     "author": "sarbian",
     "release_status": "stable",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "resources": {
         "x_ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",

--- a/SmokeScreen/SmokeScreen-2.6.3.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.3.ckan
@@ -5,7 +5,8 @@
     "abstract": "SmokeScreen is a plugin that build on the engine FX added in .23 and adds new features to them. Most of the features ideas comes from Nothke.",
     "license": "BSD-2-clause",
     "author": "sarbian",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "resources": {
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",

--- a/SmokeScreen/SmokeScreen-2.6.4.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.4.ckan
@@ -5,7 +5,8 @@
     "abstract": "SmokeScreen is a plugin that build on the engine FX added in .23 and adds new features to them. Most of the features ideas comes from Nothke.",
     "license": "BSD-2-clause",
     "author": "sarbian",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "resources": {
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",

--- a/SmokeScreen/SmokeScreen-2.6.5.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.5.ckan
@@ -5,7 +5,8 @@
     "abstract": "SmokeScreen is a plugin that build on the engine FX added in .23 and adds new features to them. Most of the features ideas comes from Nothke.",
     "license": "BSD-2-clause",
     "author": "Sarbian",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "resources": {
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",

--- a/SmokeScreen/SmokeScreen-2.6.6.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.6.ckan
@@ -5,7 +5,8 @@
     "abstract": "SmokeScreen is a plugin that build on the engine FX added in .23 and adds new features to them. Most of the features ideas comes from Nothke.",
     "license": "BSD-2-clause",
     "author": "Sarbian",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "resources": {
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",

--- a/SmokeScreen/SmokeScreen-2.6.7.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.7.ckan
@@ -5,7 +5,8 @@
     "abstract": "SmokeScreen is a plugin that build on the engine FX added in .23 and adds new features to them. Most of the features ideas comes from Nothke.",
     "license": "BSD-2-clause",
     "author": "Sarbian",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "resources": {
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",

--- a/SmokeScreen/SmokeScreen-2.6.8.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.8.ckan
@@ -5,7 +5,8 @@
     "abstract": "SmokeScreen is a plugin that build on the engine FX added in .23 and adds new features to them. Most of the features ideas comes from Nothke.",
     "license": "BSD-2-clause",
     "author": "Sarbian",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "resources": {
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",

--- a/SmokeScreen/SmokeScreen-2.6.9.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.9.0.ckan
@@ -11,7 +11,8 @@
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.6.9.0",
-    "ksp_version": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.4",
     "install": [
         {
             "find": "SmokeScreen",


### PR DESCRIPTION
2.6.10 has fixed some stuff that was broken in 1.0.5, so restricting older versions to 1.0.4