### PR TITLE
KerbalStuff -> i52.de migration: Now with extra bangs!

### DIFF
--- a/BDArmory/BDArmory-0.7.3.ckan
+++ b/BDArmory/BDArmory-0.7.3.ckan
@@ -11,7 +11,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, etc. ",
     "author": "BahamutoD",
     "version": "0.7.3",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.7.3",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.7.3.zip",
     "x_generated_by": "netkan",
     "download_size": 18397531
 }

--- a/BDArmory/BDArmory-0.9.0.ckan
+++ b/BDArmory/BDArmory-0.9.0.ckan
@@ -13,7 +13,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, AI, etc. ",
     "version": "0.9.0",
     "author": "BahamutoD",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.0",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.0.zip",
     "download_size": 17950619,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-0.9.1.ckan
+++ b/BDArmory/BDArmory-0.9.1.ckan
@@ -13,7 +13,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, AI, etc. ",
     "version": "0.9.1",
     "author": "BahamutoD",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.1",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.1.zip",
     "download_size": 17951306,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.10.0.ckan
+++ b/BDArmory/BDArmory-v0.10.0.ckan
@@ -13,7 +13,7 @@
     },
     "version": "v0.10.0",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.10.0",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.10.0.zip",
     "download_size": 30014696,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.10.1.ckan
+++ b/BDArmory/BDArmory-v0.10.1.ckan
@@ -13,7 +13,7 @@
     },
     "version": "v0.10.1",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.10.1",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.10.1.zip",
     "download_size": 30015925,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.10.2.ckan
+++ b/BDArmory/BDArmory-v0.10.2.ckan
@@ -13,7 +13,7 @@
     },
     "version": "v0.10.2",
     "ksp_version": "1.0.5",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.10.2",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.10.2.zip",
     "download_size": 31461986,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.8.0.ckan
+++ b/BDArmory/BDArmory-v0.8.0.ckan
@@ -11,7 +11,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, etc. ",
     "author": "BahamutoD",
     "version": "v0.8.0",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/v0.8.0",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-v0.8.0.zip",
     "x_generated_by": "netkan",
     "download_size": 18112041
 }

--- a/BDArmory/BDArmory-v0.8.1.ckan
+++ b/BDArmory/BDArmory-v0.8.1.ckan
@@ -11,7 +11,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, etc. ",
     "author": "BahamutoD",
     "version": "v0.8.1",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/v0.8.1",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-v0.8.1.zip",
     "x_generated_by": "netkan",
     "download_size": 18247655
 }

--- a/BDArmory/BDArmory-v0.8.2.ckan
+++ b/BDArmory/BDArmory-v0.8.2.ckan
@@ -11,7 +11,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, etc. ",
     "author": "BahamutoD",
     "version": "v0.8.2",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/v0.8.2",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-v0.8.2.zip",
     "x_generated_by": "netkan",
     "download_size": 18247753
 }

--- a/BDArmory/BDArmory-v0.8.3.ckan
+++ b/BDArmory/BDArmory-v0.8.3.ckan
@@ -12,7 +12,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, AI, etc. ",
     "version": "v0.8.3",
     "author": "BahamutoD",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/v0.8.3",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-v0.8.3.zip",
     "ksp_version_min": "1.0.2",
     "ksp_version_max": "1.0.4",
     "download_size": 19051598,

--- a/BDArmory/BDArmory-v0.9.1.ckan
+++ b/BDArmory/BDArmory-v0.9.1.ckan
@@ -13,7 +13,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, AI, etc. ",
     "version": "v0.9.1",
     "author": "BahamutoD",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.1",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.1.zip",
     "download_size": 17951306,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.9.2.ckan
+++ b/BDArmory/BDArmory-v0.9.2.ckan
@@ -13,7 +13,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, AI, etc. ",
     "version": "v0.9.2",
     "author": "BahamutoD",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.2",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.2.zip",
     "download_size": 17951465,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.9.3.ckan
+++ b/BDArmory/BDArmory-v0.9.3.ckan
@@ -13,7 +13,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, AI, etc. ",
     "version": "v0.9.3",
     "author": "BahamutoD",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.3",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.3.zip",
     "download_size": 17956494,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.9.4.ckan
+++ b/BDArmory/BDArmory-v0.9.4.ckan
@@ -13,7 +13,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, AI, etc. ",
     "version": "v0.9.4",
     "author": "BahamutoD",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.4",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.4.zip",
     "download_size": 17957880,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.9.5.ckan
+++ b/BDArmory/BDArmory-v0.9.5.ckan
@@ -13,7 +13,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, AI, etc. ",
     "version": "v0.9.5",
     "author": "BahamutoD",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.5",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.5.zip",
     "download_size": 17962718,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.9.6.ckan
+++ b/BDArmory/BDArmory-v0.9.6.ckan
@@ -13,7 +13,7 @@
     "abstract": "Adds gun turrets, missiles, bombs, AI, etc. ",
     "version": "v0.9.6",
     "author": "BahamutoD",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.6",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.6.zip",
     "download_size": 17965220,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.9.7.ckan
+++ b/BDArmory/BDArmory-v0.9.7.ckan
@@ -13,7 +13,7 @@
     },
     "version": "v0.9.7",
     "ksp_version": "1.0.4",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.7",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.7.zip",
     "download_size": 17972990,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.9.8.2.ckan
+++ b/BDArmory/BDArmory-v0.9.8.2.ckan
@@ -13,7 +13,7 @@
     },
     "version": "v0.9.8.2",
     "ksp_version": "1.0.4",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.8.2",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.8.2.zip",
     "download_size": 17976288,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.9.9.1.ckan
+++ b/BDArmory/BDArmory-v0.9.9.1.ckan
@@ -13,7 +13,7 @@
     },
     "version": "v0.9.9.1",
     "ksp_version": "1.0.4",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.9.1",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.9.1.zip",
     "download_size": 18489443,
     "x_generated_by": "netkan"
 }

--- a/BDArmory/BDArmory-v0.9.9.ckan
+++ b/BDArmory/BDArmory-v0.9.9.ckan
@@ -13,7 +13,7 @@
     },
     "version": "v0.9.9",
     "ksp_version": "1.0.4",
-    "download": "https://kerbalstuff.com/mod/90/BahamutoD%27s%20Armory/download/0.9.9",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/BahamutoDs_Armory/BahamutoDs_Armory-0.9.9.zip",
     "download_size": 18571303,
     "x_generated_by": "netkan"
 }

--- a/BilliardsPlanetPack/BilliardsPlanetPack-0.1.ckan
+++ b/BilliardsPlanetPack/BilliardsPlanetPack-0.1.ckan
@@ -76,7 +76,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1239/Billiard%27s%20Planet%20Pack/download/0.1",
+    "download": "http://i.52k.de/kspmods/storage/GregroxMun_8555/Billiards_Planet_Pack/Billiards_Planet_Pack-0.1.zip",
     "download_size": 3761,
     "x_generated_by": "netkan"
 }

