### PR TITLE
RCSBuildAid 0.7.6 only supports 1.0.5

### DIFF
--- a/RCSBuildAid/RCSBuildAid-v0.7.6.ckan
+++ b/RCSBuildAid/RCSBuildAid-v0.7.6.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "RCSBuildAid",
-    "ksp_version_min": "1.0.2",
+    "ksp_version_min": "1.0.5",
     "ksp_version_max": "1.0.5",
     "resources": 
     {


### PR DESCRIPTION
RCSBA 0.7.6 fails in KSP 1.0.4