### PR TITLE
Rename MechJebForAll to MechJebAndEngineerForAll and make it availabl…

### DIFF
--- a/MechJebAndEngineerForAll/MechJebAndEngineerForAll-1.1.0.ckan
+++ b/MechJebAndEngineerForAll/MechJebAndEngineerForAll-1.1.0.ckan
@@ -1,20 +1,17 @@
 {
 "spec_version": 1,
-"identifier" : "MechJebForAll",
+"identifier" : "MechJebAndEngineerForAll",
 "name" : "MechJeb and Engineer for all!",
 "author" : [ "nadseh" ],
-"version" : "1.2.0.0",
+"version" : "1.1.0",
 "abstract" : "Automatically includes a MechJeb computer, Flight Engineer and Build Engineer on any craft that includes a probe core or a command module.",
-"ksp_version" : "1.0",
+"ksp_version" : "0.90",
 "license" : "GPL-3.0",
-"download": "http://addons-origin.cursecdn.com/files/2235/984/MechJebAndEngineerForAll-v1.2.0.0.zip",
-"depends": [{ "name": "ModuleManager" }],
-"recommends":[
+"download": "http://addons.curse.cursecdn.com/files/2225/270/MechJebAndEngineerForAll-v1.1.0.0.zip",
+"depends": [
 { "name": "MechJeb2" },
+{ "name": "ModuleManager" },
 { "name": "KerbalEngineerRedux" }],
-"resources" : {
-    "homepage"     : "http://forum.kerbalspaceprogram.com/threads/83362"
-},
 "install": [ {"file": "MechJebAndEngineerForAll.cfg",
 			"install_to": "GameData" }
 ]

--- a/MechJebAndEngineerForAll/MechJebAndEngineerForAll-1.2.0.0.ckan
+++ b/MechJebAndEngineerForAll/MechJebAndEngineerForAll-1.2.0.0.ckan
@@ -1,17 +1,20 @@
 {
 "spec_version": 1,
-"identifier" : "MechJebForAll",
+"identifier" : "MechJebAndEngineerForAll",
 "name" : "MechJeb and Engineer for all!",
 "author" : [ "nadseh" ],
-"version" : "1.1.0",
+"version" : "1.2.0.0",
 "abstract" : "Automatically includes a MechJeb computer, Flight Engineer and Build Engineer on any craft that includes a probe core or a command module.",
-"ksp_version" : "0.90",
+"ksp_version" : "any",
 "license" : "GPL-3.0",
-"download": "http://addons.curse.cursecdn.com/files/2225/270/MechJebAndEngineerForAll-v1.1.0.0.zip",
-"depends": [
+"download": "http://addons-origin.cursecdn.com/files/2235/984/MechJebAndEngineerForAll-v1.2.0.0.zip",
+"depends": [{ "name": "ModuleManager" }],
+"recommends":[
 { "name": "MechJeb2" },
-{ "name": "ModuleManager" },
 { "name": "KerbalEngineerRedux" }],
+"resources" : {
+    "homepage"     : "http://forum.kerbalspaceprogram.com/threads/83362"
+},
 "install": [ {"file": "MechJebAndEngineerForAll.cfg",
 			"install_to": "GameData" }
 ]


### PR DESCRIPTION
…e to any version of KSP.

This new name more properly matches upstream name. Also, as it is a ModuleManager configuration file, make it to no depend on the version of KSP.