### PR TITLE
RoverWheelSounds seems to live on curseforge for the time being.

### DIFF
--- a/RoverWheelSounds/RoverWheelSounds-2.2.ckan
+++ b/RoverWheelSounds/RoverWheelSounds-2.2.ckan
@@ -23,5 +23,5 @@
             "install_to": "GameData"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/rover-wheel-sounds/files/2294492/download",
+    "download": "http://kerbal.curseforge.com/projects/rover-wheel-sounds/files/2294492/download"
 }

--- a/RoverWheelSounds/RoverWheelSounds-2.2.ckan
+++ b/RoverWheelSounds/RoverWheelSounds-2.2.ckan
@@ -1,0 +1,27 @@
+{
+    "spec_version": 1,
+    "identifier": "RoverWheelSounds",
+    "name": "Rover Wheel Sounds",
+    "abstract": "Adds motor sound effects to the four stock motorized rover wheels.",
+    "author": "pizzaoverhead",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/55104",
+        "repository": "https://github.com/pizzaoverhead/WheelSounds"
+    },
+    "version": "2.2",
+    "ksp_version": "1.1.0",
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.6.23"
+        }
+    ],
+    "install": [
+        {
+            "file": "GameData/WheelSounds",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "http://kerbal.curseforge.com/projects/rover-wheel-sounds/files/2294492/download",
+}


### PR DESCRIPTION
Stripped out the old kerbalstuff references.  The github hasn't been updated since 1.3 - but might as well leave it in I suppose.