### PR TITLE
Move VesselView to Dropbox

### DIFF
--- a/VesselView/VesselView-v0.71.ckan
+++ b/VesselView/VesselView-v0.71.ckan
@@ -6,14 +6,12 @@
     "author": "PeteTimesSix",
     "license": "MIT",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/80581-0-90-Vessel-Viewer",
-        "kerbalstuff": "https://kerbalstuff.com/mod/731/Vessel%20Viewer",
-        "repository": "https://github.com/PeteTimesSix/VesselViewer",
-        "x_screenshot": "https://kerbalstuff.com/content/PeteTimesSix_9312/Vessel_Viewer/Vessel_Viewer-1430515428.3340502.jpg"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72855-102-vessel-viewer",
+        "repository": "https://github.com/PeteTimesSix/VesselViewer"
     },
     "version": "v0.71",
     "ksp_version_min": "1.0.2",
-    "ksp_version_max": "1.0.4",
+    "ksp_version_max": "1.0.5",
     "depends": [
         {
             "name": "Toolbar"
@@ -27,7 +25,7 @@
             "name": "RasterPropMonitor"
         }
     ],
-    "download": "http://ckan1.spacedock.info/storage/PeteTimesSix_9312/Vessel_Viewer/Vessel_Viewer-0.71.zip",
+    "download": "https://dl.dropbox.com/s/odezb7nj3gb03xa/VVComplete.zip?dl=0",
     "download_size": 40378,
     "x_generated_by": "netkan"
 }


### PR DESCRIPTION
Primary download on forum thread, takes the load off the KS mirror.
Advised this mod is functional in 1.0.5 in CKAN forum thread
Next version of this mod is probably going to need an epoch.