### PR TITLE
1.7.12 is compatible with KSP 1.1.3

### DIFF
--- a/Toolbar/Toolbar-1.7.13.ckan
+++ b/Toolbar/Toolbar-1.7.13.ckan
@@ -1,0 +1,29 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Toolbar",
+    "name": "Toolbar",
+    "abstract": "API for third-party plugins to provide toolbar buttons",
+    "author": "blizzy78",
+    "license": "BSD-2-clause",
+    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/60863",
+        "repository": "https://github.com/blizzy78/ksp_toolbar"
+    },
+    "version": "1.7.12",
+    "ksp_version": "1.1.3",
+    "install": [
+        {
+            "find": "GameData/000_Toolbar",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://www.blizzy.de/toolbar/Toolbar-1.7.12.zip",
+    "download_size": 78204,
+    "download_hash": {
+        "sha1": "69CDDAB0D9C077D76F755C86F431818758C3F762",
+        "sha256": "E14F02FEB9F3AFB4139A054DF0F42926B463DD79CF004367B971EB9F50947897"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
This CKAN file will hopefully help Mods that depend on Toolbar to be avialalble again on CKAN

