### PR TITLE
Update KerbalAlarmClock-v3.6.3.0.ckan

### DIFF
--- a/KerbalAlarmClock/KerbalAlarmClock-v3.6.3.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.6.3.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v3.6.3.0",
     "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.1.99",
+    "ksp_version_max": "1.1.2",
     "recommends": [
         {
             "name": "TriggerAu-Flags"

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.7.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.7.0.0.ckan
@@ -14,7 +14,7 @@
         "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.7.0.0",
-    "ksp_version_min": "1.1.0",
+    "ksp_version_min": "1.1.3",
     "ksp_version_max": "1.1.99",
     "recommends": [
         {

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.7.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.7.0.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v3.7.0.0",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.1.99",
+    "ksp_version_max": "1.1.3",
     "recommends": [
         {
             "name": "TriggerAu-Flags"

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.7.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.7.1.0.ckan
@@ -14,7 +14,7 @@
         "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.7.1.0",
-    "ksp_version_min": "1.1.0",
+    "ksp_version_min": "1.1.3",
     "ksp_version_max": "1.1.99",
     "recommends": [
         {


### PR DESCRIPTION
as per NetKAN #4283 https://github.com/KSP-CKAN/NetKAN/issues/4283 changes 3.6.3 to be the last version of KerbalAlarmClock for 1.1.2 KSP.

