### PR TITLE
Mark WiderContractApp final release as obsolete

### DIFF
--- a/WiderContractsApp/WiderContractsApp-1.3.4.ckan
+++ b/WiderContractsApp/WiderContractsApp-1.3.4.ckan
@@ -1,8 +1,8 @@
 {
     "spec_version": "v1.4",
     "identifier": "WiderContractsApp",
-    "name": "Wider Contracts App",
-    "abstract": "The stock contracts app, but 60% wider.",
+    "name": "Wider Contracts App - Obsolete",
+    "abstract": "The functionality of this mod has been moved into Contract Configurator. This version does nothing other than display a message saying it is obsolete.",
     "author": "nightingale",
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
@@ -21,5 +21,5 @@
         "sha256": "B8C1BB8BF8E08991E311F968F502DFE1D1679AB08E0841821AE3D4341FC18C6E"
     },
     "download_content_type": "application/zip",
-    "x_generated_by": "netkan"
+    "x_generated_by": "politas"
 }


### PR DESCRIPTION
This final release does nothing other than display a message saying it is obsolete.
Ref KSP-CKAN/CKAN#1805
Waiting on KSP-CKAN/NetKAN#4325 to be merged