### PR TITLE
Revert "HeatManagement and VanguardAstrodynamicsVXSeries to spacedock downloads"

### DIFF
--- a/HeatManagement/HeatManagement-0.26.3.ckan
+++ b/HeatManagement/HeatManagement-0.26.3.ckan
@@ -6,7 +6,9 @@
     "author": "Randazzo",
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/118189"
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/118189",
+        "kerbalstuff": "https://kerbalstuff.com/mod/723/Heat%20Management",
+        "x_screenshot": "https://kerbalstuff.com/content/Randazzo_9223/Heat_Management/Heat_Management-1433314874.6989393.png"
     },
     "version": "0.26.3",
     "ksp_version": "1.0.5",
@@ -24,7 +26,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "http://spacedock.info/mod/65/Heat%20Management/download/0.26.3",
+    "download": "http://i.52k.de/kspmods/storage/Randazzo_9223/Heat_Management/Heat_Management-0.26.3.zip",
     "download_size": 2444907,
     "x_generated_by": "netkan"
 }

--- a/VanguardAstrodynamicsVXSeries/VanguardAstrodynamicsVXSeries-1.2.1.ckan
+++ b/VanguardAstrodynamicsVXSeries/VanguardAstrodynamicsVXSeries-1.2.1.ckan
@@ -6,7 +6,9 @@
     "author": "Randazzo",
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/127803-1-0-4-Vanguard-Astrodynamics-VX-series-stockalike-engine-pack-(1-0)"
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/127803-1-0-4-Vanguard-Astrodynamics-VX-series-stockalike-engine-pack-(1-0)",
+        "kerbalstuff": "https://kerbalstuff.com/mod/973/Vanguard%20Astrodynamics%20VX%20Series%20Stockalike%20Engine%20Pack",
+        "x_screenshot": "https://kerbalstuff.com/content/Randazzo_9223/Vanguard_Astrodynamics_VX_Series_Stockalike_Engine_Pack/Vanguard_Astrodynamics_VX_Series_Stockalike_Engine_Pack-1436088954.0255756.png"
     },
     "version": "1.2.1",
     "ksp_version": "1.0.5",
@@ -16,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "http://spacedock.info/mod/68/VX%20Series%20Stockalike%20Engine%20Pack/download/1.2.1",
+    "download": "http://i.52k.de/kspmods/storage/Randazzo_9223/Vanguard_Astrodynamics_VX_Series_Stockalike_Engine_Pack/Vanguard_Astrodynamics_VX_Series_Stockalike_Engine_Pack-1.2.1.zip",
     "download_size": 3646417,
     "x_generated_by": "netkan"
 }


### PR DESCRIPTION
Reverts KSP-CKAN/CKAN-meta#980

Spacedock links died.