### PR TITLE
Patial recovery of KS mods.

### DIFF
--- a/ADIOS/ADIOS-V.15.ckan
+++ b/ADIOS/ADIOS-V.15.ckan
@@ -26,7 +26,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/545/ADIOS/download/V.15",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/59833EEE.zip",
     "download_size": 1805594,
     "x_generated_by": "netkan"
 }

--- a/ALCOR/ALCOR-0.9.4.ckan
+++ b/ALCOR/ALCOR-0.9.4.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1015/ALCOR/download/0.9.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/9BBEAB7A.zip",
     "download_size": 1498026,
     "x_generated_by": "netkan"
 }

--- a/ActivateWhenShielded/ActivateWhenShielded-1.0.1.ckan
+++ b/ActivateWhenShielded/ActivateWhenShielded-1.0.1.ckan
@@ -22,7 +22,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1269/ActivateWhenShielded/download/1.0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B59F1808.zip",
     "download_size": 471,
     "x_generated_by": "netkan"
 }

--- a/Aerostats/Aerostats-0.0.1.ckan
+++ b/Aerostats/Aerostats-0.0.1.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1380/Aerostats/download/0.0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/1AA1C168.zip",
     "download_size": 397704,
     "x_generated_by": "netkan"
 }

--- a/AirPark/AirPark-0.12.ckan
+++ b/AirPark/AirPark-0.12.ckan
@@ -12,7 +12,7 @@
     },
     "version": "0.12",
     "ksp_version": "1.0.4",
-    "download": "https://kerbalstuff.com/mod/1227/AirPark/download/0.12",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/A13FDDFD.zip",
     "download_size": 3658,
     "x_generated_by": "netkan"
 }

--- a/Airlock/Airlock-1.0.1.ckan
+++ b/Airlock/Airlock-1.0.1.ckan
@@ -22,7 +22,7 @@
             "filter": "ModuleAirlock.cs"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1011/Airlock/download/1.0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/1216243E.zip",
     "download_size": 4094,
     "x_generated_by": "netkan"
 }

--- a/AntennaRange/AntennaRange-1.10.3.ckan
+++ b/AntennaRange/AntennaRange-1.10.3.ckan
@@ -30,7 +30,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/254/AntennaRange/download/1.10.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/A199D395.zip",
     "download_size": 233256,
     "x_generated_by": "netkan"
 }

--- a/AntennaRangePatch4Antennas/AntennaRangePatch4Antennas-0.1.0.ckan
+++ b/AntennaRangePatch4Antennas/AntennaRangePatch4Antennas-0.1.0.ckan
@@ -29,7 +29,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1191/AntennaRangePatch4Antennas/download/0.1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/0E9F40B9.zip",
     "download_size": 1845,
     "x_generated_by": "netkan"
 }

--- a/AntennaRangePatch4ORIGAMEAntenna/AntennaRangePatch4ORIGAMEAntenna-1.0.ckan
+++ b/AntennaRangePatch4ORIGAMEAntenna/AntennaRangePatch4ORIGAMEAntenna-1.0.ckan
@@ -27,7 +27,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1245/AntennaRangePatch4ORIGAMEAntenna/download/1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/CBEC214D.zip",
     "download_size": 739,
     "x_generated_by": "netkan"
 }

--- a/AntennaRangePatch4OctoSat/AntennaRangePatch4OctoSat-2.0.ckan
+++ b/AntennaRangePatch4OctoSat/AntennaRangePatch4OctoSat-2.0.ckan
@@ -27,7 +27,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1339/AntennaRangePatch4OctoSat/download/2.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/59D47D23.zip",
     "download_size": 355,
     "x_generated_by": "netkan"
 }

--- a/Antennas/Antennas-1.2.ckan
+++ b/Antennas/Antennas-1.2.ckan
@@ -23,7 +23,7 @@
             "filter": "Thumbs.db"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/920/Antennas/download/1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/55002207.zip",
     "download_size": 4257428,
     "x_generated_by": "netkan"
 }

--- a/AutoAsparagus/AutoAsparagus-v1.1.ckan
+++ b/AutoAsparagus/AutoAsparagus-v1.1.ckan
@@ -14,7 +14,7 @@
     },
     "version": "v1.1",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/87/AutoAsparagus/download/v1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/486A74A7.zip",
     "download_size": 31506,
     "x_generated_by": "netkan"
 }

--- a/AutoSmartParts/AutoSmartParts-0.0.4e.ckan
+++ b/AutoSmartParts/AutoSmartParts-0.0.4e.ckan
@@ -17,7 +17,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/762/AutoSmartParts/download/0.0.4e",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/E0E48AE1.zip",
     "download_size": 6268,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/B52H/B52H-104.105.ckan
+++ b/B52H/B52H-104.105.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData/Skunk_Works"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1281/B52H/download/104.105",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/1982C447.zip",
     "download_size": 6737219,
     "x_generated_by": "netkan"
 }

--- a/BDArmorySorting/BDArmorySorting-1.0.2.ckan
+++ b/BDArmorySorting/BDArmorySorting-1.0.2.ckan
@@ -15,7 +15,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1117/BDArmorySorting/download/1.0.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/95F1EE0F.zip",
     "download_size": 304,
     "x_generated_by": "netkan"
 }

--- a/BackgroundProcessing/BackgroundProcessing-0.4.1.0.ckan
+++ b/BackgroundProcessing/BackgroundProcessing-0.4.1.0.ckan
@@ -17,7 +17,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/302/BackgroundProcessing/download/0.4.1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4123E9B7.zip",
     "download_size": 13296,
     "x_generated_by": "netkan"
 }

--- a/BalastanksExtended/BalastanksExtended-1.0.ckan
+++ b/BalastanksExtended/BalastanksExtended-1.0.ckan
@@ -22,7 +22,7 @@
             "install_to": "GameData/kdufferskorp"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1297/balastanks-extended/download/1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C651DD27.zip",
     "download_size": 1841332,
     "x_generated_by": "netkan"
 }

--- a/BalastanksExtended/BalastanksExtended-1.1.ckan
+++ b/BalastanksExtended/BalastanksExtended-1.1.ckan
@@ -22,7 +22,7 @@
             "install_to": "GameData/kdufferskorp"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1297/balastanks-extended/download/1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/08B6F376.zip",
     "download_size": 1841738,
     "x_generated_by": "netkan"
 }

--- a/Ballistanks/Ballistanks-1.ckan
+++ b/Ballistanks/Ballistanks-1.ckan
@@ -17,7 +17,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1254/Ballistanks/download/1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/E9452026.zip",
     "download_size": 513716,
     "x_generated_by": "netkan"
 }

--- a/BetterBurnTime/BetterBurnTime-1.0.ckan
+++ b/BetterBurnTime/BetterBurnTime-1.0.ckan
@@ -13,7 +13,7 @@
     },
     "version": "1.0",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/1293/BetterBurnTime/download/1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/64747A55.zip",
     "download_size": 9581,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/BetterBurnTime/BetterBurnTime-1.1.1.ckan
+++ b/BetterBurnTime/BetterBurnTime-1.1.1.ckan
@@ -13,7 +13,7 @@
     },
     "version": "1.1.1",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/1293/BetterBurnTime/download/1.1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/6EF56713.zip",
     "download_size": 14252,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/BetterBurnTime/BetterBurnTime-1.1.2.ckan
+++ b/BetterBurnTime/BetterBurnTime-1.1.2.ckan
@@ -13,7 +13,7 @@
     },
     "version": "1.1.2",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/1293/BetterBurnTime/download/1.1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3D455395.zip",
     "download_size": 14652,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/BetterBurnTime/BetterBurnTime-1.1.ckan
+++ b/BetterBurnTime/BetterBurnTime-1.1.ckan
@@ -13,7 +13,7 @@
     },
     "version": "1.1",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/1293/BetterBurnTime/download/1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4AA9263C.zip",
     "download_size": 14366,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/BetterBurnTime/BetterBurnTime-1.2.ckan
+++ b/BetterBurnTime/BetterBurnTime-1.2.ckan
@@ -13,7 +13,7 @@
     },
     "version": "1.2",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/1293/BetterBurnTime/download/1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/55DFA604.zip",
     "download_size": 16615,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/BetterCrewAssignment/BetterCrewAssignment-1.01.ckan
+++ b/BetterCrewAssignment/BetterCrewAssignment-1.01.ckan
@@ -18,7 +18,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1340/BetterCrewAssignment/download/1.01",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/ACF32CFB.zip",
     "download_size": 46118,
     "x_generated_by": "netkan"
 }

--- a/BetterEmissives/BetterEmissives-1.3.ckan
+++ b/BetterEmissives/BetterEmissives-1.3.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/833/BetterEmissives/download/1.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/5F374786.zip",
     "download_size": 6861,
     "x_generated_by": "netkan"
 }

--- a/BetterIonDrives/BetterIonDrives-v0.1.ckan
+++ b/BetterIonDrives/BetterIonDrives-v0.1.ckan
@@ -19,7 +19,7 @@
             "filter": ".DS_Store"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/995/BetterIonDrives/download/v0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/D35E434D.zip",
     "download_size": 87060,
     "x_generated_by": "netkan"
 }

--- a/BetterTimeWarp/BetterTimeWarp-2.2.ckan
+++ b/BetterTimeWarp/BetterTimeWarp-2.2.ckan
@@ -13,7 +13,7 @@
     },
     "version": "2.2",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/770/BetterTimeWarp/download/2.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/A6235BC9.zip",
     "download_size": 14705,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/Canadarm/Canadarm-1.51.ckan
+++ b/Canadarm/Canadarm-1.51.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1098/Canadarm/download/1.51",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/05B56EC0.zip",
     "download_size": 5383952,
     "x_generated_by": "netkan"
 }

--- a/Chatterer/Chatterer-0.9.7.ckan
+++ b/Chatterer/Chatterer-0.9.7.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.9.7",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/124/Chatterer/download/0.9.7",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/1C28BC18.zip",
     "download_size": 6910860,
     "x_generated_by": "netkan"
 }

