### PR TITLE
Custom Asteroids manual updates

### DIFF
--- a/CustomAsteroids-Pops-Stock-Inner/CustomAsteroids-Pops-Stock-Inner-v1.1.0.ckan
+++ b/CustomAsteroids-Pops-Stock-Inner/CustomAsteroids-Pops-Stock-Inner-v1.1.0.ckan
@@ -8,9 +8,8 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80483",
-        "kerbalstuff": "https://kerbalstuff.com/mod/251/Custom%20Asteroids",
         "repository": "https://github.com/Starstrider42/Custom-Asteroids",
-        "x_screenshot": "https://kerbalstuff.com/content/Starstrider42_807/Custom_Asteroids/Custom_Asteroids.png"
+        "x_screenshot": "https://spacedock.info/content/Starstrider42_1134/Custom_Asteroids/Custom_Asteroids-1456053768.2688773.png"
     },
     "version": "v1.1.0",
     "ksp_version_min": "0.25",
@@ -41,7 +40,7 @@
             "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/251/Custom%20Asteroids/download/v1.1.0",
+    "download": "https://github.com/Starstrider42/Custom-Asteroids/releases/download/v1.1.0/CustomAsteroids_v1.1.0.zip",
     "download_size": 24276,
     "x_maintained_by": "Starstrider42",
     "x_generated_by": "netkan"

--- a/CustomAsteroids-Pops-Stock-Inner/CustomAsteroids-Pops-Stock-Inner-v1.2.0.ckan
+++ b/CustomAsteroids-Pops-Stock-Inner/CustomAsteroids-Pops-Stock-Inner-v1.2.0.ckan
@@ -8,9 +8,9 @@
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72785-/",
-        "kerbalstuff": "https://kerbalstuff.com/mod/251/Custom%20Asteroids",
+        "spacedock": "https://spacedock.info/mod/210/Custom%20Asteroids",
         "repository": "https://github.com/Starstrider42/Custom-Asteroids",
-        "x_screenshot": "https://kerbalstuff.com/content/Starstrider42_807/Custom_Asteroids/Custom_Asteroids.png"
+        "x_screenshot": "https://spacedock.info/content/Starstrider42_1134/Custom_Asteroids/Custom_Asteroids-1456053768.2688773.png"
     },
     "version": "v1.2.0",
     "ksp_version_min": "0.18",
@@ -41,7 +41,7 @@
             "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/251/Custom%20Asteroids/download/v1.2.0",
+    "download": "https://spacedock.info/mod/210/Custom%20Asteroids/download/v1.2.0",
     "download_size": 26341,
     "x_maintained_by": "Starstrider42",
     "x_generated_by": "netkan"

--- a/CustomAsteroids-Pops-Stock-Outer/CustomAsteroids-Pops-Stock-Outer-v1.1.0.ckan
+++ b/CustomAsteroids-Pops-Stock-Outer/CustomAsteroids-Pops-Stock-Outer-v1.1.0.ckan
@@ -8,9 +8,8 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80483",
-        "kerbalstuff": "https://kerbalstuff.com/mod/251/Custom%20Asteroids",
         "repository": "https://github.com/Starstrider42/Custom-Asteroids",
-        "x_screenshot": "https://kerbalstuff.com/content/Starstrider42_807/Custom_Asteroids/Custom_Asteroids.png"
+        "x_screenshot": "https://spacedock.info/content/Starstrider42_1134/Custom_Asteroids/Custom_Asteroids-1456053768.2688773.png"
     },
     "version": "v1.1.0",
     "ksp_version_min": "0.25",
@@ -47,7 +46,7 @@
             "filter_regexp": "(?<!Trans-Jool\\.cfg)$"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/251/Custom%20Asteroids/download/v1.1.0",
+    "download": "https://github.com/Starstrider42/Custom-Asteroids/releases/download/v1.1.0/CustomAsteroids_v1.1.0.zip",
     "download_size": 24276,
     "x_maintained_by": "Starstrider42",
     "x_generated_by": "netkan"

--- a/CustomAsteroids-Pops-Stock-Outer/CustomAsteroids-Pops-Stock-Outer-v1.2.0.ckan
+++ b/CustomAsteroids-Pops-Stock-Outer/CustomAsteroids-Pops-Stock-Outer-v1.2.0.ckan
@@ -8,9 +8,9 @@
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72785-/",
-        "kerbalstuff": "https://kerbalstuff.com/mod/251/Custom%20Asteroids",
+        "spacedock": "https://spacedock.info/mod/210/Custom%20Asteroids",
         "repository": "https://github.com/Starstrider42/Custom-Asteroids",
