### PR TITLE
ProceduralDynamics-0.9.3 - lose the "v"

### DIFF
--- a/ProceduralDynamics/ProceduralDynamics-0.9.3.ckan
+++ b/ProceduralDynamics/ProceduralDynamics-0.9.3.ckan
@@ -10,7 +10,7 @@
             "name": "ProceduralWings"
         }
     ],
-    "version": "v0.9.3",
+    "version": "0.9.3",
     "author": "NathanKell",
     "download": "https://github.com/NathanKell/ProceduralWings/releases/download/v0.9.3/Procedural_Wings-0.9.3.zip",
     "resources": {


### PR DESCRIPTION
No idea how many users we have still running 0.90. I suspect not many, and this will fix up the "Max KSP" in the GUI
