### PR TITLE
KSP-AVC - 1.1.5 - Limit KSP compatibility

### DIFF
--- a/KSP-AVC/KSP-AVC-1.1.5.0.ckan
+++ b/KSP-AVC/KSP-AVC-1.1.5.0.ckan
@@ -1,17 +1,16 @@
 {
-	"spec_version": 1,
-	"identifier": "KSP-AVC",
-	"ksp_version": "any",
-	"resources": 
-	{
-		"homepage": "http://forum.kerbalspaceprogram.com/threads/79745",
-		"repository": "https://github.com/CYBUTEK/KSPAddonVersionChecker"
-	},
-	"name": "KSP AVC",
-	"license": "GPL-3.0",
-	"abstract": "In-Game GUI for KSP Addon Version Checker",
-	"author": "cybutek",
-	"version": "1.1.5.0",
-	"download": "http://addons.cursecdn.com/files/2216/818/KSP-AVC-1.1.5.0.zip",
-    "x_packaged_by": "hakan42 - hand-packaged as the mod is curse-only at the moment"
+    "spec_version": 1,
+    "identifier": "KSP-AVC",
+    "ksp_version_max": "1.0.5",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/79745",
+        "repository": "https://github.com/CYBUTEK/KSPAddonVersionChecker"
+    },
+    "name": "KSP AVC",
+    "license": "GPL-3.0",
+    "abstract": "In-Game GUI for KSP Addon Version Checker",
+    "author": "cybutek",
+    "version": "1.1.5.0",
+    "download": "http://addons.cursecdn.com/files/2216/818/KSP-AVC-1.1.5.0.zip",
+    "x_packaged_by": "hakan42, politas - Finally hit a KSP version it couldn't handle"
 }


### PR DESCRIPTION
Unity 5 finally broke KSP-AVC's compatibility.
Closes #1089