### PR TITLE
Clean up old RCSBuildAid releases

### DIFF
--- a/RCSBuildAid/RCSBuildAid-v0.7.8.ckan
+++ b/RCSBuildAid/RCSBuildAid-v0.7.8.ckan
@@ -12,9 +12,8 @@
         "bugtracker": "https://github.com/m4v/RCSBuildAid/issues",
         "manual": "https://github.com/m4v/RCSBuildAid/blob/master/README.asciidoc"
     },
-    "version": "v0.7.7-14",
-    "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.1.0",
+    "version": "v0.7.8",
+    "ksp_version": "1.0.5",
     "supports": [
         {
             "name": "Toolbar"
@@ -30,11 +29,11 @@
             "filter": "Sources"
         }
     ],
-    "download": "http://addons-origin.cursecdn.com/files/2292/475/RCSBuildAid_v0.7.7-14-g74c9da7.zip",
-    "download_size": 116760,
+    "download": "http://addons-origin.cursecdn.com/files/2305/296/RCSBuildAid_v0.7.8.zip",
+    "download_size": 131209,
     "download_hash": {
-        "sha1": "012AAD8877E0AAA782B92DAB78F5A793B569CCB1",
-        "sha256": "C7F9B551B703EB89B406E8C86BCC371F24448A76D024A6544E447F8D7F17CCF8"
+        "sha1": "C1210A06FC6DC8EA6F628EA23DF32F0DF94D9A3B",
+        "sha256": "D99F7C7C4DD033DE3ADABF56F3C513C265D07EF955F13FA5ADCE2D14E8F3D707"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
v0.7.7-14 has been removed from Curseforge and the new v0.8 is the only KSP 1.1 compatible release.

Hmmph. Didn't expect that to turn into a rename.