--- a/Contares/Contares-1.4.ckan
+++ b/Contares/Contares-1.4.ckan
@@ -23,7 +23,7 @@
             "name": "RealPlume"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1186/CONTARES/download/1.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/00333415.zip",
     "download_size": 17140298,
     "x_generated_by": "netkan"
 }

--- a/Contares/Contares-1.5.1.ckan
+++ b/Contares/Contares-1.5.1.ckan
@@ -23,7 +23,7 @@
             "name": "RealPlume"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1186/CONTARES/download/1.5.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/62A60DD8.zip",
     "download_size": 21179123,
     "x_generated_by": "netkan"
 }

--- a/Contares/Contares-1.5.2.ckan
+++ b/Contares/Contares-1.5.2.ckan
@@ -23,7 +23,7 @@
             "name": "RealPlume"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1186/CONTARES/download/1.5.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/2D5B3014.zip",
     "download_size": 22226259,
     "x_generated_by": "netkan"
 }

--- a/Contares/Contares-1.5.3.ckan
+++ b/Contares/Contares-1.5.3.ckan
@@ -23,7 +23,7 @@
             "name": "RealPlume"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1186/CONTARES/download/1.5.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/E343158D.zip",
     "download_size": 26764554,
     "x_generated_by": "netkan"
 }

--- a/Contares/Contares-1.5.ckan
+++ b/Contares/Contares-1.5.ckan
@@ -23,7 +23,7 @@
             "name": "RealPlume"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1186/CONTARES/download/1.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/DD10778C.zip",
     "download_size": 20332772,
     "x_generated_by": "netkan"
 }

--- a/Contares/Contares-1.6.0.ckan
+++ b/Contares/Contares-1.6.0.ckan
@@ -23,7 +23,7 @@
             "name": "RealPlume"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1186/CONTARES/download/1.6.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/469033D6.zip",
     "download_size": 39332365,
     "x_generated_by": "netkan"
 }

--- a/Contares/Contares-1.6.1.ckan
+++ b/Contares/Contares-1.6.1.ckan
@@ -23,7 +23,7 @@
             "name": "RealPlume"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1186/CONTARES/download/1.6.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/55DA4D1D.zip",
     "download_size": 44442543,
     "x_generated_by": "netkan"
 }

--- a/Contares/Contares-1.6.3.ckan
+++ b/Contares/Contares-1.6.3.ckan
@@ -23,7 +23,7 @@
             "name": "RealPlume"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1186/CONTARES/download/1.6.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/A806997E.zip",
     "download_size": 53832344,
     "x_generated_by": "netkan"
 }

--- a/ContractConfigurator-Banking/ContractConfigurator-Banking-V.01.ckan
+++ b/ContractConfigurator-Banking/ContractConfigurator-Banking-V.01.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData/ContractPacks"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/649/Banking/download/V.01",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/A2D6C091.zip",
     "download_size": 78635,
     "x_generated_by": "netkan"
 }

--- a/ContractConfigurator-KerbinSideJobs/ContractConfigurator-KerbinSideJobs-1.5.ckan
+++ b/ContractConfigurator-KerbinSideJobs/ContractConfigurator-KerbinSideJobs-1.5.ckan
@@ -26,7 +26,7 @@
             "install_to": "GameData/ContractPacks"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/812/Kerbin-SideJobs/download/1.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/2F2DD709.zip",
     "download_size": 127380,
     "x_generated_by": "netkan"
 }

--- a/CrewFiles/CrewFiles-2.1.ckan
+++ b/CrewFiles/CrewFiles-2.1.ckan
@@ -15,7 +15,7 @@
     },
     "version": "2.1",
     "ksp_version": "0.90.0",
-    "download": "https://kerbalstuff.com/mod/39/CrewFiles/download/2.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/5FEA61D7.zip",
     "download_size": 32206,
     "x_generated_by": "netkan"
 }

--- a/DefaultActionGroups/DefaultActionGroups-1.0.ckan
+++ b/DefaultActionGroups/DefaultActionGroups-1.0.ckan
@@ -28,7 +28,7 @@
             "install_to": "GameData/DefaultActionGroups"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1275/DefaultActionGroups/download/1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/0E954CC3.zip",
     "download_size": 33850,
     "x_generated_by": "netkan"
 }

--- a/EVAManager/EVAManager-6.ckan
+++ b/EVAManager/EVAManager-6.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/726/EVAManager/download/6",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/2A6DF773.zip",
     "download_size": 22751,
     "x_generated_by": "netkan"
 }

--- a/EditorExtensionsRedux/EditorExtensionsRedux-3.0.0.ckan
+++ b/EditorExtensionsRedux/EditorExtensionsRedux-3.0.0.ckan
@@ -12,7 +12,7 @@
     "version": "3.0.0",
     "ksp_version_min": "1.0.0",
     "ksp_version_max": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/1342/EditorExtensionsRedux/download/3.0.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/0AD5233A.zip",
     "download_size": 27134,
     "x_generated_by": "netkan"
 }

--- a/EditorExtensionsRedux/EditorExtensionsRedux-3.0.1.ckan
+++ b/EditorExtensionsRedux/EditorExtensionsRedux-3.0.1.ckan
@@ -13,7 +13,7 @@
     "version": "3.0.1",
     "ksp_version_min": "1.0.2",
     "ksp_version_max": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/1342/EditorExtensionsRedux/download/3.0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C376F1DA.zip",
     "download_size": 27095,
     "x_generated_by": "netkan"
 }

--- a/EditorExtensionsRedux/EditorExtensionsRedux-3.0.2.ckan
+++ b/EditorExtensionsRedux/EditorExtensionsRedux-3.0.2.ckan
@@ -13,7 +13,7 @@
     "version": "3.0.2",
     "ksp_version_min": "1.0.2",
     "ksp_version_max": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/1342/EditorExtensionsRedux/download/3.0.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/EFC02F1E.zip",
     "download_size": 43724,
     "x_generated_by": "netkan"
 }

--- a/EditorTime/EditorTime-1.0.1.ckan
+++ b/EditorTime/EditorTime-1.0.1.ckan
@@ -25,7 +25,7 @@
             "filter": "EditorTime.cs"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1091/EditorTime/download/1.0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/36AE6351.zip",
     "download_size": 12947,
     "x_generated_by": "netkan"
 }

--- a/ElectricCost/ElectricCost-1.0.1.ckan
+++ b/ElectricCost/ElectricCost-1.0.1.ckan
@@ -16,7 +16,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1072/ElectricCost/download/1.0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/5E3F6871.zip",
     "download_size": 232,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/EngineLighting/EngineLighting-1.4.0.ckan
+++ b/EngineLighting/EngineLighting-1.4.0.ckan
@@ -25,7 +25,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/817/EngineLighting/download/1.4.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/506698D4.zip",
     "download_size": 50715,
     "x_generated_by": "netkan"
 }

--- a/EngineLighting/EngineLighting-1.4.1.ckan
+++ b/EngineLighting/EngineLighting-1.4.1.ckan
@@ -25,7 +25,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/817/EngineLighting/download/1.4.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/7CA9F0E0.zip",
     "download_size": 51544,
     "x_generated_by": "netkan"
 }

--- a/EngineResponseTime/EngineResponseTime-1.0.5.ckan
+++ b/EngineResponseTime/EngineResponseTime-1.0.5.ckan
@@ -16,7 +16,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1123/EngineResponseTime/download/1.0.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/DB8EFE2F.zip",
     "download_size": 354,
     "x_generated_by": "netkan"
 }

--- a/Entropy/Entropy-v0.5.1.ckan
+++ b/Entropy/Entropy-v0.5.1.ckan
@@ -35,7 +35,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/388/Entropy/download/v0.5.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/CF4434E9.zip",
     "download_size": 15180,
     "x_generated_by": "netkan"
 }

--- a/EntropyRealChute/EntropyRealChute-v0.5.1.ckan
+++ b/EntropyRealChute/EntropyRealChute-v0.5.1.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/388/Entropy/download/v0.5.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/CF4434E9.zip",
     "download_size": 15180,
     "x_generated_by": "netkan"
 }

--- a/EvaFuel/EvaFuel-0.0.2.ckan
+++ b/EvaFuel/EvaFuel-0.0.2.ckan
@@ -14,7 +14,7 @@
     "version": "0.0.2",
     "ksp_version_min": "0.24.2",
     "ksp_version_max": "1.0.99",
-    "download": "https://kerbalstuff.com/mod/198/EvaFuel/download/0.0.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4FC5B1A4.zip",
     "download_size": 2949,
     "x_generated_by": "netkan"
 }

--- a/ExceptionDetector/ExceptionDetector-v.1.1.ckan
+++ b/ExceptionDetector/ExceptionDetector-v.1.1.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/557/ExceptionDetector/download/v.1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C72E288A.zip",
     "download_size": 5290,
     "x_generated_by": "netkan"
 }

--- a/Farscape/Farscape-4.ckan
+++ b/Farscape/Farscape-4.ckan
@@ -26,7 +26,7 @@
             "install_to": "GameData/Mike_NZ_Crafts"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1176/Farscape/download/4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/FC7D40DA.zip",
     "download_size": 6276310,
     "x_generated_by": "netkan"
 }

--- a/FlagRotate/FlagRotate-1.1.1.ckan
+++ b/FlagRotate/FlagRotate-1.1.1.ckan
@@ -13,7 +13,7 @@
     },
     "version": "1.1.1",
     "ksp_version": "1.0.4",
-    "download": "https://kerbalstuff.com/mod/588/FlagRotate/download/1.1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/6044D897.zip",
     "download_size": 5532,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/FlagRotate/FlagRotate-1.1.2.ckan
+++ b/FlagRotate/FlagRotate-1.1.2.ckan
@@ -13,7 +13,7 @@
     },
     "version": "1.1.2",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/588/FlagRotate/download/1.1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/1EB0002C.zip",
     "download_size": 5501,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/G-Effects/G-Effects-0.2.3.ckan
