### PR TITLE
Added a git-master version of Kerbal Engineer

### DIFF
--- a/KerbalEngineerRedux/KerbalEngineerRedux-git-master.ckan
+++ b/KerbalEngineerRedux/KerbalEngineerRedux-git-master.ckan
@@ -1,0 +1,28 @@
+{
+    "spec_version" : 1,
+    "identifier" : "KerbalEngineerRedux",
+    "##$kref" : "#/ckan/github/CYBUTEK/KerbalEngineer",
+    "##$vref" : "#/ckan/ksp-avc",
+    "version" : "git-master",
+    "download": "http://github.com/CYBUTEK/KerbalEngineer/archive/master.zip",
+    "download_size": 1546791,
+    "ksp_version_min": "1.0.5",
+    "name" : "Kerbal Engineer Redux",
+    "abstract" : "Reveals important statistics about your ship and its orbit during building and flight",
+    "author" : "CYBUTEK",
+    "license" : "GPL-3.0",
+    "release_status" : "testing",
+    "resources" : {
+    	"homepage" : "http://forum.kerbalspaceprogram.com/threads/18230",
+    	"github" : {
+    		"url" : "https://github.com/CYBUTEK/KerbalEngineer"
+    	}
+    },
+    "install": [
+        {
+            "file": "KerbalEngineer-master/Output/KerbalEngineer",
+            "install_to": "GameData"
+        }
+    ]
+}
+


### PR DESCRIPTION
This defines a "git-master" version for Kerbal Engineer which pulls the current build directly from the master repository. It is merely a stopgap measure for until we get an official release for KSP 1.0.5.

I am not sure this is the best way to do it; it installs cleanly, though, and I'm surely not the only one who thinks this mod is a must-have.