--- a/BurnTogether/BurnTogether-alpha_7.0.ckan
+++ b/BurnTogether/BurnTogether-alpha_7.0.ckan
@@ -21,7 +21,7 @@
             "comment": "no way to install files from .zip, it's an MM patch to add functionality to pods without the part"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/658/Burn%20Together%21/download/alpha_7.0",
+    "download": "http://i.52k.de/kspmods/storage/BahamutoD_531/Burn_Together/Burn_Together-alpha_7.0.zip",
     "download_size": 90431,
     "x_generated_by": "netkan"
 }

--- a/Ceteras-Suit-Pack/Ceteras-Suit-Pack-0.2.ckan
+++ b/Ceteras-Suit-Pack/Ceteras-Suit-Pack-0.2.ckan
@@ -22,7 +22,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1309/Cetera%27s%20Suit%20Pack/download/0.2",
+    "download": "http://i.52k.de/kspmods/storage/Cetera_17106/Ceteras_Suit_Pack/Ceteras_Suit_Pack-0.2.zip",
     "download_size": 63131844,
     "x_generated_by": "netkan"
 }

--- a/DangIt/DangIt-0.5.3.2.ckan
+++ b/DangIt/DangIt-0.5.3.2.ckan
@@ -27,7 +27,7 @@
     "abstract": "A random failure mod for KSP.",
     "author": "Ippo",
     "version": "0.5.3.2",
-    "download": "https://kerbalstuff.com/mod/7/DangIt%21/download/0.5.3.2",
+    "download": "http://i.52k.de/kspmods/storage/Coffeeman_4174/DangIt/DangIt-0.5.3.2.zip",
     "x_generated_by": "netkan",
     "download_size": 155554
 }

--- a/DangIt/DangIt-0.6.1.ckan
+++ b/DangIt/DangIt-0.6.1.ckan
@@ -28,7 +28,7 @@
             "name": "Entropy"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/7/DangIt%21/download/0.6.1",
+    "download": "http://i.52k.de/kspmods/storage/Coffeeman_4174/DangIt/DangIt-0.6.1.zip",
     "download_size": 142755,
     "x_generated_by": "netkan"
 }

--- a/DangIt/DangIt-0.6.2.ckan
+++ b/DangIt/DangIt-0.6.2.ckan
@@ -28,7 +28,7 @@
             "name": "Entropy"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/7/DangIt%21/download/0.6.2",
+    "download": "http://i.52k.de/kspmods/storage/Coffeeman_4174/DangIt/DangIt-0.6.2.zip",
     "download_size": 119700,
     "x_generated_by": "netkan"
 }

--- a/DangIt/DangIt-0.6.ckan
+++ b/DangIt/DangIt-0.6.ckan
@@ -27,7 +27,7 @@
     "abstract": "A random failure mod for KSP.",
     "author": "Ippo",
     "version": "0.6",
-    "download": "https://kerbalstuff.com/mod/7/DangIt%21/download/0.6",
+    "download": "http://i.52k.de/kspmods/storage/Coffeeman_4174/DangIt/DangIt-0.6.zip",
     "x_generated_by": "netkan",
     "download_size": 142514
 }

--- a/DeepFreeze/DeepFreeze-V0.16.0.2.ckan
+++ b/DeepFreeze/DeepFreeze-V0.16.0.2.ckan
@@ -38,7 +38,7 @@
     "abstract": "This mod provides the ability to freeze and thaw kerbals for those long space journeys.",
     "author": "JPLRepo",
     "version": "V0.16.0.2",
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.16.0.2",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.16.0.2.zip",
     "x_generated_by": "netkan",
     "download_size": 14118637
 }

--- a/DeepFreeze/DeepFreeze-V0.16.0.3.ckan
+++ b/DeepFreeze/DeepFreeze-V0.16.0.3.ckan
@@ -39,7 +39,7 @@
     "abstract": "This mod provides the ability to freeze and thaw kerbals for those long space journeys.",
     "author": "JPLRepo",
     "version": "V0.16.0.3",
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.16.0.3",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.16.0.3.zip",
     "x_generated_by": "netkan",
     "x_screenshot": "https://kerbalstuff.com/content/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-1433720483.1306732.png",
     "download_size": 14226942

--- a/DeepFreeze/DeepFreeze-V0.17.0.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.17.0.0.ckan
@@ -39,7 +39,7 @@
     "abstract": "This mod provides the ability to freeze and thaw kerbals for those long space journeys.",
     "author": "JPLRepo",
     "version": "V0.17.0.0",
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.17.0.0",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.17.0.0.zip",
     "x_generated_by": "netkan",
     "x_screenshot": "https://kerbalstuff.com/content/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-1433720483.1306732.png",
     "download_size": 7441308

--- a/DeepFreeze/DeepFreeze-V0.17.1.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.17.1.0.ckan
@@ -54,7 +54,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.17.1.0",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.17.1.0.zip",
     "download_size": 11524202,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DeepFreeze/DeepFreeze-V0.18.0.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.18.0.0.ckan
@@ -54,7 +54,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.18.0.0",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.18.0.0.zip",
     "download_size": 16226306,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DeepFreeze/DeepFreeze-V0.18.1.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.18.1.0.ckan
@@ -59,7 +59,7 @@
             "filter": "Agencies"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.18.1.0",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.18.1.0.zip",
     "download_size": 16157910,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DeepFreeze/DeepFreeze-V0.18.2.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.18.2.0.ckan
@@ -59,7 +59,7 @@
             "filter": "Agencies"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.18.2.0",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.18.2.0.zip",
     "download_size": 16959786,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DeepFreeze/DeepFreeze-V0.18.2.1.ckan
+++ b/DeepFreeze/DeepFreeze-V0.18.2.1.ckan
@@ -59,7 +59,7 @@
             "filter": "Agencies"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.18.2.1",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.18.2.1.zip",
     "download_size": 16964673,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DeepFreeze/DeepFreeze-V0.19.0.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.19.0.0.ckan
@@ -59,7 +59,7 @@
             "filter": "Agencies"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.19.0.0",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.19.0.0.zip",
     "download_size": 18559411,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DeepFreeze/DeepFreeze-V0.19.1.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.19.1.0.ckan
@@ -59,7 +59,7 @@
             "filter": "Agencies"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.19.1.0",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.19.1.0.zip",
     "download_size": 18560620,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DeepFreeze/DeepFreeze-V0.19.2.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.19.2.0.ckan
@@ -59,7 +59,7 @@
             "filter": "Agencies"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.19.2.0",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.19.2.0.zip",
     "download_size": 18591978,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DeepFreeze/DeepFreeze-V0.19.3.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.19.3.0.ckan
@@ -59,7 +59,7 @@
             "filter": "Agencies"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.19.3.0",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.19.3.0.zip",
     "download_size": 18592271,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DeepFreeze/DeepFreeze-V0.20.0.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.20.0.0.ckan
@@ -59,7 +59,7 @@
             "filter": "Agencies"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.20.0.0",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.20.0.0.zip",
     "download_size": 18838025,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DeepFreeze/DeepFreeze-V0.20.1.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.20.1.0.ckan
