### PR TITLE
Create RCSBuildAid-0.7.7-14.ckan

### DIFF
--- a/RCSBuildAid/RCSBuildAid-0.7.7-14.ckan
+++ b/RCSBuildAid/RCSBuildAid-0.7.7-14.ckan
@@ -15,6 +15,7 @@
     "abstract": "This is something I made for placing RCS thrusters in the right positions in the first try without having to go back and forth between the VAB and the hacked gravity launchpad.  Features: Display thrust and torque forces caused by RCS or engines. Delta V readout for RCS. Dry center of mass marker. Average center of mass marker. Ability to resize editor's overlay markers. Display total mass of resources.",
     "author": "m4v",
     "version": "0.7.7-14",
+    "release-status": "development",
     "download": "http://addons-origin.cursecdn.com/files/2292/475/RCSBuildAid_v0.7.7-14-g74c9da7.zip",
     "supports" : [ 
         { "name" : "Toolbar" },

--- a/RCSBuildAid/RCSBuildAid-0.7.7-14.ckan
+++ b/RCSBuildAid/RCSBuildAid-0.7.7-14.ckan
@@ -1,0 +1,30 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "RCSBuildAid",
+    "ksp_version_min": "1.1.0",
+    "ksp_version_max": "1.1.0",
+    "resources": 
+    {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/35996",
+        "manual": "https://github.com/m4v/RCSBuildAid/blob/master/README.asciidoc",
+        "repository": "https://github.com/m4v/RCSBuildAid",
+        "bugtracker": "https://github.com/m4v/RCSBuildAid/issues"
+    },
+    "name": "RCS Build Aid",
+    "license": "LGPL-3.0",
+    "abstract": "This is something I made for placing RCS thrusters in the right positions in the first try without having to go back and forth between the VAB and the hacked gravity launchpad.  Features: Display thrust and torque forces caused by RCS or engines. Delta V readout for RCS. Dry center of mass marker. Average center of mass marker. Ability to resize editor's overlay markers. Display total mass of resources.",
+    "author": "m4v",
+    "version": "0.7.7-14",
+    "download": "http://addons-origin.cursecdn.com/files/2292/475/RCSBuildAid_v0.7.7-14-g74c9da7.zip",
+    "supports" : [ 
+        { "name" : "Toolbar" },
+        { "name" : "KSP-AVC" }
+    ],
+    "install": [
+        { 
+            "file" : "RCSBuildAid",
+            "install_to" : "GameData",
+            "filter" : "Sources"
+        }
+    ]
+}


### PR DESCRIPTION
Pre-release compliant in accordance with http://forum.kerbalspaceprogram.com/index.php?/topic/135824-rcs-build-aid-compiled-for-ksp-11/

`ckan compare` says this version of the mod is higher than 0.7.7 so I'm assuming it'll work out fine like this even though it somewhat breaks the pattern.

ksp_versions fetched from the bundled .version file.