### PR TITLE
ModularFlightIntegrator Compatibility fix

### DIFF
--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.1.3.0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.1.3.0.ckan
@@ -11,7 +11,8 @@
         "ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
     },
     "version": "1.1.3.0",
-    "ksp_version": "1.1",
+    "ksp_version_min": "1.1.0",
+    "ksp_version_max": "1.1.1",
     "install": [
         {
             "find": "ModularFlightIntegrator",


### PR DESCRIPTION
1.1.3 is not compatible with all 1.1 releases.