@@ -59,7 +59,7 @@
             "filter": "Agencies"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.20.1.0",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.20.1.0.zip",
     "download_size": 18840632,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DeepFreeze/DeepFreeze-V0.20.2.ckan
+++ b/DeepFreeze/DeepFreeze-V0.20.2.ckan
@@ -59,7 +59,7 @@
             "filter": "Agencies"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/895/DeepFreeze%20Continued.../download/V0.20.2",
+    "download": "http://i.52k.de/kspmods/storage/JPLRepo_4429/DeepFreeze_Continued/DeepFreeze_Continued-V0.20.2.zip",
     "download_size": 18846366,
     "x_via": "Author JPLRepo",
     "x_generated_by": "netkan"

--- a/DunaPlus/DunaPlus-0.1.ckan
+++ b/DunaPlus/DunaPlus-0.1.ckan
@@ -41,7 +41,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/690/AstroGamers%20DunaPlus%20Mod%21/download/0.1",
+    "download": "http://i.52k.de/kspmods/storage/AstroGamer_8562/AstroGamers_DunaPlus_Mod/AstroGamers_DunaPlus_Mod-0.1.zip",
     "download_size": 63561872,
     "x_generated_by": "netkan"
 }

--- a/EVAOK/EVAOK-1.0.ckan
+++ b/EVAOK/EVAOK-1.0.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1326/EVA%20OK%21/download/1.0",
+    "download": "http://i.52k.de/kspmods/storage/wrcsubers_13275/EVA_OK/EVA_OK-1.0.zip",
     "download_size": 2240,
     "x_generated_by": "netkan"
 }

--- a/EVAOK/EVAOK-1.1.0.ckan
+++ b/EVAOK/EVAOK-1.1.0.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1326/EVA%20OK%21/download/1.1.0",
+    "download": "http://i.52k.de/kspmods/storage/wrcsubers_13275/EVA_OK/EVA_OK-1.1.0.zip",
     "download_size": 6274,
     "x_generated_by": "netkan"
 }

--- a/EnginesPlus/EnginesPlus-1.4.ckan
+++ b/EnginesPlus/EnginesPlus-1.4.ckan
@@ -23,7 +23,7 @@
     "abstract": "Adds more engines to the game! Like a 3.75m Poodle or ect!",
     "author": "AstroGamer",
     "version": "1.4",
-    "download": "https://kerbalstuff.com/mod/952/AstroGamer%27s%20EnginesPlus%20Mod/download/1.4",
+    "download": "http://i.52k.de/kspmods/storage/AstroGamer_8562/AstroGamers_EnginesPlus_Mod/AstroGamers_EnginesPlus_Mod-1.4.zip",
     "x_generated_by": "netkan",
     "x_screenshot": "https://kerbalstuff.com/content/AstroGamer_8562/AstroGamers_EnginesPlus_Mod/AstroGamers_EnginesPlus_Mod-1435866016.820681.png",
     "download_size": 13845837

--- a/EnginesPlus/EnginesPlus-1.6.ckan
+++ b/EnginesPlus/EnginesPlus-1.6.ckan
@@ -23,7 +23,7 @@
     "abstract": "Adds more engines to the game! Like a 3.75m Poodle or ect!",
     "author": "AstroGamer",
     "version": "1.6",
-    "download": "https://kerbalstuff.com/mod/952/AstroGamer%27s%20EnginesPlus%20Mod/download/1.6",
+    "download": "http://i.52k.de/kspmods/storage/AstroGamer_8562/AstroGamers_EnginesPlus_Mod/AstroGamers_EnginesPlus_Mod-1.6.zip",
     "x_generated_by": "netkan",
     "x_screenshot": "https://kerbalstuff.com/content/AstroGamer_8562/AstroGamers_EnginesPlus_Mod/AstroGamers_EnginesPlus_Mod-1435866016.820681.png",
     "download_size": 13845838

--- a/EnginesPlus/EnginesPlus-1.8.ckan
+++ b/EnginesPlus/EnginesPlus-1.8.ckan
@@ -19,7 +19,7 @@
     "abstract": "Adds more engines + fuel tanks to the game! Like a 3.75m Poodle or liquid fuel only tanks!",
     "version": "1.8",
     "author": "AstroGamer",
-    "download": "https://kerbalstuff.com/mod/952/AstroGamer%27s%20EnginesPlus%20Mod/download/1.8",
+    "download": "http://i.52k.de/kspmods/storage/AstroGamer_8562/AstroGamers_EnginesPlus_Mod/AstroGamers_EnginesPlus_Mod-1.8.zip",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/127424-1-0-4-EnginesPlus!-New-engines-for-your-rockets!-(1-4)?p=2053865#post2053865",
         "kerbalstuff": "https://kerbalstuff.com/mod/952/AstroGamer's%20EnginesPlus%20Mod",

--- a/EnginesPlus/EnginesPlus-2.0.ckan
+++ b/EnginesPlus/EnginesPlus-2.0.ckan
@@ -24,7 +24,7 @@
             "filter": "Source.txt"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/952/AstroGamer%27s%20EnginesPlus%20Mod/download/2.0",
+    "download": "http://i.52k.de/kspmods/storage/AstroGamer_8562/AstroGamers_EnginesPlus_Mod/AstroGamers_EnginesPlus_Mod-2.0.zip",
     "download_size": 8178762,
     "x_generated_by": "netkan"
 }

--- a/EvePlus/EvePlus-0.2.ckan
+++ b/EvePlus/EvePlus-0.2.ckan
@@ -41,7 +41,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/685/AstroGamer%27s%20EvePlus%20Mod/download/0.2",
+    "download": "http://i.52k.de/kspmods/storage/AstroGamer_8562/AstroGamers_EvePlus_Mod/AstroGamers_EvePlus_Mod-0.2.zip",
     "download_size": 29920497,
     "x_generated_by": "netkan"
 }

--- a/ForScienceContinued/ForScienceContinued-0.26.1.ckan
+++ b/ForScienceContinued/ForScienceContinued-0.26.1.ckan
@@ -18,7 +18,7 @@
     "abstract": "Build upon the ForScience mod by WaveFunctionP. This version adds an interface and exciting new features to it.",
     "author": "SpaceTiger",
     "version": "0.26.1",
-    "download": "https://kerbalstuff.com/mod/477/ForScience%20Continued%21/download/0.26.1",
+    "download": "http://i.52k.de/kspmods/storage/SpaceTiger_5933/ForScience_Continued/ForScience_Continued-0.26.1.zip",
     "x_generated_by": "netkan",
     "download_size": 24894
 }

--- a/ForScienceContinued/ForScienceContinued-0.27.1.ckan
+++ b/ForScienceContinued/ForScienceContinued-0.27.1.ckan
@@ -23,7 +23,7 @@
     "abstract": "Build upon the ForScience mod by WaveFunctionP. This version adds an interface and exciting new features to it.",
     "author": "SpaceTiger",
     "version": "0.27.1",
-    "download": "https://kerbalstuff.com/mod/477/ForScience%20Continued%21/download/0.27.1",
+    "download": "http://i.52k.de/kspmods/storage/SpaceTiger_5933/ForScience_Continued/ForScience_Continued-0.27.1.zip",
     "x_generated_by": "netkan",
     "download_size": 77052
 }

