### PR TITLE
Fix typo

### DIFF
--- a/KerboKatzSmallUtilities-DisableTempGauges/KerboKatzSmallUtilities-DisableTempGauges-1.0.0.ckan
+++ b/KerboKatzSmallUtilities-DisableTempGauges/KerboKatzSmallUtilities-DisableTempGauges-1.0.0.ckan
@@ -17,9 +17,14 @@
             "name": "KerboKatzUtilities"
         }
     ],
+    "conflicts": [
+        {
+            "name": "DisableTempGagues"
+        }
+    ],
     "install": [
         {
-            "find": "DisableTempGauges",
+            "find": "DisableTempGagues",
             "install_to": "GameData/KerboKatz/SmallUtilities"
         }
     ],

--- a/KerboKatzSmallUtilities-DisableTempGauges/KerboKatzSmallUtilities-DisableTempGauges-1.0.0.ckan
+++ b/KerboKatzSmallUtilities-DisableTempGauges/KerboKatzSmallUtilities-DisableTempGauges-1.0.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
-    "identifier": "KerboKatzSmallUtilities-DisableTempGagues",
-    "name": "KerboKatz - SmallUtilities - DisableTempGagues",
+    "identifier": "KerboKatzSmallUtilities-DisableTempGauges",
+    "name": "KerboKatz - SmallUtilities - DisableTempGauges",
     "abstract": "Disables the heat gauges everytime you enter the flight",
     "author": "SpaceTiger",
     "license": "restricted",
@@ -19,7 +19,7 @@
     ],
     "install": [
         {
-            "find": "DisableTempGagues",
+            "find": "DisableTempGauges",
             "install_to": "GameData/KerboKatz/SmallUtilities"
         }
     ],


### PR DESCRIPTION
Apparently the old KerbalStuff file contained a typo. Fixed the typo and moved into the correct folder.