### PR TITLE
KIS 1.2.9 release

### DIFF
--- a/KIS/KIS-1.2.9.ckan
+++ b/KIS/KIS-1.2.9.ckan
@@ -1,0 +1,18 @@
+{
+    "spec_version"    : 1,
+    "name"            : "Kerbal Inventory System",
+    "identifier"      : "KIS",
+    "abstract"        : "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
+        "repository": "https://github.com/KospY/KIS"
+    },
+    "download"        : "http://kerbal.curseforge.com/projects/kerbal-inventory-system-kis/files/2297755/download",
+    "suggests": [
+        { "name": "KAS" }
+    ],
+    "license"         : "restricted",
+    "author"          : [ "KospY", "Winn75", "IgorZ" ],
+    "version"         : "1.2.9",
+    "ksp_version"     : "1.1"
+}


### PR DESCRIPTION
Hey,

Is there a way to make CKAn automatically pickup latest file from CurseForge? E.g. for this particular project latest release is always available via link: http://kerbal.curseforge.com/projects/kerbal-inventory-system-kis/files/latest. Though, if I add such link into the `.ckan` file people won't be able to browse previous versions.

I'm fine to post ckan updates on every release. Just curious :)