--- a/ForScienceContinued/ForScienceContinued-0.27.2.ckan
+++ b/ForScienceContinued/ForScienceContinued-0.27.2.ckan
@@ -23,7 +23,7 @@
     "abstract": "Build upon the ForScience mod by WaveFunctionP. This version adds an interface and exciting new features to it.",
     "author": "SpaceTiger",
     "version": "0.27.2",
-    "download": "https://kerbalstuff.com/mod/477/ForScience%20Continued%21/download/0.27.2",
+    "download": "http://i.52k.de/kspmods/storage/SpaceTiger_5933/ForScience_Continued/ForScience_Continued-0.27.2.zip",
     "x_generated_by": "netkan",
     "download_size": 82784
 }

--- a/ForScienceContinued/ForScienceContinued-0.27.ckan
+++ b/ForScienceContinued/ForScienceContinued-0.27.ckan
@@ -18,7 +18,7 @@
     "abstract": "Build upon the ForScience mod by WaveFunctionP. This version adds an interface and exciting new features to it.",
     "author": "SpaceTiger",
     "version": "0.27",
-    "download": "https://kerbalstuff.com/mod/477/ForScience%20Continued%21/download/0.27",
+    "download": "http://i.52k.de/kspmods/storage/SpaceTiger_5933/ForScience_Continued/ForScience_Continued-0.27.zip",
     "x_generated_by": "netkan",
     "download_size": 77016
 }

--- a/ForScienceContinued/ForScienceContinued-1.0.0.ckan
+++ b/ForScienceContinued/ForScienceContinued-1.0.0.ckan
@@ -23,7 +23,7 @@
     "abstract": "Build upon the ForScience mod by WaveFunctionP. This version adds an interface and exciting new features to it.",
     "author": "SpaceTiger",
     "version": "1.0.0",
-    "download": "https://kerbalstuff.com/mod/477/ForScience%20Continued%21/download/1.0.0",
+    "download": "http://i.52k.de/kspmods/storage/SpaceTiger_5933/ForScience_Continued/ForScience_Continued-1.0.0.zip",
     "x_generated_by": "netkan",
     "download_size": 84794
 }

--- a/ForScienceContinued/ForScienceContinued-1.0.1.ckan
+++ b/ForScienceContinued/ForScienceContinued-1.0.1.ckan
@@ -23,7 +23,7 @@
     "abstract": "Build upon the ForScience mod by WaveFunctionP. This version adds an interface and exciting new features to it.",
     "author": "SpaceTiger",
     "version": "1.0.1",
-    "download": "https://kerbalstuff.com/mod/477/ForScience%20Continued%21/download/1.0.1",
+    "download": "http://i.52k.de/kspmods/storage/SpaceTiger_5933/ForScience_Continued/ForScience_Continued-1.0.1.zip",
     "x_generated_by": "netkan",
     "download_size": 84711
 }

--- a/ForScienceContinued/ForScienceContinued-1.0.2.ckan
+++ b/ForScienceContinued/ForScienceContinued-1.0.2.ckan
@@ -23,7 +23,7 @@
     "abstract": "Build upon the ForScience mod by WaveFunctionP. This version adds an interface and exciting new features to it.",
     "author": "SpaceTiger",
     "version": "1.0.2",
-    "download": "https://kerbalstuff.com/mod/477/ForScience%20Continued%21/download/1.0.2",
+    "download": "http://i.52k.de/kspmods/storage/SpaceTiger_5933/ForScience_Continued/ForScience_Continued-1.0.2.zip",
     "x_generated_by": "netkan",
     "download_size": 86053
 }

--- a/ForScienceContinued/ForScienceContinued-1.0.3.ckan
+++ b/ForScienceContinued/ForScienceContinued-1.0.3.ckan
@@ -23,7 +23,7 @@
     "abstract": "Build upon the ForScience mod by WaveFunctionP. This version adds an interface and exciting new features to it.",
     "author": "SpaceTiger",
     "version": "1.0.3",
-    "download": "https://kerbalstuff.com/mod/477/ForScience%20Continued%21/download/1.0.3",
+    "download": "http://i.52k.de/kspmods/storage/SpaceTiger_5933/ForScience_Continued/ForScience_Continued-1.0.3.zip",
     "x_generated_by": "netkan",
     "download_size": 86198
 }

--- a/ForScienceContinued/ForScienceContinued-1.0.4.ckan
+++ b/ForScienceContinued/ForScienceContinued-1.0.4.ckan
@@ -19,7 +19,7 @@
     "abstract": "Build upon the ForScience mod by WaveFunctionP. This version adds an interface and exciting new features to it.",
     "version": "1.0.4",
     "author": "SpaceTiger",
-    "download": "https://kerbalstuff.com/mod/477/ForScience%20Continued%21/download/1.0.4",
+    "download": "http://i.52k.de/kspmods/storage/SpaceTiger_5933/ForScience_Continued/ForScience_Continued-1.0.4.zip",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106004-0-90-ForScience-Continued",
         "repository": "https://github.com/Xarun/ForScience/",

--- a/ForScienceContinued/ForScienceContinued-1.1.0.ckan
+++ b/ForScienceContinued/ForScienceContinued-1.1.0.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData/KerboKatz"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/477/ForScience%20Continued%21/download/1.1.0",
+    "download": "http://i.52k.de/kspmods/storage/SpaceTiger_5933/ForScience_Continued/ForScience_Continued-1.1.0.zip",
     "download_size": 88638,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/HexisRoundedAttachmentKit/HexisRoundedAttachmentKit-0.1.ckan
+++ b/HexisRoundedAttachmentKit/HexisRoundedAttachmentKit-0.1.ckan
@@ -16,7 +16,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1034/Hexi%27s%20Rounded%20Attachment%20Kit/download/0.1",
+    "download": "http://i.52k.de/kspmods/storage/Hexicube_13201/Hexis_Rounded_Attachment_Kit/Hexis_Rounded_Attachment_Kit-0.1.zip",
     "download_size": 105635,
     "x_generated_by": "netkan"
 }

--- a/KKPsMoarKerbals/KKPsMoarKerbals-1.1.ckan
+++ b/KKPsMoarKerbals/KKPsMoarKerbals-1.1.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/461/KKP%27s%20MoarKerbals/download/1.1",
+    "download": "http://i.52k.de/kspmods/storage/strideknight_5484/KKPs_MoarKerbals/KKPs_MoarKerbals-1.1.zip",
     "download_size": 5068824,
     "x_generated_by": "netkan"
 }

--- a/KPseudonym-ConfigPack-International/KPseudonym-ConfigPack-International-v1.0.ckan
+++ b/KPseudonym-ConfigPack-International/KPseudonym-ConfigPack-International-v1.0.ckan
@@ -26,7 +26,7 @@
             ]
         }
     ],
