### PR TITLE
Explicitly depend KWRocketry so that we don't show this mod as compatible

### DIFF
--- a/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.10.ckan
+++ b/KWRocketry-CommunityFixes-interstage/KWRocketry-CommunityFixes-interstage-0.4.10.ckan
@@ -17,6 +17,10 @@
     "depends": [
         {
             "name": "KWRocketry-CommunityFixes"
+        },
+        {
+            "name": "KWRocketry",
+            "version": "2.7.0-community"
         }
     ],
     "install": [


### PR DESCRIPTION
This fails for the reason this PR exists; It can't be installed under 1.1.0.