+++ b/G-Effects/G-Effects-0.2.3.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.2.3",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/925/G-Effects/download/0.2.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/26854DDD.zip",
     "download_size": 736126,
     "x_generated_by": "netkan"
 }

--- a/G-Effects/G-Effects-0.3.1.ckan
+++ b/G-Effects/G-Effects-0.3.1.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.3.1",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/925/G-Effects/download/0.3.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/81B7B9C1.zip",
     "download_size": 735192,
     "x_generated_by": "netkan"
 }

--- a/GeometricShapeAeroTests/GeometricShapeAeroTests-0.2f.ckan
+++ b/GeometricShapeAeroTests/GeometricShapeAeroTests-0.2f.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/757/GeometricShapeAeroTests/download/0.2f",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B1068368.zip",
     "download_size": 12145599,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/Goodspeed/Goodspeed-1.4.ckan
+++ b/Goodspeed/Goodspeed-1.4.ckan
@@ -20,7 +20,7 @@
             "filter": "sourcecode"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/722/GPOSpeedFuelPump/download/1.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/069D109E.zip",
     "download_size": 24972,
     "x_generated_by": "netkan"
 }

--- a/Hangar/Hangar-2.3.1.ckan
+++ b/Hangar/Hangar-2.3.1.ckan
@@ -40,7 +40,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/270/Hangar/download/2.3.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/782DFE3C.zip",
     "download_size": 22777233,
     "x_generated_by": "netkan"
 }

--- a/Historian/Historian-1.1.1.ckan
+++ b/Historian/Historian-1.1.1.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/821/Historian/download/1.1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/628D324A.zip",
     "download_size": 40209,
     "x_generated_by": "netkan"
 }

--- a/HotRockets/HotRockets-1.0.4.1.ckan
+++ b/HotRockets/HotRockets-1.0.4.1.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/741/HotRockets/download/1.0.4.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/47AB60EB.zip",
     "download_size": 2280347,
     "x_generated_by": "netkan"
 }

--- a/ImprovedStrategies/ImprovedStrategies-0.131.ckan
+++ b/ImprovedStrategies/ImprovedStrategies-0.131.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/423/ImprovedStrategies/download/0.131",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/64B82DA4.zip",
     "download_size": 3489,
     "x_generated_by": "netkan"
 }

--- a/KSP-64k-12HourDay/KSP-64k-12HourDay-v1.1.2.ckan
+++ b/KSP-64k-12HourDay/KSP-64k-12HourDay-v1.1.2.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/573/64K/download/v1.1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3CBC8FE8.zip",
     "download_size": 12488810,
     "asbtract": "Add-on to 64k to scale the rotation period of Kerbin and other worlds appropriately to the size of the system.",
     "x_generated_by": "netkan"

--- a/KSP-64k-imgviewer/KSP-64k-imgviewer-v1.1.2.ckan
+++ b/KSP-64k-imgviewer/KSP-64k-imgviewer-v1.1.2.ckan
@@ -27,7 +27,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/573/64K/download/v1.1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3CBC8FE8.zip",
     "download_size": 12488810,
     "asbtract": "Adds the delta-V map for the 6.4x scaled Kerbin System to the game as an in-game viewable item using the ImageViewer mod.",
     "x_generated_by": "netkan"

--- a/KSP-64k/KSP-64k-v1.1.2.ckan
+++ b/KSP-64k/KSP-64k-v1.1.2.ckan
@@ -45,7 +45,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/573/64K/download/v1.1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3CBC8FE8.zip",
     "download_size": 12488810,
     "x_generated_by": "netkan"
 }

--- a/KSPIRC/KSPIRC-0.14.5.2.ckan
+++ b/KSPIRC/KSPIRC-0.14.5.2.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.14.5.2",
     "ksp_version": "1.0.4",
-    "download": "https://kerbalstuff.com/mod/422/KSPIRC/download/0.14.5.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C21B7202.zip",
     "download_size": 183809,
     "x_generated_by": "netkan"
 }

--- a/KScale2/KScale2-1.1.0.2.ckan
+++ b/KScale2/KScale2-1.1.0.2.ckan
@@ -20,7 +20,7 @@
             "name": "Kopernicus"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/905/KScale2/download/1.1.0.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/AE29C55B.zip",
     "download_size": 5869602,
     "ksp_min_version": "1.0",
     "x_generated_by": "netkan"

--- a/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.0.ckan
+++ b/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.0.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData/KWCommunityFixes"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/0DC69D6E.zip",
     "download_size": 5676,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.1.ckan
+++ b/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.1.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData/KWCommunityFixes"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/84C78D70.zip",
     "download_size": 5677,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.2.ckan
+++ b/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.2.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData/KWCommunityFixes"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/9AEFB4A8.zip",
     "download_size": 5661,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.3.ckan
+++ b/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.3.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData/KWCommunityFixes"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/9C3BFDFF.zip",
     "download_size": 4921,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.4.ckan
+++ b/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.4.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData/KWCommunityFixes"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B657F70A.zip",
     "download_size": 5611,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.5.ckan
+++ b/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.5.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData/KWCommunityFixes"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/F5796641.zip",
     "download_size": 22278,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.6.ckan
+++ b/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.6.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData/KWCommunityFixes"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.6",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/481817FE.zip",
     "download_size": 22317,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.0.ckan
+++ b/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.0.ckan
@@ -34,7 +34,7 @@
             "filter": "KWPatch-interstage.cfg"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/0DC69D6E.zip",
     "download_size": 5676,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.1.ckan
+++ b/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.1.ckan
@@ -34,7 +34,7 @@
             "filter": "KWPatch-interstage.cfg"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/84C78D70.zip",
     "download_size": 5677,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.2.ckan
+++ b/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.2.ckan
@@ -34,7 +34,7 @@
             "filter": "KWPatch-interstage.cfg"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/9AEFB4A8.zip",
     "download_size": 5661,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.3.ckan
+++ b/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.3.ckan
@@ -34,7 +34,7 @@
             "filter": "KWPatch-interstage.cfg"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/9C3BFDFF.zip",
     "download_size": 4921,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.4.ckan
+++ b/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.4.ckan
@@ -34,7 +34,7 @@
             "filter": "KWPatch-interstage.cfg"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B657F70A.zip",
     "download_size": 5611,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.5.ckan
+++ b/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.5.ckan
@@ -34,7 +34,7 @@
             "filter": "KWPatch-interstage.cfg"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/F5796641.zip",
     "download_size": 22278,
     "x_generated_by": "netkan"
 }

--- a/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.6.ckan
+++ b/KWRocketry-CommunityFixes/KWRocketry-CommunityFixes-0.4.6.ckan
@@ -34,7 +34,7 @@
             "filter": "KWPatch-interstage.cfg"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes/download/0.4.6",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/481817FE.zip",
     "download_size": 22317,
     "x_generated_by": "netkan"
 }

--- a/KabinKraziness/KabinKraziness-V0.3.2.ckan
+++ b/KabinKraziness/KabinKraziness-V0.3.2.ckan
@@ -34,7 +34,7 @@
             "filter_regexp": "KKInterfaces.dll"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/684/KabinKraziness/download/V0.3.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/5EBE71E1.zip",
     "download_size": 55459,
     "x_generated_by": "netkan"
 }

--- a/KeepFit/KeepFit-0.8.3.3.ckan
+++ b/KeepFit/KeepFit-0.8.3.3.ckan
@@ -26,7 +26,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/295/keepfit/download/0.8.3.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/0CB28B78.zip",
     "download_size": 89195,
     "x_generated_by": "netkan"
 }

--- a/KeepFit/KeepFit-0.8.4.3.ckan
+++ b/KeepFit/KeepFit-0.8.4.3.ckan
@@ -26,7 +26,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/295/keepfit/download/0.8.4.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/AFD9A633.zip",
     "download_size": 89122,
     "x_generated_by": "netkan"
 }

--- a/KerbalKrashSystem/KerbalKrashSystem-0.04.ckan
+++ b/KerbalKrashSystem/KerbalKrashSystem-0.04.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1389/KerbalKrashSystem/download/0.04",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/6DCB7045.zip",
     "download_size": 62546,
     "x_generated_by": "netkan"
 }

--- a/KerbalKrashSystem/KerbalKrashSystem-0.2.ckan
+++ b/KerbalKrashSystem/KerbalKrashSystem-0.2.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1389/KerbalKrashSystem/download/0.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/904B0FAA.zip",
     "download_size": 66678,
     "x_generated_by": "netkan"
 }

--- a/KerbalMass/KerbalMass-1.0.ckan
+++ b/KerbalMass/KerbalMass-1.0.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/567/KerbalMass/download/1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/D6D278F3.zip",
     "download_size": 49524,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/Kerbalert/Kerbalert-0.1.ckan
+++ b/Kerbalert/Kerbalert-0.1.ckan
@@ -12,7 +12,7 @@
     },
     "version": "0.1",
     "ksp_version": "1.0.2",
-    "download": "https://kerbalstuff.com/mod/809/Kerbalert/download/0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/F29984B5.zip",
     "download_size": 404661,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/Kerbanomics/Kerbanomics-0.1.8.ckan
+++ b/Kerbanomics/Kerbanomics-0.1.8.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/427/Kerbanomics/download/0.1.8",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/EB5154A4.zip",
     "download_size": 16285,
     "x_generated_by": "netkan"
 }

--- a/KerbinSide/KerbinSide-1-1.0.5.ckan
+++ b/KerbinSide/KerbinSide-1-1.0.5.ckan
@@ -24,7 +24,7 @@
             "filter": "AirRace"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/77/KerbinSide/download/1.0.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C828CA4D.zip",
     "download_size": 60256780,
     "x_generated_by": "netkan"
 }