-    "download": "https://kerbalstuff.com/mod/537/peadar1987%27s%20KPseudonym%20config%20pack/download/v1.0",
+    "download": "http://i.52k.de/kspmods/storage/peadar1987_6684/peadar1987s_KPseudonym_config_pack/peadar1987s_KPseudonym_config_pack-v1.0.zip",
     "download_size": 70965,
     "x_generated_by": "netkan"
 }

--- a/Kaboom/Kaboom-1.1.0.ckan
+++ b/Kaboom/Kaboom-1.1.0.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/471/Kaboom%21/download/1.1.0",
+    "download": "http://i.52k.de/kspmods/storage/russnash_5698/Kaboom/Kaboom-1.1.0.zip",
     "download_size": 25683,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/LetThereBeLight/LetThereBeLight-v1.3.ckan
+++ b/LetThereBeLight/LetThereBeLight-v1.3.ckan
@@ -13,7 +13,7 @@
     },
     "version": "v1.3",
     "ksp_version": "0.90.0",
-    "download": "https://kerbalstuff.com/mod/603/LetThereBeLight%21/download/v1.3",
+    "download": "http://i.52k.de/kspmods/storage/comma_7315/LetThereBeLight/LetThereBeLight-v1.3.zip",
     "download_size": 8566,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/MoarEggs/MoarEggs-1.2.0_-_KSP_1.0_Update.ckan
+++ b/MoarEggs/MoarEggs-1.2.0_-_KSP_1.0_Update.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/681/Moar%20Eggs%21/download/1.2.0_-_KSP_1.0_Update",
+    "download": "http://i.52k.de/kspmods/storage/ENygma_8485/Moar_Eggs/Moar_Eggs-1.2.0_-_KSP_1.0_Update.zip",
     "download_size": 709859,
     "x_generated_by": "netkan"
 }

--- a/MrScienceMeistersNuclearWarfare/MrScienceMeistersNuclearWarfare-0.5.1.ckan
+++ b/MrScienceMeistersNuclearWarfare/MrScienceMeistersNuclearWarfare-0.5.1.ckan
@@ -24,7 +24,7 @@
             "filter": ".DS_Store"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/990/MrScienceMeister%27s%20Nuclear%20Warfare/download/0.5.1",
+    "download": "http://i.52k.de/kspmods/storage/MrScienceMeister_12552/MrScienceMeisters_Nuclear_Warfare/MrScienceMeisters_Nuclear_Warfare-0.5.1.zip",
     "download_size": 2639236,
     "x_generated_by": "netkan"
 }

--- a/MrScienceMeistersNuclearWarfare/MrScienceMeistersNuclearWarfare-v0.3.ckan
+++ b/MrScienceMeistersNuclearWarfare/MrScienceMeistersNuclearWarfare-v0.3.ckan
@@ -19,7 +19,7 @@
     "abstract": "A relatively simple mod that adds in parts for you to wage nuclear war.  Requires BD Armory",
     "version": "v0.3",
     "author": "MrScienceMeister",
-    "download": "https://kerbalstuff.com/mod/990/MrScienceMeister%27s%20Nuclear%20Warfare/download/v0.3",
+    "download": "http://i.52k.de/kspmods/storage/MrScienceMeister_12552/MrScienceMeisters_Nuclear_Warfare/MrScienceMeisters_Nuclear_Warfare-v0.3.zip",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/128402-WIP-Nuclear-Warfare?p=2073062#post2073062",
         "kerbalstuff": "https://kerbalstuff.com/mod/990/MrScienceMeister's%20Nuclear%20Warfare",

--- a/MrScienceMeistersNuclearWarfare/MrScienceMeistersNuclearWarfare-v0.4_Moar_Missiles.ckan
+++ b/MrScienceMeistersNuclearWarfare/MrScienceMeistersNuclearWarfare-v0.4_Moar_Missiles.ckan
@@ -24,7 +24,7 @@
             "filter": ".DS_Store"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/990/MrScienceMeister%27s%20Nuclear%20Warfare/download/v0.4_Moar_Missiles",
+    "download": "http://i.52k.de/kspmods/storage/MrScienceMeister_12552/MrScienceMeisters_Nuclear_Warfare/MrScienceMeisters_Nuclear_Warfare-v0.4_Moar_Missiles.zip",
     "download_size": 2750608,
     "x_generated_by": "netkan"
 }

--- a/MrScienceMeistersSimpleNuclearReactor/MrScienceMeistersSimpleNuclearReactor-v0.1.ckan
+++ b/MrScienceMeistersSimpleNuclearReactor/MrScienceMeistersSimpleNuclearReactor-v0.1.ckan
@@ -19,7 +19,7 @@
             "filter": ".DS_Store"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/994/MrScienceMeister%27s%20SimpleNuclearReactor/download/v0.1",
+    "download": "http://i.52k.de/kspmods/storage/MrScienceMeister_12552/MrScienceMeisters_SimpleNuclearReactor/MrScienceMeisters_SimpleNuclearReactor-v0.1.zip",
     "download_size": 343462,
     "x_generated_by": "netkan"
 }

--- a/NEAR/NEAR-1.3.1.ckan
+++ b/NEAR/NEAR-1.3.1.ckan
@@ -23,7 +23,7 @@
     "abstract": "NEAR replaces KSP's stock mass-based aerodynamics model with a relatively simple, slightly more realistic one.",
     "version": "1.3.1",
     "author": "ferram4",
-    "download": "https://kerbalstuff.com/mod/54/Neophyte%27s%20Elementary%20Aerodynamics%20Replacement/download/v1.3.1",
+    "download": "http://i.52k.de/kspmods/storage/ferram4_54/Neophytes_Elementary_Aerodynamics_Replacement/Neophytes_Elementary_Aerodynamics_Replacement-v1.3.1.zip",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/86419",
         "repository": "https://github.com/ferram4/Ferram-Aerospace-Research/tree/NEAR",

--- a/NEAR/NEAR-v1.3.1.ckan
+++ b/NEAR/NEAR-v1.3.1.ckan
@@ -29,7 +29,7 @@
             "name": "FerramAerospaceResearch"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/54/Neophyte%27s%20Elementary%20Aerodynamics%20Replacement/download/v1.3.1",
+    "download": "http://i.52k.de/kspmods/storage/ferram4_54/Neophytes_Elementary_Aerodynamics_Replacement/Neophytes_Elementary_Aerodynamics_Replacement-v1.3.1.zip",
     "download_size": 78227,
     "x_generated_by": "netkan"
 }

--- a/NyrathsUSAFOrion/NyrathsUSAFOrion-1.0.19b.ckan
+++ b/NyrathsUSAFOrion/NyrathsUSAFOrion-1.0.19b.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1170/Nyrath%27s%20USAFOrion/download/1.0.19b",
+    "download": "http://i.52k.de/kspmods/storage/TiktaalikDreaming_7164/Nyraths_USAFOrion/Nyraths_USAFOrion-1.0.19b.zip",
     "download_size": 9712177,
     "x_generated_by": "netkan"
 }

