### PR TITLE
Add missing file installation

### DIFF
--- a/DockingPortAlignmentIndicator/DockingPortAlignmentIndicator-6.2.ckan
+++ b/DockingPortAlignmentIndicator/DockingPortAlignmentIndicator-6.2.ckan
@@ -22,6 +22,10 @@
         {
             "file": "GameData/NavyFish",
             "install_to": "GameData"
+        },
+        {
+            "file": "GameData/JSI/RPMPodPatches",
+            "install_to": "GameData/JSI"
         }
     ],
     "download": "http://addons-origin.cursecdn.com/files/2236/857/DockingPortAlignment-6.2.zip",


### PR DESCRIPTION
netkan file is currently frozen pending Curse scraping. It has been updated.
Found missing file through Godarklights metadata checker