### PR TITLE
Use Sarbian repository for Mechjeb2-Dev

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -16,7 +16,7 @@
 
         {
             "name":      "MechJeb2-dev",
-            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/MechJeb2-ci.tar.gz",
+            "uri":       "https://ksp.sarbian.com/ckan/MechJeb2-ci.tar.gz",
             "x_mirror":  false,
             "x_comment": "MechJeb2 Development (prerelease and Jenkins) ckans"
         },


### PR DESCRIPTION
I now have a CKAN repository where my jenkins server adds all new Mechjen2 Dev builds.

You have a look at the generated files here : 
https://ksp.sarbian.com/ckan/