--- a/OTHOABsTankMergerforProceduralParts/OTHOABsTankMergerforProceduralParts-0.12.ckan
+++ b/OTHOABsTankMergerforProceduralParts/OTHOABsTankMergerforProceduralParts-0.12.ckan
@@ -22,7 +22,7 @@
             "install_to": "GameData/OTHOABmisc"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/486/OTHOAB%27s%20textures%20for%20Procedural%20Parts/download/0.12",
+    "download": "http://i.52k.de/kspmods/storage/OTHOAB_6015/OTHOABs_textures_for_Procedural_Parts/OTHOABs_textures_for_Procedural_Parts-0.12.zip",
     "download_size": 4108032,
     "x_generated_by": "netkan"
 }

--- a/OTHOABstexturesforProceduralParts/OTHOABstexturesforProceduralParts-0.12.ckan
+++ b/OTHOABstexturesforProceduralParts/OTHOABstexturesforProceduralParts-0.12.ckan
@@ -22,7 +22,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/486/OTHOAB%27s%20textures%20for%20Procedural%20Parts/download/0.12",
+    "download": "http://i.52k.de/kspmods/storage/OTHOAB_6015/OTHOABs_textures_for_Procedural_Parts/OTHOABs_textures_for_Procedural_Parts-0.12.zip",
     "download_size": 4108032,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/Olympic1ARPIcons/Olympic1ARPIcons-0.6.0a.ckan
+++ b/Olympic1ARPIcons/Olympic1ARPIcons-0.6.0a.ckan
@@ -76,7 +76,7 @@
             "filter": "thumbs.db"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1095/Olympic1%27s%20ARP%20Icons/download/0.6.0a",
+    "download": "http://i.52k.de/kspmods/storage/Olympic1_4967/Olympic1s_ARP_Icons/Olympic1s_ARP_Icons-0.6.0a.zip",
     "download_size": 177334,
     "x_generated_by": "netkan"
 }

--- a/Olympic1ARPIcons/Olympic1ARPIcons-v0.7.0.ckan
+++ b/Olympic1ARPIcons/Olympic1ARPIcons-v0.7.0.ckan
@@ -76,7 +76,7 @@
             "filter": "thumbs.db"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1095/Olympic1%27s%20ARP%20Icons/download/v0.7.0",
+    "download": "http://i.52k.de/kspmods/storage/Olympic1_4967/Olympic1s_ARP_Icons/Olympic1s_ARP_Icons-v0.7.0.zip",
     "download_size": 243903,
     "x_generated_by": "netkan"
 }

--- a/Olympic1ARPIcons/Olympic1ARPIcons-v0.7.1.ckan
+++ b/Olympic1ARPIcons/Olympic1ARPIcons-v0.7.1.ckan
@@ -76,7 +76,7 @@
             "filter": "thumbs.db"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1095/Olympic1%27s%20ARP%20Icons/download/v0.7.1",
+    "download": "http://i.52k.de/kspmods/storage/Olympic1_4967/Olympic1s_ARP_Icons/Olympic1s_ARP_Icons-v0.7.1.zip",
     "download_size": 245365,
     "x_generated_by": "netkan"
 }

--- a/Olympic1ARPIcons/Olympic1ARPIcons-v0.7.2.ckan
+++ b/Olympic1ARPIcons/Olympic1ARPIcons-v0.7.2.ckan
@@ -76,7 +76,7 @@
             "filter": "thumbs.db"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1095/Olympic1%27s%20ARP%20Icons/download/v0.7.2",
+    "download": "http://i.52k.de/kspmods/storage/Olympic1_4967/Olympic1s_ARP_Icons/Olympic1s_ARP_Icons-v0.7.2.zip",
     "download_size": 245637,
     "x_generated_by": "netkan"
 }

--- a/RedversusBlue/RedversusBlue-0.0.0.ckan
+++ b/RedversusBlue/RedversusBlue-0.0.0.ckan
@@ -24,7 +24,7 @@
             "filter": ".DS_Store"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1077/Red%20versus%20Blue%21%20A%20BDArmory%20expansion%20pack/download/0.0.0",
+    "download": "http://i.52k.de/kspmods/storage/MaxSimm_13703/Red_versus_Blue_A_BDArmory_expansion_pack/Red_versus_Blue_A_BDArmory_expansion_pack-0.0.0.zip",
     "download_size": 681122,
     "x_generated_by": "netkan"
 }

--- a/RedversusBlue/RedversusBlue-0.1.ckan
+++ b/RedversusBlue/RedversusBlue-0.1.ckan
@@ -24,7 +24,7 @@
             "filter": ".DS_Store"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1077/Red%20versus%20Blue%21%20A%20BDArmory%20expansion%20pack/download/0.1",
+    "download": "http://i.52k.de/kspmods/storage/MaxSimm_13703/Red_versus_Blue_A_BDArmory_expansion_pack/Red_versus_Blue_A_BDArmory_expansion_pack-0.1.zip",
     "download_size": 2433825,
     "x_generated_by": "netkan"
 }

--- a/RhatssPlanetpack/RhatssPlanetpack-0.1.ckan
+++ b/RhatssPlanetpack/RhatssPlanetpack-0.1.ckan
@@ -18,7 +18,7 @@
     "abstract": "RPM is a planet pack. take a look",
     "version": "0.1",
     "author": "Roberthasalltehswag",
-    "download": "https://kerbalstuff.com/mod/1074/Rhats%27s%20Planet%20pack/download/0.1",
+    "download": "http://i.52k.de/kspmods/storage/Roberthasalltehswag_11107/Rhatss_Planet_pack/Rhatss_Planet_pack-0.1.zip",
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/1074/Rhats's%20Planet%20pack",
         "x_screenshot": "https://kerbalstuff.com/content/Roberthasalltehswag_11107/Rhatss_Planet_pack/Rhatss_Planet_pack-1439407601.2785337.png"

--- a/RhatssPlanetpack/RhatssPlanetpack-1.2.ckan
+++ b/RhatssPlanetpack/RhatssPlanetpack-1.2.ckan
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1074/Rhats%27s%20Planet%20pack/download/1.2",
+    "download": "http://i.52k.de/kspmods/storage/Roberthasalltehswag_11107/Rhatss_Planet_pack/Rhatss_Planet_pack-1.2.zip",
     "download_size": 39897555,
     "x_generated_by": "netkan"
 }

--- a/RhatssPlanetpack/RhatssPlanetpack-2.0.ckan
+++ b/RhatssPlanetpack/RhatssPlanetpack-2.0.ckan
@@ -22,7 +22,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1074/Rhats%27s%20Planet%20pack/download/2.0",
+    "download": "http://i.52k.de/kspmods/storage/Roberthasalltehswag_11107/Rhatss_Planet_pack/Rhatss_Planet_pack-2.0.zip",
     "download_size": 39897555,
     "x_generated_by": "netkan"
 }

--- a/Sirens/Sirens-1.0.ckan
+++ b/Sirens/Sirens-1.0.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1258/Sirens%21/download/1.0",
+    "download": "http://i.52k.de/kspmods/storage/Azimech_2742/Sirens/Sirens-1.0.zip",
     "download_size": 1334605,
     "x_generated_by": "netkan"
 }

