### PR TITLE
Update and rename MK2KSPIIntegration-Version_8.5.0.P-FIXED.ckan to MK…

### DIFF
--- a/MK2KSPIIntegration/MK2KSPIIntegration-8.5.0.P-FIXED.ckan
+++ b/MK2KSPIIntegration/MK2KSPIIntegration-8.5.0.P-FIXED.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/ABZB/Mk2_Extended_KSPI_Integration",
         "x_screenshot": "https://kerbalstuff.com/content/ABZB_173/MK2_KSPI_Integration/MK2_KSPI_Integration-1441205848.2309968.png"
     },
-    "version": "Version_8.5.0.P-FIXED",
+    "version": "8.5.0.P-FIXED",
     "ksp_version": "1.0.4",
     "depends": [
         {


### PR DESCRIPTION
…2KSPIIntegration-8.5.0.P-FIXED.ckan

Remove irregular version string. This should stop KSP showing the wrong Max KSP version on 1.0.5 installations. Might mess up 1.0.4 installs, though. I'll check after this goes through.