### PR TITLE
Bump Community tech tree and Pilot Assistant to 1.1.2.

### DIFF
--- a/CommunityTechTree/CommunityTechTree-2.4.ckan
+++ b/CommunityTechTree/CommunityTechTree-2.4.ckan
@@ -12,7 +12,7 @@
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Community_Tech_Tree/Community_Tech_Tree-1460998599.9045794.png"
     },
     "version": "2.4",
-    "ksp_version": "1.1.0",
+    "ksp_version": "1.1.2",
     "depends": [
         {
             "name": "ModuleManager",

--- a/PilotAssistant/PilotAssistant-1.12.5.ckan
+++ b/PilotAssistant/PilotAssistant-1.12.5.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/Crzyrndm/Pilot-Assistant"
     },
     "version": "1.12.5",
-    "ksp_version": "1.1.0",
+    "ksp_version": "1.1.2",
     "install": [
         {
             "file": "GameData/Pilot Assistant",


### PR DESCRIPTION
I've been testing these in 1.1.2 for a few days and haven't had any issues.