### PR TITLE
Add conflicts for Kduffers Wheels packs

### DIFF
--- a/KduffersKorpHotrodWheels/KduffersKorpHotrodWheels-1.0.ckan
+++ b/KduffersKorpHotrodWheels/KduffersKorpHotrodWheels-1.0.ckan
@@ -6,11 +6,13 @@
     "author": "amankduffers",
     "license": "MIT",
     "resources": {
-        "kerbalstuff": "https://kerbalstuff.com/mod/1092/Kduffers%20Korp%20Hotrod%20Wheels",
-        "x_screenshot": "https://kerbalstuff.com/content/amankduffers_8935/Kduffers_Korp_Hotrod_Wheels/Kduffers_Korp_Hotrod_Wheels-1439998459.8594246.png"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/119150-kduffers-multi-wheels-kmw" 
     },
     "version": "1.0",
     "ksp_version": "1.0.4",
+    "conflicts": [
+        { "name": "KduffersMultiwheels" }
+    ],
     "install": [
         {
             "file": "kduffers korp hotrod wheels",
@@ -18,6 +20,5 @@
         }
     ],
     "download": "http://ckan1.spacedock.info/storage/amankduffers_8935/Kduffers_Korp_Hotrod_Wheels/Kduffers_Korp_Hotrod_Wheels-1.0.zip",
-    "download_size": 19738386,
-    "x_generated_by": "netkan"
+    "download_size": 19738386
 }

--- a/KduffersKorpHotrodWheels/KduffersKorpHotrodWheels-1.1.ckan
+++ b/KduffersKorpHotrodWheels/KduffersKorpHotrodWheels-1.1.ckan
@@ -6,9 +6,11 @@
     "author": "amankduffers",
     "license": "MIT",
     "resources": {
-        "kerbalstuff": "https://kerbalstuff.com/mod/1092/Kduffers%20Korp%20Hotrod%20Wheels",
-        "x_screenshot": "https://kerbalstuff.com/content/amankduffers_8935/Kduffers_Korp_Hotrod_Wheels/Kduffers_Korp_Hotrod_Wheels-1439998459.8594246.png"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/119150-kduffers-multi-wheels-kmw" 
     },
+    "conflicts": [
+        { "name": "KduffersMultiwheels" }
+    ],
     "version": "1.1",
     "ksp_version": "1.0.5",
     "install": [
@@ -18,6 +20,5 @@
         }
     ],
     "download": "http://ckan1.spacedock.info/storage/amankduffers_8935/Kduffers_Korp_Hotrod_Wheels/Kduffers_Korp_Hotrod_Wheels-1.1.zip",
-    "download_size": 19490047,
-    "x_generated_by": "netkan"
+    "download_size": 19490047
 }

--- a/KduffersMultiwheels/KduffersMultiwheels-1.0.ckan
+++ b/KduffersMultiwheels/KduffersMultiwheels-1.0.ckan
@@ -23,9 +23,11 @@
     "author": "amankduffers",
     "download": "http://ckan1.spacedock.info/storage/amankduffers_8935/Kduffers_Multiwheels/Kduffers_Multiwheels-1.0.zip",
     "resources": {
-        "kerbalstuff": "https://kerbalstuff.com/mod/1090/Kduffers%20Multiwheels",
-        "x_screenshot": "https://kerbalstuff.com/content/amankduffers_8935/Kduffers_Multiwheels/Kduffers_Multiwheels-1439939882.1698072.png"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/119150-kduffers-multi-wheels-kmw" 
     },
-    "download_size": 4883726,
-    "x_generated_by": "netkan"
+    "conflicts": [
+        { "name": "kdufferskorpracewheel" },
+        { "name": "KduffersKorpHotrodWheels" }
+    ],
+    "download_size": 4883726
 }

--- a/KduffersMultiwheels/KduffersMultiwheels-1.3.ckan
+++ b/KduffersMultiwheels/KduffersMultiwheels-1.3.ckan
@@ -6,9 +6,12 @@
     "author": "amankduffers",
     "license": "MIT",
     "resources": {
-        "kerbalstuff": "https://kerbalstuff.com/mod/1090/Kduffers%20Multiwheels",
-        "x_screenshot": "https://kerbalstuff.com/content/amankduffers_8935/Kduffers_Multiwheels/Kduffers_Multiwheels-1440194695.9358244.png"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/119150-kduffers-multi-wheels-kmw" 
     },
+    "conflicts": [
+        { "name": "kdufferskorpracewheel" },
+        { "name": "KduffersKorpHotrodWheels" }
+    ],
     "version": "1.3",
     "ksp_version": "1.0.5",
     "install": [
@@ -22,6 +25,5 @@
         }
     ],
     "download": "http://ckan1.spacedock.info/storage/amankduffers_8935/Kduffers_Multiwheels/Kduffers_Multiwheels-1.3.zip",
-    "download_size": 35676274,
-    "x_generated_by": "netkan"
+    "download_size": 35676274
 }

--- a/kdufferskorpracewheel/kdufferskorpracewheel-1.0.ckan
+++ b/kdufferskorpracewheel/kdufferskorpracewheel-1.0.ckan
@@ -6,9 +6,11 @@
     "author": "amankduffers",
     "license": "MIT",
     "resources": {
-        "kerbalstuff": "https://kerbalstuff.com/mod/1051/kduffers%20korp%20race%20wheel",
-        "x_screenshot": "https://kerbalstuff.com/content/amankduffers_8935/kduffers_korp_race_wheel/kduffers_korp_race_wheel-1438555918.262257.png"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/119150-kduffers-multi-wheels-kmw" 
     },
+    "conflicts": [
+        { "name": "KduffersMultiwheels" }
+    ],
     "version": "1.0",
     "ksp_version": "1.0.5",
     "install": [
@@ -18,6 +20,5 @@
         }
     ],
     "download": "http://ckan1.spacedock.info/storage/amankduffers_8935/kduffers_korp_race_wheel/kduffers_korp_race_wheel-1.0.zip",
-    "download_size": 1065817,
-    "x_generated_by": "netkan"
+    "download_size": 1065817
 }


### PR DESCRIPTION
Multiwheels contains the other two packs.
Also sets homepage to forum link and removes kerbalstuff links.
Closes #1031