### PR TITLE
AtmosphereAutopilot is compatible with 1.1.2

### DIFF
--- a/AtmosphereAutopilot/AtmosphereAutopilot-v1.5.3.ckan
+++ b/AtmosphereAutopilot/AtmosphereAutopilot-v1.5.3.ckan
@@ -11,7 +11,7 @@
     },
     "version": "v1.5.3",
     "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.1.1",
+    "ksp_version_max": "1.1.2",
     "depends": [
         {
             "name": "ModuleManager"


### PR DESCRIPTION
Per KSP forum post: http://forum.kerbalspaceprogram.com/index.php?/topic/124417-112-atmosphereautopilot-153/&do=findComment&comment=2572523