--- a/Kosmodrome/Kosmodrome-1.0.ckan
+++ b/Kosmodrome/Kosmodrome-1.0.ckan
@@ -17,7 +17,7 @@
             "name": "KerbalKonstructs"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/208/Kosmodrome/download/1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/5D709DA0.zip",
     "download_size": 4742819,
     "x_generated_by": "netkan"
 }

--- a/Kronkus/Kronkus-1.1.ckan
+++ b/Kronkus/Kronkus-1.1.ckan
@@ -22,7 +22,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1152/Kronkus/download/1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/8B88321F.zip",
     "download_size": 30326122,
     "x_generated_by": "netkan"
 }

--- a/Kronkus/Kronkus-v1.0.ckan
+++ b/Kronkus/Kronkus-v1.0.ckan
@@ -22,7 +22,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1152/Kronkus/download/v1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/A718222E.zip",
     "download_size": 31505429,
     "x_generated_by": "netkan"
 }

--- a/Kronkus/Kronkus-v1.1.ckan
+++ b/Kronkus/Kronkus-v1.1.ckan
@@ -22,7 +22,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1152/Kronkus/download/1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/8B88321F.zip",
     "download_size": 30326122,
     "x_generated_by": "netkan"
 }

--- a/Ktolemy/Ktolemy-0.2.ckan
+++ b/Ktolemy/Ktolemy-0.2.ckan
@@ -18,7 +18,7 @@
             "version": "1:beta-04"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1223/Ktolemy/download/0.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/2B05EE0A.zip",
     "download_size": 1358,
     "x_generated_by": "netkan"
 }

--- a/Kurrikane/Kurrikane-1.0.ckan
+++ b/Kurrikane/Kurrikane-1.0.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/939/Kurrikane/download/1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/2149CA86.zip",
     "download_size": 518112,
     "x_generated_by": "netkan"
 }

--- a/LLL-Extras/LLL-Extras-14.ckan
+++ b/LLL-Extras/LLL-Extras-14.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData/LLL-Extra"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/954/LLL/download/14",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C3E89178.zip",
     "download_size": 13028822,
     "x_generated_by": "netkan"
 }

--- a/LLL/LLL-14.ckan
+++ b/LLL/LLL-14.ckan
@@ -39,7 +39,7 @@
             "filter": "Parts"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/954/LLL/download/14",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C3E89178.zip",
     "download_size": 13028822,
     "x_generated_by": "netkan"
 }

--- a/LightsOut/LightsOut-v0.1.5.ckan
+++ b/LightsOut/LightsOut-v0.1.5.ckan
@@ -13,7 +13,7 @@
     },
     "version": "v0.1.5",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/678/LightsOut/download/v0.1.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B8472B00.zip",
     "download_size": 16433,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/MACH-5/MACH-5-0.12.ckan
+++ b/MACH-5/MACH-5-0.12.ckan
@@ -17,7 +17,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/587/MACH_5/download/0.12",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/57AAE784.zip",
     "download_size": 405350,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/MACH-5/MACH-5-1.0.ckan
+++ b/MACH-5/MACH-5-1.0.ckan
@@ -17,7 +17,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/587/MACH_5/download/1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/6F7EA8D5.zip",
     "download_size": 405350,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/MapViewPlus/MapViewPlus-0.1.1.ckan
+++ b/MapViewPlus/MapViewPlus-0.1.1.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.1.1",
     "ksp_version": "1.0.4",
-    "download": "https://kerbalstuff.com/mod/1122/MapViewPlus/download/0.1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/1787F324.zip",
     "download_size": 6225,
     "x_generated_by": "netkan"
 }

--- a/MemoryUsage/MemoryUsage-v1.20.ckan
+++ b/MemoryUsage/MemoryUsage-v1.20.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameRoot"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/317/MemoryUsage/download/v1.20",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/D583E347.zip",
     "download_size": 46017,
     "x_generated_by": "netkan"
 }

--- a/MicroFuels/MicroFuels-0.1.ckan
+++ b/MicroFuels/MicroFuels-0.1.ckan
@@ -25,7 +25,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/541/MicroFuels/download/0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/80267B15.zip",
     "download_size": 7123,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/ModuleSolarTracking/ModuleSolarTracking-0.1.ckan
+++ b/ModuleSolarTracking/ModuleSolarTracking-0.1.ckan
@@ -17,7 +17,7 @@
             "filter": "ModuleSolarTracking.cs"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1004/ModuleSolarTracking/download/0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3CC32C89.zip",
     "download_size": 2682,
     "x_generated_by": "netkan"
 }

--- a/MovieTime/MovieTime-0.5.0.ckan
+++ b/MovieTime/MovieTime-0.5.0.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/409/MovieTime/download/0.5.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/CA81F222.zip",
     "download_size": 1300281,
     "x_generated_by": "netkan"
 }

--- a/Multiports/Multiports-1.0.2.ckan
+++ b/Multiports/Multiports-1.0.2.ckan
@@ -17,7 +17,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1107/Multiports/download/1.0.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3A346C64.zip",
     "download_size": 1895,
     "x_generated_by": "netkan"
 }

--- a/MusicMute/MusicMute-1.1.0.ckan
+++ b/MusicMute/MusicMute-1.1.0.ckan
@@ -11,7 +11,7 @@
     },
     "version": "1.1.0",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/755/MusicMute/download/1.1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/ACB02333.zip",
     "download_size": 29213,
     "x_generated_by": "netkan"
 }

--- a/NanoGauges/NanoGauges-0.7.12-1388.ckan
+++ b/NanoGauges/NanoGauges-0.7.12-1388.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/429/NanoGauges/download/0.7.12-1388",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C0378A6A.zip",
     "download_size": 1478002,
     "x_generated_by": "netkan"
 }

--- a/NanoGauges/NanoGauges-0.7.13-1406.ckan
+++ b/NanoGauges/NanoGauges-0.7.13-1406.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/429/NanoGauges/download/0.7.13-1406",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C2367AC4.zip",
     "download_size": 1478136,
     "x_generated_by": "netkan"
 }

--- a/NanoGauges/NanoGauges-0.7.14-1488.ckan
+++ b/NanoGauges/NanoGauges-0.7.14-1488.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/429/NanoGauges/download/0.7.14-1488",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/BCA3E585.zip",
     "download_size": 1519027,
     "x_generated_by": "netkan"
 }

--- a/NanoGauges/NanoGauges-0.7.15-1500.ckan
+++ b/NanoGauges/NanoGauges-0.7.15-1500.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/429/NanoGauges/download/0.7.15-1500",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/5986BB77.zip",
     "download_size": 1540687,
     "x_generated_by": "netkan"
 }

--- a/NovaPunch/NovaPunch-2.09.ckan
+++ b/NovaPunch/NovaPunch-2.09.ckan
@@ -23,7 +23,7 @@
             "comment": "NovaPunch craft files"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/26/NovaPunch/download/2.09",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/867298B6.zip",
     "download_size": 59628660,
     "x_generated_by": "netkan"
 }

--- a/OpenTree/OpenTree-2.3.ckan
+++ b/OpenTree/OpenTree-2.3.ckan
@@ -17,7 +17,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/829/OpenTree/download/2.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/8AB4DFF0.zip",
     "download_size": 17321,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder-USILS-CommunityPatch/Pathfinder-USILS-CommunityPatch-0.4.0.ckan
+++ b/Pathfinder-USILS-CommunityPatch/Pathfinder-USILS-CommunityPatch-0.4.0.ckan
@@ -35,7 +35,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1180/Pathfinder-USILS-CommunityPatch/download/0.4.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/5032F80D.zip",
     "download_size": 2800,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder/Pathfinder-0.8.9.ckan
+++ b/Pathfinder/Pathfinder-0.8.9.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData/WildBlueIndustries"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/933/Pathfinder/download/0.8.9",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4FFF0B09.zip",
     "download_size": 13052366,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder/Pathfinder-0.9.0.ckan
+++ b/Pathfinder/Pathfinder-0.9.0.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData/WildBlueIndustries"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/933/Pathfinder/download/0.9.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/A6FD083E.zip",
     "download_size": 13614966,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder/Pathfinder-0.9.1.ckan
+++ b/Pathfinder/Pathfinder-0.9.1.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData/WildBlueIndustries"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/933/Pathfinder/download/0.9.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/392946F0.zip",
     "download_size": 13567715,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder/Pathfinder-0.9.2.ckan
+++ b/Pathfinder/Pathfinder-0.9.2.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData/WildBlueIndustries"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/933/Pathfinder/download/0.9.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/CBDAC560.zip",
     "download_size": 13795290,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder/Pathfinder-0.9.3.ckan
+++ b/Pathfinder/Pathfinder-0.9.3.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData/WildBlueIndustries"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/933/Pathfinder/download/0.9.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/5CACF908.zip",
     "download_size": 13627242,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder/Pathfinder-0.9.4.ckan
+++ b/Pathfinder/Pathfinder-0.9.4.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData/WildBlueIndustries"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/933/Pathfinder/download/0.9.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/CB1221F8.zip",
     "download_size": 14365325,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder/Pathfinder-0.9.5.ckan
+++ b/Pathfinder/Pathfinder-0.9.5.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData/WildBlueIndustries"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/933/Pathfinder/download/0.9.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/1663F089.zip",
     "download_size": 14380680,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder/Pathfinder-0.9.6.ckan
+++ b/Pathfinder/Pathfinder-0.9.6.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData/WildBlueIndustries"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/933/Pathfinder/download/0.9.6",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/BB017768.zip",
     "download_size": 15677121,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder/Pathfinder-0.9.7.ckan
+++ b/Pathfinder/Pathfinder-0.9.7.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData/WildBlueIndustries"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/933/Pathfinder/download/0.9.7",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/EEB11646.zip",
     "download_size": 16334566,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder/Pathfinder-0.9.8.a.ckan
+++ b/Pathfinder/Pathfinder-0.9.8.a.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData/WildBlueIndustries"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/933/Pathfinder/download/0.9.8.a",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4CF4661A.zip",
     "download_size": 16331683,
     "x_generated_by": "netkan"
 }

