### PR TITLE
Unify AdvancedJetEngine under a single identifier

### DIFF
--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
@@ -2,10 +2,10 @@
     "spec_version": 1,
     "name"     : "Advanced Jet Engine (AJE)",
     "abstract" : "Realistic jet engines for KSP",
-    "identifier": "AJE",
-    "download" : "https://github.com/camlost2/AJE/archive/1.6.8.zip",
+    "identifier": "AdvancedJetEngine",
+    "download" : "https://github.com/camlost2/AJE/archive/1.6.4.zip",
     "license"  : "LGPL-2.1",
-    "version"  : "1.6.8",
+    "version"  : "1.6.4",
     "release_status" : "stable",
     "ksp_version" : "0.25",
     "resources" : {

--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "name"     : "Advanced Jet Engine (AJE)",
     "abstract" : "Realistic jet engines for KSP",
     "identifier": "AdvancedJetEngine",
@@ -8,6 +8,12 @@
     "version"  : "1.6.4",
     "release_status" : "stable",
     "ksp_version" : "0.25",
+    "install": [
+        {
+            "find"       : "AJE",
+            "install_to" : "GameData"
+        }
+    ],
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/70008",
         "github"   : {

--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "name"     : "Advanced Jet Engine (AJE)",
     "abstract" : "Realistic jet engines for KSP",
     "identifier": "AdvancedJetEngine",
@@ -8,6 +8,12 @@
     "version"  : "1.6.8",
     "release_status" : "stable",
     "ksp_version" : "0.25",
+    "install": [
+        {
+            "find"       : "AJE",
+            "install_to" : "GameData"
+        }
+    ],
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/70008",
         "github"   : {

--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
@@ -1,13 +1,13 @@
 {
     "spec_version": 1,
-    "name"     : "Advanced Jet Engine (AJE) - Deprecated",
-    "abstract" : "Deprecated version of AJE, you want the other one.",
-    "identifier": "AJE",
-    "download" : "https://github.com/camlost2/AJE/archive/1.7a.zip",
+    "name"     : "Advanced Jet Engine (AJE)",
+    "abstract" : "Realistic jet engines for KSP",
+    "identifier": "AdvancedJetEngine",
+    "download" : "https://github.com/camlost2/AJE/archive/1.6.8.zip",
     "license"  : "LGPL-2.1",
-    "version"  : "1.7a",
+    "version"  : "1.6.8",
     "release_status" : "stable",
-    "ksp_version" : "0.90",
+    "ksp_version" : "0.25",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/70008",
         "github"   : {
@@ -16,7 +16,7 @@
     },
     "depends" : [
         { "name" : "FerramAerospaceResearch" },
-        { "name" : "ModuleManager", "min_version" : "2.5.4" }
+        { "name" : "ModuleManager", "min_version" : "2.3.5" }
     ],
     "recommends" : [
         { "name" : "RealFuels" },

--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "name"     : "Advanced Jet Engine (AJE)",
     "abstract" : "Realistic jet engines for KSP",
-    "identifier": "AJE",
+    "identifier": "AdvancedJetEngine",
     "download" : "https://github.com/camlost2/AJE/archive/1.6.zip",
     "license"  : "LGPL-2.1",
     "version"  : "1.6",

--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "name"     : "Advanced Jet Engine (AJE)",
     "abstract" : "Realistic jet engines for KSP",
     "identifier": "AdvancedJetEngine",
@@ -8,6 +8,12 @@
     "version"  : "1.6",
     "release_status" : "stable",
     "ksp_version" : "0.25",
+    "install": [
+        {
+            "find"       : "AJE",
+            "install_to" : "GameData"
+        }
+    ],
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/70008",
         "github"   : {

--- a/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
-    "name"     : "Advanced Jet Engine (AJE) - Deprecated",
-    "abstract" : "Deprecated version of AJE, you want the other one.",
+    "name"     : "Advanced Jet Engine (AJE)",
+    "abstract" : "Realistic jet engines for KSP",
     "identifier": "AdvancedJetEngine",
     "download" : "https://github.com/camlost2/AJE/archive/1.7a.zip",
     "license"  : "LGPL-2.1",

--- a/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "name"     : "Advanced Jet Engine (AJE)",
     "abstract" : "Realistic jet engines for KSP",
     "identifier": "AdvancedJetEngine",
@@ -8,6 +8,12 @@
     "version"  : "1.7a",
     "release_status" : "stable",
     "ksp_version" : "0.90",
+    "install": [
+        {
+            "find"       : "AJE",
+            "install_to" : "GameData"
+        }
+    ],
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/70008",
         "github"   : {

--- a/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
@@ -1,13 +1,13 @@
 {
     "spec_version": 1,
-    "name"     : "Advanced Jet Engine (AJE)",
-    "abstract" : "Realistic jet engines for KSP",
-    "identifier": "AJE",
-    "download" : "https://github.com/camlost2/AJE/archive/1.6.4.zip",
+    "name"     : "Advanced Jet Engine (AJE) - Deprecated",
+    "abstract" : "Deprecated version of AJE, you want the other one.",
+    "identifier": "AdvancedJetEngine",
+    "download" : "https://github.com/camlost2/AJE/archive/1.7a.zip",
     "license"  : "LGPL-2.1",
-    "version"  : "1.6.4",
+    "version"  : "1.7a",
     "release_status" : "stable",
-    "ksp_version" : "0.25",
+    "ksp_version" : "0.90",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/70008",
         "github"   : {
@@ -16,7 +16,7 @@
     },
     "depends" : [
         { "name" : "FerramAerospaceResearch" },
-        { "name" : "ModuleManager", "min_version" : "2.3.5" }
+        { "name" : "ModuleManager", "min_version" : "2.5.4" }
     ],
     "recommends" : [
         { "name" : "RealFuels" },


### PR DESCRIPTION
Changing identifiers is a taboo but in this case `AJE` has not had a new .ckan since the days of ksp 0.90 and is, for many intents and purposes, a dead identifier. So with this we unify AJE and AdvancedJetEngine giving a clear upgrade path and reducing confusion overall.

Closes https://github.com/KSP-CKAN/CKAN/issues/1439