### PR TITLE
Bump PlanetShine epoch

### DIFF
--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-1-0.2.5.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-1-0.2.5.ckan
@@ -1,0 +1,38 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "PlanetShine-Config-Default",
+    "name": "PlanetShine - Default configuration",
+    "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",
+    "author": "Valerian",
+    "license": "Apache-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/96497",
+        "repository": "https://github.com/valerian/ksp-planetshine",
+        "curse": "http://kerbal.curseforge.com/projects/planetshine"
+    },
+    "version": "1:0.2.5",
+    "ksp_version_min": "1.1.0",
+    "ksp_version_max": "1.1.0",
+    "provides": [
+        "PlanetShine-Config"
+    ],
+    "depends": [
+        {
+            "name": "PlanetShine"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "PlanetShine-Config"
+        }
+    ],
+    "install": [
+        {
+            "find": "GameData/PlanetShine/Config",
+            "install_to": "GameData/PlanetShine"
+        }
+    ],
+    "download": "http://addons-origin.cursecdn.com/files/2292/131/PlanetShine-0.2.5.zip",
+    "download_size": 45752,
+    "x_generated_by": "netkan"
+}

--- a/PlanetShine/PlanetShine-1-0.2.5.ckan
+++ b/PlanetShine/PlanetShine-1-0.2.5.ckan
@@ -1,0 +1,32 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "PlanetShine",
+    "name": "PlanetShine",
+    "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",
+    "author": "Valerian",
+    "license": "Apache-2.0",
+    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/96497",
+        "repository": "https://github.com/valerian/ksp-planetshine",
+        "curse": "http://kerbal.curseforge.com/projects/planetshine"
+    },
+    "version": "1:0.2.5",
+    "ksp_version_min": "1.1.0",
+    "ksp_version_max": "1.1.0",
+    "depends": [
+        {
+            "name": "PlanetShine-Config"
+        }
+    ],
+    "install": [
+        {
+            "find": "GameData/PlanetShine",
+            "install_to": "GameData",
+            "filter": "Config"
+        }
+    ],
+    "download": "http://addons-origin.cursecdn.com/files/2292/131/PlanetShine-0.2.5.zip",
+    "download_size": 45752,
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
#1071 showed we were installing `PlanetShine` incorrectly and its changes will fix future installs, however by using an epoch we can have ckan think that planetshine has an update and will force a re-install to the correct path (to those that choose to update). 

cc @valerian 