### PR TITLE
Set Epoch on recent KAX ckans

### DIFF
--- a/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.3.ckan
+++ b/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.12",
+    "spec_version": "v1.4",
     "identifier": "KerbalAircraftExpansion",
     "name": "Kerbal Aircraft Expansion (KAX)",
     "abstract": "A pack of select parts for your aircrafting needs, including propellers, helicopter rotors, and more!",

--- a/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.3.ckan
+++ b/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.12",
     "identifier": "KerbalAircraftExpansion",
     "name": "Kerbal Aircraft Expansion (KAX)",
     "abstract": "A pack of select parts for your aircrafting needs, including propellers, helicopter rotors, and more!",
@@ -32,6 +32,10 @@
                 "Example Craft"
             ],
             "comment": "Example crafts are filtered out becouse its impossible to install ships to subdirectory."
+        },
+        {
+            "find": "Example Craft",
+            "install_to": "Ships/SPH"
         }
     ],
     "download": "https://kerbalstuff.com/mod/391/Kerbal%20Aircraft%20Expansion%20%28KAX%29/download/KAX_v2.5.3",

--- a/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.3.ckan
+++ b/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.3.ckan
@@ -10,7 +10,7 @@
         "kerbalstuff": "https://kerbalstuff.com/mod/391/Kerbal%20Aircraft%20Expansion%20(KAX)",
         "x_screenshot": "https://kerbalstuff.com/content/keptin_4750/Kerbal_Aircraft_Expansion_KAX/Kerbal_Aircraft_Expansion_KAX.jpg"
     },
-    "version": "KAX_v2.5.3",
+    "version": "1:KAX_v2.5.3",
     "ksp_version": "1.0.5",
     "depends": [
         {

--- a/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.3.ckan
+++ b/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.3.ckan
@@ -32,10 +32,6 @@
                 "Example Craft"
             ],
             "comment": "Example crafts are filtered out becouse its impossible to install ships to subdirectory."
-        },
-        {
-            "find": "Example Craft",
-            "install_to": "Ships/SPH"
         }
     ],
     "download": "https://kerbalstuff.com/mod/391/Kerbal%20Aircraft%20Expansion%20%28KAX%29/download/KAX_v2.5.3",

--- a/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.4.ckan
+++ b/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.4.ckan
@@ -32,10 +32,6 @@
                 "Example Craft"
             ],
             "comment": "Example crafts are filtered out becouse its impossible to install ships to subdirectory."
-        },
-        {
-            "find": "Example Craft",
-            "install_to": "Ships/SPH"
         }
     ],
     "download": "https://kerbalstuff.com/mod/391/Kerbal%20Aircraft%20Expansion%20%28KAX%29/download/KAX_v2.5.4",

--- a/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.4.ckan
+++ b/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.4.ckan
@@ -32,6 +32,10 @@
                 "Example Craft"
             ],
             "comment": "Example crafts are filtered out becouse its impossible to install ships to subdirectory."
+        },
+        {
+            "find": "Example Craft",
+            "install_to": "Ships/SPH"
         }
     ],
     "download": "https://kerbalstuff.com/mod/391/Kerbal%20Aircraft%20Expansion%20%28KAX%29/download/KAX_v2.5.4",

--- a/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.4.ckan
+++ b/KerbalAircraftExpansion/KerbalAircraftExpansion-1-KAX_v2.5.4.ckan
@@ -10,7 +10,7 @@
         "kerbalstuff": "https://kerbalstuff.com/mod/391/Kerbal%20Aircraft%20Expansion%20(KAX)",
         "x_screenshot": "https://kerbalstuff.com/content/keptin_4750/Kerbal_Aircraft_Expansion_KAX/Kerbal_Aircraft_Expansion_KAX.jpg"
     },
-    "version": "KAX_v2.5.4",
+    "version": "1:KAX_v2.5.4",
     "ksp_version": "1.0.5",
     "depends": [
         {


### PR DESCRIPTION
KerbalAircraftExpansion recently started inserting "KAX-" at the start of their version numbers. Epoch required to fix versioning. Also, install example craft to Ships/SPH.