### PR TITLE
Update RealChute-1.3.2.4.ckan

### DIFF
--- a/RealChute/RealChute-1.3.2.4.ckan
+++ b/RealChute/RealChute-1.3.2.4.ckan
@@ -12,7 +12,8 @@
         "x_screenshot": "https://kerbalstuff.com/content/stupid_chris_308/RealChute_Parachute_Systems/RealChute_Parachute_Systems.png"
     },
     "version": "1.3.2.4",
-    "ksp_version": "1.0.5",
+    "ksp_version_min": "1.0.2",
+    "ksp_version_max": "1.0.4",
     "depends": [
         {
             "name": "ModuleManager",


### PR DESCRIPTION
Apparently this is the last version for 1.0.4, not the first for 1.0.5, according to Stupid_Chris