--- a/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-6.9.ckan
+++ b/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-6.9.ckan
@@ -29,7 +29,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1289/Stryker%27s%20Aerospace%20and%20IVA%27s/download/6.9",
+    "download": "http://i.52k.de/kspmods/storage/strykersm_1142/Strykers_Aerospace_and_IVAs/Strykers_Aerospace_and_IVAs-6.9.zip",
     "download_size": 3625516,
     "x_generated_by": "netkan"
 }

--- a/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-7.1.ckan
+++ b/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-7.1.ckan
@@ -29,7 +29,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1289/Stryker%27s%20Aerospace%20and%20IVA%27s/download/7.1",
+    "download": "http://i.52k.de/kspmods/storage/strykersm_1142/Strykers_Aerospace_and_IVAs/Strykers_Aerospace_and_IVAs-7.1.zip",
     "download_size": 4251743,
     "x_generated_by": "netkan"
 }

--- a/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-7.2.ckan
+++ b/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-7.2.ckan
@@ -29,7 +29,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1289/Stryker%27s%20Aerospace%20and%20IVA%27s/download/7.2",
+    "download": "http://i.52k.de/kspmods/storage/strykersm_1142/Strykers_Aerospace_and_IVAs/Strykers_Aerospace_and_IVAs-7.2.zip",
     "download_size": 4460833,
     "x_generated_by": "netkan"
 }

--- a/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-7.31.ckan
+++ b/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-7.31.ckan
@@ -29,7 +29,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1289/Stryker%27s%20Aerospace%20and%20IVA%27s/download/7.31",
+    "download": "http://i.52k.de/kspmods/storage/strykersm_1142/Strykers_Aerospace_and_IVAs/Strykers_Aerospace_and_IVAs-7.31.zip",
     "download_size": 4511647,
     "x_generated_by": "netkan"
 }

--- a/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-V5.1.ckan
+++ b/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-V5.1.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1289/Stryker%27s%20Aerospace%20and%20IVA%27s/download/V5.1",
+    "download": "http://i.52k.de/kspmods/storage/strykersm_1142/Strykers_Aerospace_and_IVAs/Strykers_Aerospace_and_IVAs-V5.1.zip",
     "download_size": 3067177,
     "x_generated_by": "netkan"
 }

--- a/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-V5.ckan
+++ b/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-V5.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1289/Stryker%27s%20Aerospace%20and%20IVA%27s/download/V5",
+    "download": "http://i.52k.de/kspmods/storage/strykersm_1142/Strykers_Aerospace_and_IVAs/Strykers_Aerospace_and_IVAs-V5.zip",
     "download_size": 2989774,
     "x_generated_by": "netkan"
 }

--- a/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-V6.1.ckan
+++ b/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-V6.1.ckan
@@ -29,7 +29,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1289/Stryker%27s%20Aerospace%20and%20IVA%27s/download/V6.1",
+    "download": "http://i.52k.de/kspmods/storage/strykersm_1142/Strykers_Aerospace_and_IVAs/Strykers_Aerospace_and_IVAs-V6.1.zip",
     "download_size": 3344305,
     "x_generated_by": "netkan"
 }

--- a/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-V6.ckan
+++ b/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-V6.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1289/Stryker%27s%20Aerospace%20and%20IVA%27s/download/V6",
+    "download": "http://i.52k.de/kspmods/storage/strykersm_1142/Strykers_Aerospace_and_IVAs/Strykers_Aerospace_and_IVAs-V6.zip",
     "download_size": 3344109,
     "x_generated_by": "netkan"
 }

--- a/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-V8.1.ckan
+++ b/StrykersAerospaceandIVAs/StrykersAerospaceandIVAs-V8.1.ckan
@@ -39,7 +39,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1289/Stryker%27s%20Aerospace%20and%20IVA%27s/download/V8.1",
+    "download": "http://i.52k.de/kspmods/storage/strykersm_1142/Strykers_Aerospace_and_IVAs/Strykers_Aerospace_and_IVAs-V8.1.zip",
     "download_size": 15197506,
     "x_generated_by": "netkan"
 }

--- a/TDIndustrysOrionbits10m/TDIndustrysOrionbits10m-0.26.ckan
+++ b/TDIndustrysOrionbits10m/TDIndustrysOrionbits10m-0.26.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/586/TD%20Industry%27s%20Orion%20bits%2010m/download/0.26",
+    "download": "http://i.52k.de/kspmods/storage/TiktaalikDreaming_7164/TD_Industrys_Orion_bits_10m/TD_Industrys_Orion_bits_10m-0.26.zip",
     "download_size": 29791605,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/TDIndustrysOrionbits10m/TDIndustrysOrionbits10m-0.3.0.ckan
+++ b/TDIndustrysOrionbits10m/TDIndustrysOrionbits10m-0.3.0.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/586/TD%20Industry%27s%20Orion%20bits%2010m/download/0.3.0",
+    "download": "http://i.52k.de/kspmods/storage/TiktaalikDreaming_7164/TD_Industrys_Orion_bits_10m/TD_Industrys_Orion_bits_10m-0.3.0.zip",
     "download_size": 16445973,
     "x_via": "Automated KerbalStuff CKAN submission",
     "x_generated_by": "netkan"

--- a/TheMartianRockets/TheMartianRockets-25_I_really_dont_know.ckan
+++ b/TheMartianRockets/TheMartianRockets-25_I_really_dont_know.ckan
@@ -23,7 +23,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1192/MajorLeaugeRocketScience%27s%20The%20Martian%20Rockets/download/25_I_really_dont_know",
+    "download": "http://i.52k.de/kspmods/storage/CliftonM_12500/MajorLeaugeRocketSciences_The_Martian_Rockets/MajorLeaugeRocketSciences_The_Martian_Rockets-25_I_really_dont_know.zip",
     "download_size": 2526909,
     "x_generated_by": "netkan"
 }

--- a/VaporosBlueGalaxySkybox/VaporosBlueGalaxySkybox-1.0.ckan
+++ b/VaporosBlueGalaxySkybox/VaporosBlueGalaxySkybox-1.0.ckan
@@ -30,7 +30,7 @@
             "install_to": "GameData/TextureReplacer"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1413/Vaporo%27s%20Blue%20Galaxy%20Skybox/download/1.0",
+    "download": "http://i.52k.de/kspmods/storage/Vaporo_19313/Vaporos_Blue_Galaxy_Skybox/Vaporos_Blue_Galaxy_Skybox-1.0.zip",
     "download_size": 3737042,
     "x_generated_by": "netkan"
 }

--- a/VerticalPropulsionEmporium/VerticalPropulsionEmporium-v0.20a.ckan
+++ b/VerticalPropulsionEmporium/VerticalPropulsionEmporium-v0.20a.ckan
@@ -32,7 +32,7 @@
     "abstract": "Vertical Propulsion Emporium",
     "author": "Kerb_fu",
     "version": "v0.20a",