--- a/Pathfinder/Pathfinder-0.9.9.ckan
+++ b/Pathfinder/Pathfinder-0.9.9.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData/WildBlueIndustries"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/933/Pathfinder/download/0.9.9",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/59661A93.zip",
     "download_size": 16331837,
     "x_generated_by": "netkan"
 }

--- a/PersistentRotation/PersistentRotation-1.0.0.ckan
+++ b/PersistentRotation/PersistentRotation-1.0.0.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/668/PersistentRotation/download/1.0.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C0138B4D.zip",
     "download_size": 34084,
     "x_generated_by": "netkan"
 }

--- a/PersistentRotation/PersistentRotation-1.0.1.ckan
+++ b/PersistentRotation/PersistentRotation-1.0.1.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/668/PersistentRotation/download/1.0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/5737EBEA.zip",
     "download_size": 35882,
     "x_generated_by": "netkan"
 }

--- a/PersistentRotation/PersistentRotation-1.0.2.ckan
+++ b/PersistentRotation/PersistentRotation-1.0.2.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/668/PersistentRotation/download/1.0.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/60F9E43B.zip",
     "download_size": 36793,
     "x_generated_by": "netkan"
 }

--- a/PersistentTrails/PersistentTrails-1.2.ckan
+++ b/PersistentTrails/PersistentTrails-1.2.ckan
@@ -18,7 +18,7 @@
             "name": "Toolbar"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/796/PersistentTrails/download/1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/F3FDBD30.zip",
     "download_size": 71313,
     "x_generated_by": "netkan"
 }

--- a/PlanetScrambler/PlanetScrambler-0.1.ckan
+++ b/PlanetScrambler/PlanetScrambler-0.1.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/768/PlanetScrambler/download/0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/DABCEE36.zip",
     "download_size": 10468,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.3.1.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.3.1.ckan
@@ -33,7 +33,7 @@
             "install_to": "GameData/PlanetShine"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/266/PlanetShine/download/0.2.3.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/2605EA36.zip",
     "download_size": 46312,
     "x_generated_by": "netkan"
 }

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.4.1.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.4.1.ckan
@@ -33,7 +33,7 @@
             "install_to": "GameData/PlanetShine"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/266/PlanetShine/download/0.2.4.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/90642852.zip",
     "download_size": 44872,
     "x_generated_by": "netkan"
 }

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.4.2.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.4.2.ckan
@@ -33,7 +33,7 @@
             "install_to": "GameData/PlanetShine"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/266/PlanetShine/download/0.2.4.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/9FF994F0.zip",
     "download_size": 44342,
     "x_generated_by": "netkan"
 }

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.4.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.4.ckan
@@ -33,7 +33,7 @@
             "install_to": "GameData/PlanetShine"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/266/PlanetShine/download/0.2.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/83ED8886.zip",
     "download_size": 47078,
     "x_generated_by": "netkan"
 }

--- a/PlanetShine/PlanetShine-0.2.3.1.ckan
+++ b/PlanetShine/PlanetShine-0.2.3.1.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData/PlanetShine"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/266/PlanetShine/download/0.2.3.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/2605EA36.zip",
     "download_size": 46312,
     "x_generated_by": "netkan"
 }

--- a/PlanetShine/PlanetShine-0.2.4.1.ckan
+++ b/PlanetShine/PlanetShine-0.2.4.1.ckan
@@ -50,7 +50,7 @@
             "filter": "Config"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/266/PlanetShine/download/0.2.4.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/90642852.zip",
     "download_size": 44872,
     "x_generated_by": "netkan"
 }

--- a/PlanetShine/PlanetShine-0.2.4.2.ckan
+++ b/PlanetShine/PlanetShine-0.2.4.2.ckan
@@ -50,7 +50,7 @@
             "filter": "Config"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/266/PlanetShine/download/0.2.4.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/9FF994F0.zip",
     "download_size": 44342,
     "x_generated_by": "netkan"
 }

--- a/PlanetShine/PlanetShine-0.2.4.ckan
+++ b/PlanetShine/PlanetShine-0.2.4.ckan
@@ -26,7 +26,7 @@
             "filter": "Config"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/266/PlanetShine/download/0.2.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/83ED8886.zip",
     "download_size": 47078,
     "x_generated_by": "netkan"
 }

--- a/PuntJeb/PuntJeb-1.0.ckan
+++ b/PuntJeb/PuntJeb-1.0.ckan
@@ -11,7 +11,7 @@
     },
     "version": "1.0",
     "ksp_version": "0.90.0",
-    "download": "https://kerbalstuff.com/mod/512/PuntJeb/download/1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/F56AFEA0.zip",
     "download_size": 5109,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/QArmory/QArmory-0.31.ckan
+++ b/QArmory/QArmory-0.31.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1150/QArmory/download/0.31",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/5477CBE5.zip",
     "download_size": 1999191,
     "x_generated_by": "netkan"
 }

--- a/QuantumStrutsContinued/QuantumStrutsContinued-1.4.ckan
+++ b/QuantumStrutsContinued/QuantumStrutsContinued-1.4.ckan
@@ -27,7 +27,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/168/QuantumStrutsContinued/download/1.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/0D09935B.zip",
     "download_size": 50773,
     "x_generated_by": "netkan"
 }

--- a/QuickBrake/QuickBrake-v1.10.ckan
+++ b/QuickBrake/QuickBrake-v1.10.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/764/QuickBrake/download/v1.10",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/636DD554.zip",
     "download_size": 55069,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/QuickContracts/QuickContracts-v1.03.ckan
+++ b/QuickContracts/QuickContracts-v1.03.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/539/QuickContracts/download/v1.03",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/62441463.zip",
     "download_size": 35213,
     "x_generated_by": "netkan"
 }

--- a/QuickExit/QuickExit-v1.31.ckan
+++ b/QuickExit/QuickExit-v1.31.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/341/QuickExit/download/v1.31",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/D7262E82.zip",
     "download_size": 60132,
     "x_generated_by": "netkan"
 }

--- a/QuickGoTo/QuickGoTo-v1.20.ckan
+++ b/QuickGoTo/QuickGoTo-v1.20.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/653/QuickGoTo/download/v1.20",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4FE4EEFE.zip",
     "download_size": 72587,
     "x_generated_by": "netkan"
 }

--- a/QuickGoTo/QuickGoTo-v1.21.ckan
+++ b/QuickGoTo/QuickGoTo-v1.21.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/653/QuickGoTo/download/v1.21",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/F07B374C.zip",
     "download_size": 73065,
     "x_generated_by": "netkan"
 }

--- a/QuickHide/QuickHide-v3.03.ckan
+++ b/QuickHide/QuickHide-v3.03.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/396/QuickHide/download/v3.03",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/29D3A44E.zip",
     "download_size": 48866,
     "x_generated_by": "netkan"
 }

--- a/QuickHide/QuickHide-v3.03a.ckan
+++ b/QuickHide/QuickHide-v3.03a.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/396/QuickHide/download/v3.03a",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B62B6077.zip",
     "download_size": 48835,
     "x_generated_by": "netkan"
 }

--- a/QuickIVA/QuickIVA-v1.11.ckan
+++ b/QuickIVA/QuickIVA-v1.11.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/568/QuickIVA/download/v1.11",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B90A94E9.zip",
     "download_size": 44255,
     "x_generated_by": "netkan"
 }

--- a/QuickMute/QuickMute-v1.06.ckan
+++ b/QuickMute/QuickMute-v1.06.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/509/QuickMute/download/v1.06",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/6B1844A0.zip",
     "download_size": 44811,
     "x_generated_by": "netkan"
 }

--- a/QuickRevert/QuickRevert-v2.11.ckan
+++ b/QuickRevert/QuickRevert-v2.11.ckan
@@ -18,7 +18,7 @@
             "name": "SRL"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/237/QuickRevert/download/v2.11",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/33B0A114.zip",
     "download_size": 93978,
     "x_generated_by": "netkan"
 }

--- a/QuickRevert/QuickRevert-v2.12.ckan
+++ b/QuickRevert/QuickRevert-v2.12.ckan
@@ -18,7 +18,7 @@
             "name": "SRL"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/237/QuickRevert/download/v2.12",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/DF46D3FF.zip",
     "download_size": 94054,
     "x_generated_by": "netkan"
 }

--- a/QuickScroll/QuickScroll-v1.32.ckan
+++ b/QuickScroll/QuickScroll-v1.32.ckan
@@ -18,7 +18,7 @@
             "name": "PartCatalog"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/436/QuickScroll/download/v1.32",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/30CFA394.zip",
     "download_size": 109230,
     "x_generated_by": "netkan"
 }

--- a/QuickSearch/QuickSearch-v1.14.ckan
+++ b/QuickSearch/QuickSearch-v1.14.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/472/QuickSearch/download/v1.14",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/7C52F7C5.zip",
     "download_size": 61906,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/QuickSearch/QuickSearch-v1.20.ckan
+++ b/QuickSearch/QuickSearch-v1.20.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/472/QuickSearch/download/v1.20",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/116B405A.zip",
     "download_size": 73185,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/QuickSearch/QuickSearch-v1.21.ckan
+++ b/QuickSearch/QuickSearch-v1.21.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/472/QuickSearch/download/v1.21",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/36B2A0F1.zip",
     "download_size": 73306,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/QuickStart/QuickStart-v1.12.ckan
+++ b/QuickStart/QuickStart-v1.12.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/763/QuickStart/download/v1.12",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/E2C0BDA4.zip",
     "download_size": 32282,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/QuizTech/QuizTech-1.2.1.ckan
+++ b/QuizTech/QuizTech-1.2.1.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/530/QuizTech/download/1.2.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/7AC9701E.zip",
     "download_size": 1414771,
     "x_generated_by": "netkan"
 }

--- a/RadiatorToggle/RadiatorToggle-1.1.ckan
+++ b/RadiatorToggle/RadiatorToggle-1.1.ckan
@@ -18,7 +18,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1274/RadiatorToggle/download/1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/66C68A76.zip",
     "download_size": 33520,
     "x_generated_by": "netkan"
 }

