### PR TITLE
Update DockingPortAlignment

### DIFF
--- a/DockingPortAlignmentIndicator/DockingPortAlignmentIndicator-6.2.ckan
+++ b/DockingPortAlignmentIndicator/DockingPortAlignmentIndicator-6.2.ckan
@@ -16,16 +16,15 @@
         {
             "name": "ModuleManager",
             "min_version": "2.5.1"
+        },
+        {
+            "name": "RasterPropMonitor"
         }
     ],
     "install": [
         {
             "file": "GameData/NavyFish",
             "install_to": "GameData"
-        },
-        {
-            "file": "GameData/JSI/RPMPodPatches",
-            "install_to": "GameData/JSI"
         }
     ],
     "download": "http://addons-origin.cursecdn.com/files/2236/857/DockingPortAlignment-6.2.zip",


### PR DESCRIPTION
The JSI files belong to RasterPropMonitor, it turns out. 
Make it a dependency
Closes #1026