### PR TITLE
Fixed PlanetShine install path and URL

### DIFF
--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/96497",
         "repository": "https://github.com/valerian/ksp-planetshine",
-        "curse": "http://kerbal.curseforge.com/projects/rcs-build-aid"
+        "curse": "http://kerbal.curseforge.com/projects/planetshine"
     },
     "version": "0.2.5",
     "ksp_version_min": "1.1.0",

--- a/PlanetShine/PlanetShine-0.2.5.ckan
+++ b/PlanetShine/PlanetShine-0.2.5.ckan
@@ -22,7 +22,7 @@
     "install": [
         {
             "find": "GameData/PlanetShine",
-            "install_to": "GameData/PlanetShine",
+            "install_to": "GameData",
             "filter": "Config"
         }
     ],

--- a/PlanetShine/PlanetShine-0.2.5.ckan
+++ b/PlanetShine/PlanetShine-0.2.5.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/96497",
         "repository": "https://github.com/valerian/ksp-planetshine",
-        "curse": "http://kerbal.curseforge.com/projects/rcs-build-aid"
+        "curse": "http://kerbal.curseforge.com/projects/planetshine"
     },
     "version": "0.2.5",
     "ksp_version_min": "1.1.0",


### PR DESCRIPTION
I had a few users reporting that PlanetShine was not properly displaying its toolbar icons, and I realized that CKAN was messing with the intended install paths. I don't know since when this issue has been there, but this should fix it.

The intended folder structure is:
* GameData
   * PlanetShine
      * Config
      * Icons
      * Plugins

However currently CKAN is giving this result:
* GameData
   * PlanetShine
      * Config
      * PlanetShine
         * Icons
         * Plugins