--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.24.0.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.24.0.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/734/RasterPropMonitor/download/v0.24.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/22B0DF97.zip",
     "download_size": 805209,
     "x_generated_by": "netkan"
 }

--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.24.1.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.24.1.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/734/RasterPropMonitor/download/v0.24.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/A3A17DD4.zip",
     "download_size": 813803,
     "x_generated_by": "netkan"
 }

--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.24.2.1.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.24.2.1.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/734/RasterPropMonitor/download/v0.24.2.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C00A5938.zip",
     "download_size": 815878,
     "x_generated_by": "netkan"
 }

--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.24.2.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-v0.24.2.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/734/RasterPropMonitor/download/v0.24.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/41EA1E66.zip",
     "download_size": 816297,
     "x_generated_by": "netkan"
 }

--- a/RasterPropMonitor/RasterPropMonitor-v0.24.0.ckan
+++ b/RasterPropMonitor/RasterPropMonitor-v0.24.0.ckan
@@ -41,7 +41,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/734/RasterPropMonitor/download/v0.24.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/22B0DF97.zip",
     "download_size": 805209,
     "x_generated_by": "netkan"
 }

--- a/RasterPropMonitor/RasterPropMonitor-v0.24.1.ckan
+++ b/RasterPropMonitor/RasterPropMonitor-v0.24.1.ckan
@@ -41,7 +41,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/734/RasterPropMonitor/download/v0.24.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/A3A17DD4.zip",
     "download_size": 813803,
     "x_generated_by": "netkan"
 }

--- a/RasterPropMonitor/RasterPropMonitor-v0.24.2.1.ckan
+++ b/RasterPropMonitor/RasterPropMonitor-v0.24.2.1.ckan
@@ -41,7 +41,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/734/RasterPropMonitor/download/v0.24.2.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C00A5938.zip",
     "download_size": 815878,
     "x_generated_by": "netkan"
 }

--- a/RasterPropMonitor/RasterPropMonitor-v0.24.2.ckan
+++ b/RasterPropMonitor/RasterPropMonitor-v0.24.2.ckan
@@ -41,7 +41,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/734/RasterPropMonitor/download/v0.24.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/41EA1E66.zip",
     "download_size": 816297,
     "x_generated_by": "netkan"
 }

--- a/Rejector/Rejector-1.2.0.ckan
+++ b/Rejector/Rejector-1.2.0.ckan
@@ -12,7 +12,7 @@
     },
     "version": "1.2.0",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/531/Rejector/download/1.2.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/720E1EE5.zip",
     "download_size": 11329,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/RemoteEverything/RemoteEverything-0.1.0.ckan
+++ b/RemoteEverything/RemoteEverything-0.1.0.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1104/RemoteEverything/download/0.1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/9C6ABA93.zip",
     "download_size": 16983,
     "x_generated_by": "netkan"
 }

--- a/ResearchBodies/ResearchBodies-1.5.ckan
+++ b/ResearchBodies/ResearchBodies-1.5.ckan
@@ -15,7 +15,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1203/ResearchBodies/download/1.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/795014AA.zip",
     "download_size": 987666,
     "x_generated_by": "netkan"
 }

--- a/ResearchBodies/ResearchBodies-1.6.ckan
+++ b/ResearchBodies/ResearchBodies-1.6.ckan
@@ -15,7 +15,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1203/ResearchBodies/download/1.6",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/6E539FB2.zip",
     "download_size": 992165,
     "x_generated_by": "netkan"
 }

--- a/RoboBrakes/RoboBrakes-0.4.1.ckan
+++ b/RoboBrakes/RoboBrakes-0.4.1.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1041/RoboBrakes/download/0.4.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/DF4CEB95.zip",
     "download_size": 44931,
     "x_generated_by": "netkan"
 }

--- a/RoboBrakes/RoboBrakes-v0.3.1.ckan
+++ b/RoboBrakes/RoboBrakes-v0.3.1.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1041/RoboBrakes/download/v0.3.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B322B5E5.zip",
     "download_size": 43014,
     "x_generated_by": "netkan"
 }

--- a/RoboBrakes/RoboBrakes-v0.4.ckan
+++ b/RoboBrakes/RoboBrakes-v0.4.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1041/RoboBrakes/download/v0.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B742C0C3.zip",
     "download_size": 45625,
     "x_generated_by": "netkan"
 }

--- a/RocketWatch/RocketWatch-1.2.ckan
+++ b/RocketWatch/RocketWatch-1.2.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/616/RocketWatch/download/1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/A93658E6.zip",
     "download_size": 159617,
     "x_generated_by": "netkan"
 }

--- a/RoverSpeed/RoverSpeed-0.9.2.ckan
+++ b/RoverSpeed/RoverSpeed-0.9.2.ckan
@@ -20,7 +20,7 @@
             "min_version": "2.6.0"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/936/RoverSpeed/download/0.9.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/44616F0B.zip",
     "download_size": 1531,
     "x_generated_by": "netkan"
 }

--- a/SAVE/SAVE-1.0.6-1190.ckan
+++ b/SAVE/SAVE-1.0.6-1190.ckan
@@ -20,7 +20,7 @@
             "filter": "source"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/466/S.A.V.E/download/1.0.6-1190",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/75B45C79.zip",
     "download_size": 45557,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/SAVE/SAVE-1.1.1-1239.ckan
+++ b/SAVE/SAVE-1.1.1-1239.ckan
@@ -20,7 +20,7 @@
             "filter": "source"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/466/S.A.V.E/download/1.1.1-1239",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/ABF8BE7D.zip",
     "download_size": 46992,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/SAVE/SAVE-1.2.2-1272.ckan
+++ b/SAVE/SAVE-1.2.2-1272.ckan
@@ -20,7 +20,7 @@
             "filter": "source"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/466/S.A.V.E/download/1.2.2-1272",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C984DC70.zip",
     "download_size": 93974,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/SAVE/SAVE-1.2.4-1314.ckan
+++ b/SAVE/SAVE-1.2.4-1314.ckan
@@ -20,7 +20,7 @@
             "filter": "source"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/466/S.A.V.E/download/1.2.4-1314",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/E0EBCAE0.zip",
     "download_size": 94538,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/SETI-Greenhouse/SETI-Greenhouse-0.9.3.ckan
+++ b/SETI-Greenhouse/SETI-Greenhouse-0.9.3.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/663/SETI-Greenhouse/download/0.9.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4DE2BAE6.zip",
     "download_size": 1155353,
     "x_generated_by": "netkan"
 }

--- a/SHADO/SHADO-4.0.ckan
+++ b/SHADO/SHADO-4.0.ckan
@@ -24,7 +24,7 @@
             "filter": "Thumbs.db"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1168/SHADO/download/4.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/7EAE5888.zip",
     "download_size": 18225123,
     "x_generated_by": "netkan"
 }

--- a/SafeChute/SafeChute-v1.8.0.ckan
+++ b/SafeChute/SafeChute-v1.8.0.ckan
@@ -14,7 +14,7 @@
     },
     "version": "v1.8.0",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/360/SafeChute/download/v1.8.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/0FCF555B.zip",
     "download_size": 6295,
     "x_generated_by": "netkan"
 }

--- a/Scatterer/Scatterer-1-v0.0215.ckan
+++ b/Scatterer/Scatterer-1-v0.0215.ckan
@@ -20,7 +20,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/700/Scatterer/download/v0.0215",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/CEA34239.zip",
     "download_size": 67483453,
     "x_generated_by": "netkan"
 }

--- a/Scatterer/Scatterer-1-v0.0216.ckan
+++ b/Scatterer/Scatterer-1-v0.0216.ckan
@@ -20,7 +20,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/700/Scatterer/download/v0.0216",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/60BF5D36.zip",
     "download_size": 67483879,
     "x_generated_by": "netkan"
 }

--- a/Scatterer/Scatterer-1-v0.0218.ckan
+++ b/Scatterer/Scatterer-1-v0.0218.ckan
@@ -20,7 +20,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/700/Scatterer/download/v0.0218",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/BE3D5ADD.zip",
     "download_size": 67517630,
     "x_generated_by": "netkan"
 }

--- a/Scatterer/Scatterer-1-v0.02182.ckan
+++ b/Scatterer/Scatterer-1-v0.02182.ckan
@@ -20,7 +20,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/700/Scatterer/download/v0.02182",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/DDBE1783.zip",
     "download_size": 67519972,
     "x_generated_by": "netkan"
 }

--- a/Scatterer/Scatterer-1-v0.021c.ckan
+++ b/Scatterer/Scatterer-1-v0.021c.ckan
@@ -20,7 +20,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/700/Scatterer/download/v0.021c",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/6AC18AA5.zip",
     "download_size": 66727409,
     "x_generated_by": "netkan"
 }

--- a/Scatterer/Scatterer-1-v0.022.ckan
+++ b/Scatterer/Scatterer-1-v0.022.ckan
@@ -20,7 +20,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/700/Scatterer/download/v0.022",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/EE93EA07.zip",
     "download_size": 67497849,
     "x_generated_by": "netkan"
 }

--- a/Scatterer/Scatterer-2-v0.022.ckan
+++ b/Scatterer/Scatterer-2-v0.022.ckan
@@ -20,7 +20,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/700/Scatterer/download/v0.022",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/EE93EA07.zip",
     "download_size": 67497849,
     "x_generated_by": "netkan"
 }

--- a/Scatterer/Scatterer-v0.019.ckan
+++ b/Scatterer/Scatterer-v0.019.ckan
@@ -20,7 +20,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/700/Scatterer/download/v0.019",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/50218C49.zip",
     "download_size": 81663906,
     "x_generated_by": "netkan"
 }

--- a/Scatterer/Scatterer-v0.0191.ckan
+++ b/Scatterer/Scatterer-v0.0191.ckan
@@ -20,7 +20,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/700/Scatterer/download/v0.0191",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/ED40369B.zip",
     "download_size": 81663893,
     "x_generated_by": "netkan"
 }