-    "download": "https://kerbalstuff.com/mod/275/Professor%20Phineas%20Kerbenstein%27s%20wonderous%20vertical%20propulsion%20emporium./download/v0.20a",
+    "download": "http://i.52k.de/kspmods/storage/Kerb_fu_3094/Professor_Phineas_Kerbensteins_wonderous_vertical_propulsion_emporium/Professor_Phineas_Kerbensteins_wonderous_vertical_propulsion_emporium-v0.20a.zip",
     "x_generated_by": "netkan",
     "download_size": 22263178
 }

--- a/VerticalPropulsionEmporium/VerticalPropulsionEmporium-v0.21b.ckan
+++ b/VerticalPropulsionEmporium/VerticalPropulsionEmporium-v0.21b.ckan
@@ -32,7 +32,7 @@
     "abstract": "Vertical Propulsion Emporium",
     "author": "Kerb_fu",
     "version": "v0.21b",
-    "download": "https://kerbalstuff.com/mod/275/Professor%20Phineas%20Kerbenstein%27s%20wonderous%20vertical%20propulsion%20emporium./download/v0.21b",
+    "download": "http://i.52k.de/kspmods/storage/Kerb_fu_3094/Professor_Phineas_Kerbensteins_wonderous_vertical_propulsion_emporium/Professor_Phineas_Kerbensteins_wonderous_vertical_propulsion_emporium-v0.21b.zip",
     "x_generated_by": "netkan",
     "download_size": 27941112
 }

--- a/VerticalPropulsionEmporium/VerticalPropulsionEmporium-v0.22b.ckan
+++ b/VerticalPropulsionEmporium/VerticalPropulsionEmporium-v0.22b.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/275/Professor%20Phineas%20Kerbenstein%27s%20wonderous%20vertical%20propulsion%20emporium./download/v0.22b",
+    "download": "http://i.52k.de/kspmods/storage/Kerb_fu_3094/Professor_Phineas_Kerbensteins_wonderous_vertical_propulsion_emporium/Professor_Phineas_Kerbensteins_wonderous_vertical_propulsion_emporium-v0.22b.zip",
     "download_size": 28468192,
     "ksp_min_version": "0.25",
     "x_generated_by": "netkan"

--- a/WernhersOldBits/WernhersOldBits-0.1.ckan
+++ b/WernhersOldBits/WernhersOldBits-0.1.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1345/Wernher%27s%20Old%20Bits/download/0.1",
+    "download": "http://i.52k.de/kspmods/storage/TiktaalikDreaming_7164/Wernhers_Old_Bits/Wernhers_Old_Bits-0.1.zip",
     "download_size": 725406,
     "x_generated_by": "netkan"
 }

--- a/WernhersOldBits/WernhersOldBits-0.2.ckan
+++ b/WernhersOldBits/WernhersOldBits-0.2.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1345/Wernher%27s%20Old%20Bits/download/0.2",
+    "download": "http://i.52k.de/kspmods/storage/TiktaalikDreaming_7164/Wernhers_Old_Bits/Wernhers_Old_Bits-0.2.zip",
     "download_size": 830721,
     "x_generated_by": "netkan"
 }

--- a/WernhersOldBits/WernhersOldBits-0.3.ckan
+++ b/WernhersOldBits/WernhersOldBits-0.3.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1345/Wernher%27s%20Old%20Bits/download/0.3",
+    "download": "http://i.52k.de/kspmods/storage/TiktaalikDreaming_7164/Wernhers_Old_Bits/Wernhers_Old_Bits-0.3.zip",
     "download_size": 991847,
     "x_generated_by": "netkan"
 }

--- a/WernhersOldBits/WernhersOldBits-0.4.ckan
+++ b/WernhersOldBits/WernhersOldBits-0.4.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1345/Wernher%27s%20Old%20Bits/download/0.4",
+    "download": "http://i.52k.de/kspmods/storage/TiktaalikDreaming_7164/Wernhers_Old_Bits/Wernhers_Old_Bits-0.4.zip",
     "download_size": 1033236,
     "x_generated_by": "netkan"
 }

--- a/WernhersOldBits/WernhersOldBits-0.5.ckan
+++ b/WernhersOldBits/WernhersOldBits-0.5.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1345/Wernher%27s%20Old%20Bits/download/0.5",
+    "download": "http://i.52k.de/kspmods/storage/TiktaalikDreaming_7164/Wernhers_Old_Bits/Wernhers_Old_Bits-0.5.zip",
     "download_size": 1144768,
     "x_generated_by": "netkan"
 }

--- a/WernhersOldBits/WernhersOldBits-0.6.ckan
+++ b/WernhersOldBits/WernhersOldBits-0.6.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1345/Wernher%27s%20Old%20Bits/download/0.6",
+    "download": "http://i.52k.de/kspmods/storage/TiktaalikDreaming_7164/Wernhers_Old_Bits/Wernhers_Old_Bits-0.6.zip",
     "download_size": 1159699,
     "x_generated_by": "netkan"
 }

--- a/sidosUraniaSystem/sidosUraniaSystem-0.8.ckan
+++ b/sidosUraniaSystem/sidosUraniaSystem-0.8.ckan
@@ -39,7 +39,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/1185/Sido%27s%20Urania%20Planet%20Pack/download/0.8",
+    "download": "http://i.52k.de/kspmods/storage/Sido_15185/Sidos_Urania_Planet_Pack/Sidos_Urania_Planet_Pack-0.8.zip",
     "download_size": 81740605,
     "x_generated_by": "netkan"
 }

--- a/superspaceparts/superspaceparts-0.3.2.ckan
+++ b/superspaceparts/superspaceparts-0.3.2.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/846/super%20space%20parts%21/download/0.3.2",
+    "download": "http://i.52k.de/kspmods/storage/niky83160_8279/super_space_parts/super_space_parts-0.3.2.zip",
     "download_size": 727663,
     "x_generated_by": "netkan"
 }

--- a/superspaceparts/superspaceparts-1.x.ckan
+++ b/superspaceparts/superspaceparts-1.x.ckan
@@ -17,7 +17,7 @@
     "abstract": "add economic fuel tank ;)",
     "author": "niky83160",
     "version": "1.x",
-    "download": "https://kerbalstuff.com/mod/846/super%20space%20parts%21/download/1.x",
+    "download": "http://i.52k.de/kspmods/storage/niky83160_8279/super_space_parts/super_space_parts-1.x.zip",
     "x_generated_by": "netkan",
     "download_size": 572012
 }

--- a/superspaceparts/superspaceparts-v.0.3.ckan
+++ b/superspaceparts/superspaceparts-v.0.3.ckan
@@ -17,7 +17,7 @@
     "abstract": "add economical parts to ksp",
     "author": "niky83160",
     "version": "v.0.3",
-    "download": "https://kerbalstuff.com/mod/846/super%20space%20parts%21/download/v.0.3",
+    "download": "http://i.52k.de/kspmods/storage/niky83160_8279/super_space_parts/super_space_parts-v.0.3.zip",
     "x_generated_by": "netkan",
     "download_size": 727832
 }


### PR DESCRIPTION
Using 23a6e900c03a9b76a0b47aa278287b87d4752577 of my tools, this migrates mods that are present on i52.de from KerbalStuff when the URLs contain exclamation marks (which were previously confusing my converter).