### PR TITLE
Publishing TacFuelBallancer 2.5.3

### DIFF
--- a/TacFuelBalancer/TacFuelBalancer-v2.5.3.ckan
+++ b/TacFuelBalancer/TacFuelBalancer-v2.5.3.ckan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.2",
+    "identifier": "TacFuelBalancer",
+    "name": "TAC Fuel Balancer",
+    "abstract": "It transfers, it balances, it mixes, it stirs!",
+    "author": [
+        "Z-Key Aerospace",
+        "Taranis Elsu"
+    ],	
+    "license": "CC-BY-NC-SA-3.0",
+    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/23808-102-tac-fuel-balancer-v251-2may/",
+        "repository": "https://github.com/thewebbooth/TacFuelBalancer"
+    },
+    "version": "2.5.3",
+    "ksp_version": "1.1.2",
+    "install": [
+        {
+            "file": "GameData/TacFuelBalancer",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "http://themoose.co.uk/ksp/TacFuelBalancer2.5.3.zip",
+}

--- a/TacFuelBalancer/TacFuelBalancer-v2.5.3.ckan
+++ b/TacFuelBalancer/TacFuelBalancer-v2.5.3.ckan
@@ -21,5 +21,5 @@
             "install_to": "GameData"
         }
     ],
-    "download": "http://themoose.co.uk/ksp/TacFuelBalancer2.5.3.zip",
+    "download": "http://themoose.co.uk/ksp/TacFuelBalancer2.5.3.zip"
 }


### PR DESCRIPTION
For KSP V1.1.2

I added this to Space Dock but it hasn't shown up in CKAN.  Do I need to make a NetKAN?  If you have the time let me know.  http://spacedock.info/mod/640/TacFuelBalancer

Thank you!