--- a/Scatterer/Scatterer-v0.0195.ckan
+++ b/Scatterer/Scatterer-v0.0195.ckan
@@ -20,7 +20,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/700/Scatterer/download/v0.0195",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C2378985.zip",
     "download_size": 93497721,
     "x_generated_by": "netkan"
 }

--- a/Scatterer/Scatterer-v0.021c.ckan
+++ b/Scatterer/Scatterer-v0.021c.ckan
@@ -20,7 +20,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/700/Scatterer/download/v0.021c",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/6AC18AA5.zip",
     "download_size": 66727409,
     "x_generated_by": "netkan"
 }

--- a/ScienceAlert/ScienceAlert-1.8.9.ckan
+++ b/ScienceAlert/ScienceAlert-1.8.9.ckan
@@ -13,7 +13,7 @@
     },
     "version": "1.8.9",
     "ksp_version": "1.0.4",
-    "download": "https://kerbalstuff.com/mod/424/ScienceAlert/download/1.8.9",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/ED8850DC.zip",
     "download_size": 465547,
     "x_generated_by": "netkan"
 }

--- a/ScienceSituationInfo/ScienceSituationInfo-1.0.ckan
+++ b/ScienceSituationInfo/ScienceSituationInfo-1.0.ckan
@@ -20,7 +20,7 @@
             "filter": "Thumbs.db"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1172/ScienceSituationInfo/download/1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4AF87B57.zip",
     "download_size": 25439,
     "x_generated_by": "netkan"
 }

--- a/ScreenMessageHider/ScreenMessageHider-1.2.ckan
+++ b/ScreenMessageHider/ScreenMessageHider-1.2.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1060/ScreenMessageHider/download/1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/02A71FEE.zip",
     "download_size": 2515,
     "x_generated_by": "netkan"
 }

--- a/ShowAllFuels/ShowAllFuels-1.ckan
+++ b/ShowAllFuels/ShowAllFuels-1.ckan
@@ -22,7 +22,7 @@
             "min_version": "2.5.1"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/354/ShowAllFuels/download/1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/002F24F8.zip",
     "download_size": 255,
     "x_generated_by": "netkan"
 }

--- a/SkyTonemapper/SkyTonemapper-0.1.ckan
+++ b/SkyTonemapper/SkyTonemapper-0.1.ckan
@@ -20,7 +20,7 @@
             "filter": "source"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1250/SkyTonemapper/download/0.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B470A8CF.zip",
     "download_size": 42486,
     "x_generated_by": "netkan"
 }

--- a/SmallFatTechnologies/SmallFatTechnologies-0.11.ckan
+++ b/SmallFatTechnologies/SmallFatTechnologies-0.11.ckan
@@ -24,7 +24,7 @@
             "filter": ".DS_Store"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/940/SmallFatTechnologies/download/0.11",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/80CDFFF6.zip",
     "download_size": 8259826,
     "x_generated_by": "netkan"
 }

--- a/Soylent/Soylent-0.2.ckan
+++ b/Soylent/Soylent-0.2.ckan
@@ -29,7 +29,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/891/Soylent/download/0.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C47FD879.zip",
     "download_size": 805802,
     "x_generated_by": "netkan"
 }

--- a/StageRecovery/StageRecovery-1.5.8.ckan
+++ b/StageRecovery/StageRecovery-1.5.8.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/97/StageRecovery/download/1.5.8",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/644B5406.zip",
     "download_size": 49111,
     "x_generated_by": "netkan"
 }

--- a/StageRecovery/StageRecovery-1.6.0.ckan
+++ b/StageRecovery/StageRecovery-1.6.0.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/97/StageRecovery/download/1.6.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/62F0980C.zip",
     "download_size": 53075,
     "x_generated_by": "netkan"
 }

--- a/StageRecovery/StageRecovery-1.6.1.ckan
+++ b/StageRecovery/StageRecovery-1.6.1.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/97/StageRecovery/download/1.6.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/174CBEA2.zip",
     "download_size": 53172,
     "x_generated_by": "netkan"
 }

--- a/StageRecovery/StageRecovery-1.6.2.ckan
+++ b/StageRecovery/StageRecovery-1.6.2.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/97/StageRecovery/download/1.6.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3FC9E77A.zip",
     "download_size": 53663,
     "x_generated_by": "netkan"
 }

--- a/StockLS/StockLS-1.0.2.ckan
+++ b/StockLS/StockLS-1.0.2.ckan
@@ -45,7 +45,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1210/StockLS/download/1.0.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/D723222B.zip",
     "download_size": 5866,
     "x_generated_by": "netkan"
 }

--- a/StockNoContracts/StockNoContracts-v1.01.ckan
+++ b/StockNoContracts/StockNoContracts-v1.01.ckan
@@ -18,7 +18,7 @@
             "min_version": "2.6.0"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/897/StockNoContracts/download/v1.01",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/8D737E52.zip",
     "download_size": 31174,
     "x_generated_by": "netkan"
 }

--- a/StockPlugins/StockPlugins-v1.11.ckan
+++ b/StockPlugins/StockPlugins-v1.11.ckan
@@ -42,7 +42,7 @@
             "name": "Telemachus"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/402/StockPlugins/download/v1.11",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/31AFC1E2.zip",
     "download_size": 37053,
     "x_generated_by": "netkan"
 }

--- a/StockRT/StockRT-v1.30.ckan
+++ b/StockRT/StockRT-v1.30.ckan
@@ -34,7 +34,7 @@
             "name": "ContractConfigurator-RemoteTech"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/327/StockRT/download/v1.30",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C89510FC.zip",
     "download_size": 36008,
     "x_generated_by": "netkan"
 }

--- a/StockSCANsat/StockSCANsat-v1.00.ckan
+++ b/StockSCANsat/StockSCANsat-v1.00.ckan
@@ -33,7 +33,7 @@
             "name": "AsteroidDay"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1126/StockSCANsat/download/v1.00",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/256FD30E.zip",
     "download_size": 52582,
     "x_generated_by": "netkan"
 }

--- a/Strategem/Strategem-1.1.ckan
+++ b/Strategem/Strategem-1.1.ckan
@@ -12,7 +12,7 @@
     },
     "version": "1.1",
     "ksp_version": "0.90.0",
-    "download": "https://kerbalstuff.com/mod/271/Strategem/download/1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B04CD8C0.zip",
     "download_size": 8741,
     "x_generated_by": "netkan"
 }

--- a/TechManager/TechManager-1.5-compat.ckan
+++ b/TechManager/TechManager-1.5-compat.ckan
@@ -12,6 +12,6 @@
     "abstract": "This mod will allow you to change the tech tree, including the creation of new tech nodes. ",
     "author": "anonish",
     "version": "1.5-compat",
-    "download": "https://kerbalstuff.com/mod/297/TechManager/download/1.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/DD419605.zip",
     "download_size": 39956
 }

--- a/TechManager/TechManager-1.5.ckan
+++ b/TechManager/TechManager-1.5.ckan
@@ -12,7 +12,7 @@
     },
     "version": "1.5",
     "ksp_version": "0.25.0",
-    "download": "https://kerbalstuff.com/mod/297/TechManager/download/1.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/DD419605.zip",
     "download_size": 39956,
     "x_generated_by": "netkan"
 }

--- a/TextureReplacer/TextureReplacer-2.4.11.ckan
+++ b/TextureReplacer/TextureReplacer-2.4.11.ckan
@@ -14,7 +14,7 @@
     },
     "version": "2.4.11",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/150/TextureReplacer/download/2.4.11",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3524EC49.zip",
     "download_size": 46586,
     "x_generated_by": "netkan"
 }

--- a/Thermometer/Thermometer-1.0.11.ckan
+++ b/Thermometer/Thermometer-1.0.11.ckan
@@ -24,7 +24,7 @@
             "filter": ".DS_Store"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/719/Thermometer/download/1.0.11",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/28FD87CC.zip",
     "download_size": 20306,
     "x_generated_by": "netkan"
 }

--- a/Thermometer/Thermometer-1.1.0.ckan
+++ b/Thermometer/Thermometer-1.1.0.ckan
@@ -24,7 +24,7 @@
             "filter": ".DS_Store"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/719/Thermometer/download/1.1.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B0C99F6B.zip",
     "download_size": 47819,
     "x_generated_by": "netkan"
 }

--- a/ToadicusTools/ToadicusTools-17.ckan
+++ b/ToadicusTools/ToadicusTools-17.ckan
@@ -17,7 +17,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/470/ToadicusTools/download/17",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/8A4E4BC5.zip",
     "download_size": 90342,
     "x_generated_by": "netkan"
 }

--- a/ToggleFuelCells/ToggleFuelCells-1.1.2.ckan
+++ b/ToggleFuelCells/ToggleFuelCells-1.1.2.ckan
@@ -22,7 +22,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1046/ToggleFuelCells/download/1.1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/DA375762.zip",
     "download_size": 30654,
     "x_generated_by": "netkan"
 }

--- a/ToggleFuelCells/ToggleFuelCells-1.1.ckan
+++ b/ToggleFuelCells/ToggleFuelCells-1.1.ckan
@@ -22,7 +22,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1046/ToggleFuelCells/download/1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/A34AD2F3.zip",
     "download_size": 29496,
     "x_generated_by": "netkan"
 }

--- a/TotalTime/TotalTime-0.5.0.ckan
+++ b/TotalTime/TotalTime-0.5.0.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1163/TotalTime/download/0.5.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/D6FCF4BD.zip",
     "download_size": 13796,
     "x_generated_by": "netkan"
 }

--- a/Trajectories/Trajectories-v1.4.3.ckan
+++ b/Trajectories/Trajectories-v1.4.3.ckan
@@ -17,7 +17,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/238/Trajectories/download/v1.4.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/567253A0.zip",
     "download_size": 65219,
     "x_generated_by": "netkan"
 }

