### PR TITLE
Add RealChute-v1.4.1.1.ckan

### DIFF
--- a/RealChute/RealChute-v1.4.1.1.ckan
+++ b/RealChute/RealChute-v1.4.1.1.ckan
@@ -1,0 +1,24 @@
+{
+    "spec_version": 1,
+    "identifier": "RealChute",
+    "name": "RealChute Parachute Systems",
+    "abstract": "RealChute is a complete rework of the stock parachute module to fix a few of it's inconveniences and get more realistic results out of parachutes!",
+    "author": "stupid_chris",
+    "license": "restricted",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/57988",
+        "repository": "https://github.com/StupidChris/RealChute"
+    },
+    "version": "v1.4.1.1",
+    "ksp_version_min": "1.1.2",
+    "ksp_version_max": "1.1.99",
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.6.0"
+        }
+    ],
+    "download": "https://github.com/StupidChris/RealChute/releases/download/v1.4.1.1/RealChute.v1.4.1.1.zip",
+    "download_size": 2674850,
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
The current version's .version file has a JSON error. This was generated from a netkan with vref removed and ksp_versions hardcoded from the info within the .version file. .netkan left intact so that it picks up the next release without issue.