### PR TITLE
CRP no longer conflict with Kerbalism.

### DIFF
--- a/CommunityResourcePack/CommunityResourcePack-0.5.1.1.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.5.1.1.ckan
@@ -13,11 +13,6 @@
     "version": "0.5.1.1",
     "ksp_version_min": "1.0.0",
     "ksp_version_max": "1.1.2",
-    "conflicts": [
-        {
-            "name": "Kerbalism"
-        }
-    ],
     "install": [
         {
             "file": "GameData/CommunityResourcePack",


### PR DESCRIPTION
v0.9.9.5 of Kerbalism fixed the conflict with CommunityResourcePack, which in detail, "food/oxygen properties have been changed to match CRP ones".
https://github.com/ShotgunNinja/Kerbalism/releases/tag/v0.9.9.5