--- a/Trajectories/Trajectories-v1.4.5.ckan
+++ b/Trajectories/Trajectories-v1.4.5.ckan
@@ -17,7 +17,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/238/Trajectories/download/v1.4.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/F801B7AA.zip",
     "download_size": 65271,
     "x_generated_by": "netkan"
 }

--- a/TweakableEverything/TweakableEverything-1.14.ckan
+++ b/TweakableEverything/TweakableEverything-1.14.ckan
@@ -38,7 +38,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/255/TweakableEverything/download/1.14",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/F95007E0.zip",
     "download_size": 263351,
     "x_generated_by": "netkan"
 }

--- a/USAFOrionMod-TD-subedition/USAFOrionMod-TD-subedition-0.30.2.ckan
+++ b/USAFOrionMod-TD-subedition/USAFOrionMod-TD-subedition-0.30.2.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/679/USAFOrionMod-TD-subedition/download/0.30.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/198F9E58.zip",
     "download_size": 95693599,
     "x_generated_by": "netkan"
 }

--- a/VOID/VOID-0.18.5.ckan
+++ b/VOID/VOID-0.18.5.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/253/VOID/download/0.18.5",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/EEF264D3.zip",
     "download_size": 326372,
     "x_generated_by": "netkan"
 }

--- a/VesselMover/VesselMover-1.1.ckan
+++ b/VesselMover/VesselMover-1.1.ckan
@@ -13,7 +13,7 @@
     },
     "version": "1.1",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/1229/VesselMover/download/1.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/25D88FE9.zip",
     "download_size": 8388,
     "x_generated_by": "netkan"
 }

--- a/VesselMover/VesselMover-1.2.ckan
+++ b/VesselMover/VesselMover-1.2.ckan
@@ -13,7 +13,7 @@
     },
     "version": "1.2",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/1229/VesselMover/download/1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/98CF36BE.zip",
     "download_size": 8928,
     "x_generated_by": "netkan"
 }

--- a/WalkAbout/WalkAbout-v1.2.ckan
+++ b/WalkAbout/WalkAbout-v1.2.ckan
@@ -19,7 +19,7 @@
             "filter": "source"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1426/WalkAbout/download/v1.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/48533224.zip",
     "download_size": 125876,
     "x_generated_by": "netkan"
 }

--- a/WarpShip/WarpShip-0.3.2.ckan
+++ b/WarpShip/WarpShip-0.3.2.ckan
@@ -35,7 +35,7 @@
             "install_to": "GameData/WarpShip"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/773/WarpShip/download/0.3.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/D7F4E60D.zip",
     "download_size": 12861455,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/WasdEditorCameraContinued/WasdEditorCameraContinued-0.5.0.ckan
+++ b/WasdEditorCameraContinued/WasdEditorCameraContinued-0.5.0.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1157/WASDEditorCameraContinued/download/0.5.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/CAAC19B2.zip",
     "download_size": 21634,
     "x_generated_by": "netkan"
 }

--- a/WasdEditorCameraContinued/WasdEditorCameraContinued-0.5.1.ckan
+++ b/WasdEditorCameraContinued/WasdEditorCameraContinued-0.5.1.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1157/WASDEditorCameraContinued/download/0.5.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/165EE7FC.zip",
     "download_size": 21713,
     "x_generated_by": "netkan"
 }

--- a/WasdEditorCameraContinued/WasdEditorCameraContinued-0.5.2.ckan
+++ b/WasdEditorCameraContinued/WasdEditorCameraContinued-0.5.2.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1157/WASDEditorCameraContinued/download/0.5.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/EE05B41F.zip",
     "download_size": 21739,
     "x_generated_by": "netkan"
 }

--- a/WasdEditorCameraContinued/WasdEditorCameraContinued-0.5.3.ckan
+++ b/WasdEditorCameraContinued/WasdEditorCameraContinued-0.5.3.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1157/WASDEditorCameraContinued/download/0.5.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/65A972C9.zip",
     "download_size": 21804,
     "x_generated_by": "netkan"
 }

--- a/WasdEditorCameraContinued/WasdEditorCameraContinued-0.6.0.ckan
+++ b/WasdEditorCameraContinued/WasdEditorCameraContinued-0.6.0.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1157/WASDEditorCameraContinued/download/0.6.0",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4D10EE86.zip",
     "download_size": 21892,
     "x_generated_by": "netkan"
 }

--- a/WasdEditorCameraContinued/WasdEditorCameraContinued-0.6.1.ckan
+++ b/WasdEditorCameraContinued/WasdEditorCameraContinued-0.6.1.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1157/WASDEditorCameraContinued/download/0.6.1",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/D87FDA88.zip",
     "download_size": 22115,
     "x_generated_by": "netkan"
 }

--- a/WasdEditorCameraContinued/WasdEditorCameraContinued-0.6.3.ckan
+++ b/WasdEditorCameraContinued/WasdEditorCameraContinued-0.6.3.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1157/WASDEditorCameraContinued/download/0.6.3",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/558EECFA.zip",
     "download_size": 38822,
     "x_generated_by": "netkan"
 }

--- a/WasdEditorCameraContinued/WasdEditorCameraContinued-0.6.4.ckan
+++ b/WasdEditorCameraContinued/WasdEditorCameraContinued-0.6.4.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1157/WASDEditorCameraContinued/download/0.6.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4BEAE16A.zip",
     "download_size": 38943,
     "x_generated_by": "netkan"
 }

--- a/WernherChecker/WernherChecker-v0.4.ckan
+++ b/WernherChecker/WernherChecker-v0.4.ckan
@@ -15,7 +15,7 @@
     "version": "v0.4",
     "ksp_version_min": "1.0.3",
     "ksp_version_max": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/91/WernherChecker/download/v0.4",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4212E069.zip",
     "download_size": 30810,
     "x_generated_by": "netkan"
 }

--- a/WildBlueTools/WildBlueTools-1.0.20.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.20.ckan
@@ -21,7 +21,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/947/WildBlueTools/download/1.0.20",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/51B2E97B.zip",
     "download_size": 1059870,
     "x_generated_by": "netkan"
 }

--- a/WildBlueTools/WildBlueTools-1.0.21.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.21.ckan
@@ -21,7 +21,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/947/WildBlueTools/download/1.0.21",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3310BF83.zip",
     "download_size": 1059768,
     "x_generated_by": "netkan"
 }

--- a/WildBlueTools/WildBlueTools-1.0.22.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.22.ckan
@@ -21,7 +21,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/947/WildBlueTools/download/1.0.22",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4EF742D4.zip",
     "download_size": 1059762,
     "x_generated_by": "netkan"
 }

--- a/WildBlueTools/WildBlueTools-1.0.23.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.23.ckan
@@ -21,7 +21,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/947/WildBlueTools/download/1.0.23",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B784F8A9.zip",
     "download_size": 1059820,
     "x_generated_by": "netkan"
 }

--- a/WildBlueTools/WildBlueTools-1.0.24.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.24.ckan
@@ -21,7 +21,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/947/WildBlueTools/download/1.0.24",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/7F27869B.zip",
     "download_size": 1060117,
     "x_generated_by": "netkan"
 }

--- a/WildBlueTools/WildBlueTools-1.0.25.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.25.ckan
@@ -21,7 +21,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/947/WildBlueTools/download/1.0.25",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/34545588.zip",
     "download_size": 1060323,
     "x_generated_by": "netkan"
 }

--- a/WildBlueTools/WildBlueTools-1.0.26.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.26.ckan
@@ -21,7 +21,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/947/WildBlueTools/download/1.0.26",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3269412C.zip",
     "download_size": 1343953,
     "x_generated_by": "netkan"
 }

--- a/WildBlueTools/WildBlueTools-1.0.27.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.27.ckan
@@ -21,7 +21,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/947/WildBlueTools/download/1.0.27",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/53182985.zip",
     "download_size": 1358440,
     "x_generated_by": "netkan"
 }

--- a/WildBlueTools/WildBlueTools-1.0.28.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.28.ckan
@@ -21,7 +21,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/947/WildBlueTools/download/1.0.28",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/EA07C48F.zip",
     "download_size": 1371403,
     "x_generated_by": "netkan"
 }

--- a/WildBlueTools/WildBlueTools-1.0.29.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.29.ckan
@@ -21,7 +21,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/947/WildBlueTools/download/1.0.29",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/E9E2E9C6.zip",
     "download_size": 1476792,
     "x_generated_by": "netkan"
 }

--- a/WinterKerbol/WinterKerbol-2015_Version_2.ckan
+++ b/WinterKerbol/WinterKerbol-2015_Version_2.ckan
@@ -48,7 +48,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1333/WinterKerbol/download/2015_Version_2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/99DE7F58.zip",
     "download_size": 28781678,
     "x_generated_by": "netkan"
 }

--- a/kal9000/kal9000-1.2.2.ckan
+++ b/kal9000/kal9000-1.2.2.ckan
@@ -25,7 +25,7 @@
             "filter": ".DS_Store"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/299/KAL9000/download/1.2.2",
+    "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/C08CF4D4.zip",
     "download_size": 784444,
     "x_generated_by": "netkan"
 }


### PR DESCRIPTION
These mods are:

1. All under FOSS licenses.
1. All present in our indexer, and so easily available for me to upload.
1. Now in a great big S3 bucket.

S3 buckets have interfaces that make me cry, and there's nowhere near as
many of these as I would like, but it's a start.

The S3 buckets I'm using will run out in a couple of years, so
longer-term we should migrate these to the Internet Archive. Yes,
they're cool with this (provided all the content is under a freely
distributable license), but it requires some fussing to get up and
running. So I've gone with S3 for now.

I've tested some, but not all of these. You can test them by going to
CKAN -> Settings and using a metadata repo of
`https://github.com/KSP-CKAN/CKAN-meta/archive/ks_recovery_1.tar.gz`.

Obviously only the migrated mods (see filelist) will work with this
migration. But it's a start.