### PR TITLE
VSR Restrict KSP versions

### DIFF
--- a/VenStockRevamp/VenStockRevamp-v1.9.2.ckan
+++ b/VenStockRevamp/VenStockRevamp-v1.9.2.ckan
@@ -11,7 +11,7 @@
     },
     "version": "v1.9.2",
     "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.1.99",
+    "ksp_version_max": "1.1.1",
     "depends": [
         {
             "name": "ModuleManager"

--- a/VenStockRevamp/VenStockRevamp-v1.9.2.ckan
+++ b/VenStockRevamp/VenStockRevamp-v1.9.2.ckan
@@ -11,7 +11,7 @@
     },
     "version": "v1.9.2",
     "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.1.1",
+    "ksp_version_max": "1.1.3",
     "depends": [
         {
             "name": "ModuleManager"


### PR DESCRIPTION
Ref KSP-CKAN/NetKAN#4336

@NathanKell, can you confirm that 1.9.2 should top out at KSP 1.1.1, or is it ok for 1.1.2 as well?