### PR TITLE
Set KSP Version for old TransferWindowPlanner releases

### DIFF
--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.1.0.ckan
@@ -20,8 +20,8 @@
       "install_to": "GameData/TriggerTech"
     }
   ],
+  "ksp_version": "0.90.0",
   "version": "v1.2.1.0",
   "download": "https://github.com/TriggerAu/TransferWindowPlanner/releases/download/v1.2.1.0/TransferWindowPlanner_1.2.1.0.zip",
-  "x_generated_by": "netkan",
   "download_size": 89805
 }

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.2.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.2.0.ckan
@@ -20,8 +20,8 @@
             "install_to": "GameData/TriggerTech"
         }
     ],
+    "ksp_version": "0.90.0",
     "version": "v1.2.2.0",
     "download": "https://github.com/TriggerAu/TransferWindowPlanner/releases/download/v1.2.2.0/TransferWindowPlanner_1.2.2.0.zip",
-    "x_generated_by": "netkan",
     "download_size": 90317
 }

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.3.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.3.0.ckan
@@ -20,8 +20,8 @@
             "install_to": "GameData/TriggerTech"
         }
     ],
+    "ksp_version": "0.90.0",
     "version": "v1.2.3.0",
     "download": "https://github.com/TriggerAu/TransferWindowPlanner/releases/download/v1.2.3.0/TransferWindowPlanner_1.2.3.0.zip",
-    "x_generated_by": "netkan",
     "download_size": 91774
 }

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.0.ckan
@@ -20,8 +20,8 @@
             "install_to": "GameData/TriggerTech"
         }
     ],
+    "ksp_version": "1.0.0",
     "version": "v1.3.0.0",
     "download": "https://github.com/TriggerAu/TransferWindowPlanner/releases/download/v1.3.0.0/TransferWindowPlanner_1.3.0.0.zip",
-    "x_generated_by": "netkan",
     "download_size": 91872
 }

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.1.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.1.ckan
@@ -20,8 +20,8 @@
             "install_to": "GameData/TriggerTech"
         }
     ],
+    "ksp_version": "1.0.2",
     "version": "v1.3.0.1",
     "download": "https://github.com/TriggerAu/TransferWindowPlanner/releases/download/v1.3.0.1/TransferWindowPlanner_1.3.0.1.zip",
-    "download_size": 91927,
-    "x_generated_by": "netkan"
+    "download_size": 91927
 }

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.1.0.ckan
@@ -15,6 +15,7 @@
         "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.3.1.0",
+    "ksp_version": "1.0.4",
     "install": [
         {
             "find": "TransferWindowPlanner",
@@ -22,6 +23,5 @@
         }
     ],
     "download": "https://github.com/TriggerAu/TransferWindowPlanner/releases/download/v1.3.1.0/TransferWindowPlanner_1.3.1.0.zip",
-    "download_size": 91997,
-    "x_generated_by": "netkan"
+    "download_size": 91997
 }


### PR DESCRIPTION
Using information included on Github.
Ref KSP-CKAN/NetKAN#3569, which should lead to 1.4.0.0 being corrected.