-        "x_screenshot": "https://kerbalstuff.com/content/Starstrider42_807/Custom_Asteroids/Custom_Asteroids.png"
+        "x_screenshot": "https://spacedock.info/content/Starstrider42_1134/Custom_Asteroids/Custom_Asteroids-1456053768.2688773.png"
     },
     "version": "v1.2.0",
     "ksp_version_min": "0.18.2",
@@ -47,7 +47,7 @@
             "filter_regexp": "(?<!Trans-Jool\\.cfg)$"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/251/Custom%20Asteroids/download/v1.2.0",
+    "download": "https://spacedock.info/mod/210/Custom%20Asteroids/download/v1.2.0",
     "download_size": 26341,
     "x_maintained_by": "Starstrider42",
     "x_generated_by": "netkan"

--- a/CustomAsteroids/CustomAsteroids-v1.1.0.ckan
+++ b/CustomAsteroids/CustomAsteroids-v1.1.0.ckan
@@ -8,11 +8,10 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80483",
-        "kerbalstuff": "https://kerbalstuff.com/mod/251/Custom%20Asteroids",
         "repository": "https://github.com/Starstrider42/Custom-Asteroids",
         "bugtracker": "https://github.com/Starstrider42/Custom-Asteroids/issues",
         "manual": "http://starstrider42.github.io/Custom-Asteroids/",
-        "x_screenshot": "https://kerbalstuff.com/content/Starstrider42_807/Custom_Asteroids/Custom_Asteroids.png"
+        "x_screenshot": "https://spacedock.info/content/Starstrider42_1134/Custom_Asteroids/Custom_Asteroids-1456053768.2688773.png"
     },
     "version": "v1.1.0",
     "ksp_version_min": "0.25",
@@ -30,6 +29,12 @@
             "name": "CustomAsteroids-Pops-Stock-Outer"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Kopernicus",
+            "min_version": "1:beta-06"
+        }
+    ],
     "install": [
         {
             "file": "GameData/CustomAsteroids",
@@ -37,7 +42,7 @@
             "filter": "config"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/251/Custom%20Asteroids/download/v1.1.0",
+    "download": "https://github.com/Starstrider42/Custom-Asteroids/releases/download/v1.1.0/CustomAsteroids_v1.1.0.zip",
     "download_size": 24276,
     "x_maintained_by": "Starstrider42",
     "x_generated_by": "netkan"

--- a/CustomAsteroids/CustomAsteroids-v1.2.0.ckan
+++ b/CustomAsteroids/CustomAsteroids-v1.2.0.ckan
@@ -29,12 +29,6 @@
             "name": "CustomAsteroids-Pops-Stock-Outer"
         }
     ],
-    "conflicts": [
-        {
-            "name": "Kopernicus",
-            "min_version": "1:beta-06"
-        }
-    ],
     "install": [
         {
             "file": "GameData/CustomAsteroids",

--- a/CustomAsteroids/CustomAsteroids-v1.2.0.ckan
+++ b/CustomAsteroids/CustomAsteroids-v1.2.0.ckan
@@ -7,11 +7,11 @@
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72785-/",
-        "kerbalstuff": "https://kerbalstuff.com/mod/251/Custom%20Asteroids",
+        "spacedock": "https://spacedock.info/mod/210/Custom%20Asteroids",
         "repository": "https://github.com/Starstrider42/Custom-Asteroids",
         "bugtracker": "https://github.com/Starstrider42/Custom-Asteroids/issues",
         "manual": "http://starstrider42.github.io/Custom-Asteroids/",
-        "x_screenshot": "https://kerbalstuff.com/content/Starstrider42_807/Custom_Asteroids/Custom_Asteroids.png"
+        "x_screenshot": "https://spacedock.info/content/Starstrider42_1134/Custom_Asteroids/Custom_Asteroids-1456053768.2688773.png"
     },
     "version": "v1.2.0",
     "ksp_version_min": "1.0.0",
@@ -42,7 +42,7 @@
             "filter": "config"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/251/Custom%20Asteroids/download/v1.2.0",
+    "download": "https://spacedock.info/mod/210/Custom%20Asteroids/download/v1.2.0",
     "download_size": 26341,
     "x_maintained_by": "Starstrider42",
     "x_generated_by": "netkan"


### PR DESCRIPTION
Removed references to KerbalStuff, fixed bad Kopernicus reference to match KSP-CKAN/NetKAN#3226 (since it appears old `.ckan` files don't get updated by the bot).