### PR TITLE
Add compatibility ceiling for deprecated mod.

### DIFF
--- a/ContractConfigurator-SCANsat/ContractConfigurator-SCANsat-1.0.1.ckan
+++ b/ContractConfigurator-SCANsat/ContractConfigurator-SCANsat-1.0.1.ckan
@@ -6,6 +6,7 @@
   "license": "public-domain",
   "x_netkan_license_ok": true,
   "x_maintained_by": "hakan42, who loves to fly missions with contracts in them",
+  "ksp_version_max" : "1.0.5",
   "depends": [
     {
       "name": "ContractConfigurator"

--- a/ContractConfigurator-SCANsat/ContractConfigurator-SCANsat-1.0.2.ckan
+++ b/ContractConfigurator-SCANsat/ContractConfigurator-SCANsat-1.0.2.ckan
@@ -6,6 +6,7 @@
     "license": "public-domain",
     "x_netkan_license_ok": true,
     "x_maintained_by": "hakan42, who loves to fly missions with contracts in them",
+    "ksp_version_max" : "1.0.5",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-SCANsat/ContractConfigurator-SCANsat-1.0.ckan
+++ b/ContractConfigurator-SCANsat/ContractConfigurator-SCANsat-1.0.ckan
@@ -6,6 +6,7 @@
   "license": "public-domain",
   "x_netkan_license_ok": true,
   "x_maintained_by": "hakan42, who loves to fly missions with contracts in them",
+  "ksp_version_max" : "1.0.5",
   "depends": [
     {
       "name": "ContractConfigurator"


### PR DESCRIPTION
Per this mod's github page (Latest commit https://github.com/SimonTheSourcerer/CCSCANsatMissionPack/commit/faad93e166c83f7713182bb167fa5539244dbe4e on Jan 23, 2015):

>Stopped in development, please use: DBT85's pack: http://forum.kerbalspaceprogram.com/threads/108097-0-90-Contract-Pack-SCANSat-v0-5-0-2015-01-22 instead.

The link is a reference to the mod we ID as `ContractConfigurator-ContractPack-SCANsat`.

I think when the .netkan for this was deleted in https://github.com/KSP-CKAN/NetKAN/commit/40c0302401916ddf877b40d2cd3a20fcc16c2257 these .ckans were simply forgotten about. This is a correction to that oversight.