### PR TITLE
Update AJE license to LGPL-2.0

### DIFF
--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
@@ -3,7 +3,7 @@
     "identifier": "AdvancedJetEngine",
     "name": "Advanced Jet Engine (AJE)",
     "abstract": "Realistic jet engines for KSP",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
@@ -3,7 +3,7 @@
     "identifier": "AdvancedJetEngine",
     "name": "Advanced Jet Engine (AJE)",
     "abstract": "Realistic jet engines for KSP",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
@@ -4,7 +4,7 @@
     "abstract" : "Realistic jet engines for KSP",
     "identifier": "AdvancedJetEngine",
     "download" : "https://github.com/camlost2/AJE/archive/1.6.zip",
-    "license"  : "LGPL-2.1",
+    "license"  : "LGPL-2.0",
     "version"  : "1.6",
     "release_status" : "stable",
     "ksp_version" : "0.25",

--- a/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
@@ -3,7 +3,7 @@
     "identifier": "AdvancedJetEngine",
     "name": "Advanced Jet Engine (AJE)",
     "abstract": "Realistic jet engines for KSP",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.0.2.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.0.2.ckan
@@ -1,6 +1,6 @@
 {
     "identifier": "AdvancedJetEngine",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "spec_version": 1,
     "depends": [
         {

--- a/AdvancedJetEngine/AdvancedJetEngine-2.0.3.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.0.3.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",
         "kerbalstuff": "https://kerbalstuff.com/mod/462/Advanced%20Jet%20Engine"

--- a/AdvancedJetEngine/AdvancedJetEngine-2.0.4.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.0.4.ckan
@@ -1,6 +1,6 @@
 {
     "identifier": "AdvancedJetEngine",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "spec_version": "v1.4",
     "depends": [
         {

--- a/AdvancedJetEngine/AdvancedJetEngine-2.2.0.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.2.0.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.2.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.2.1.ckan
@@ -1,6 +1,6 @@
 {
     "identifier": "AdvancedJetEngine",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "spec_version": "v1.4",
     "depends": [
         {

--- a/AdvancedJetEngine/AdvancedJetEngine-2.3.0.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.3.0.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.4.0.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.4.0.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.4.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.4.1.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.5.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.5.1.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.5.2.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.5.2.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers, and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.5.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.5.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.5.4.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.5.4.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers, and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.6.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.6.1.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers, and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.6.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.6.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers, and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.7.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.7.ckan
@@ -5,7 +5,7 @@
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers, and rotors in KSP.",
     "author": "camlost",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/70008",


### PR DESCRIPTION
As mentioned in KSP-CKAN/NetKAN#4157, seems like AJE's license was incorrectly specified from the beginning as LGPL-2.1 when it has always been LGPL-2.0.