### PR TITLE
Revert default ksp version to 1.0.5 - #1045

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Default flags.
-KSP_VERSION_DEFAULT="1.1.0"
+KSP_VERSION_DEFAULT="1.0.5"
 KSP_NAME_DEFAULT="dummy"
 
 # Locations of CKAN and validation.


### PR DESCRIPTION
A little early to set the new default to 1.1.0. This reverts it and brings it back in line with NetKAN.