### PR TITLE
Use the latest metadata for Jenkins builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -119,8 +119,8 @@ create_dummy_ksp () {
     mono ckan.exe ksp default $KSP_NAME
     
     # Point to the local metadata instead of GitHub.
-    mono ckan.exe repo add local "file://`pwd`/master.tar.gz"
-    mono ckan.exe repo remove default
+    # mono ckan.exe repo add local "file://`pwd`/master.tar.gz"
+    # mono ckan.exe repo remove default
     
     # Link to the downloads cache.
     ln -s ../../downloads_cache/ dummy_ksp/CKAN/downloads/


### PR DESCRIPTION
By not taking the git repo from github, we're unable to capture any changes that are meant to fix the build (ex. fixing a broken dependency download) unless the PR is rebased -- I'm pretty sure there's a specific reason we don't take the latest master, but I can't recall what it is.

There have been several cases in the past week or 2 that can demonstrate how this fails, including but not limited to https://github.com/KSP-CKAN/CKAN-meta/pull/1001 trying to fix the build of https://github.com/KSP-CKAN/CKAN-meta/pull/1000

Tagging @techman83 as Jenkins' loving dad. =)