### PR TITLE
Restrict old KerbalKrashSystem release KSP versions

### DIFF
--- a/KerbalKrashSystem/KerbalKrashSystem-1-0.3.2.ckan
+++ b/KerbalKrashSystem/KerbalKrashSystem-1-0.3.2.ckan
@@ -10,7 +10,8 @@
         "repository": "https://github.com/EnzoMeertens/KerbalKrashSystem"
     },
     "version": "1:0.3.2",
-    "ksp_version": "1.1",
+    "ksp_version_min": "1.1.0",
+    "ksp_version_max": "1.1.2",
     "depends": [
         {
             "name": "ModuleManager",

--- a/KerbalKrashSystem/KerbalKrashSystem-1-0.3.3.ckan
+++ b/KerbalKrashSystem/KerbalKrashSystem-1-0.3.3.ckan
@@ -10,7 +10,8 @@
         "repository": "https://github.com/EnzoMeertens/KerbalKrashSystem"
     },
     "version": "1:0.3.3",
-    "ksp_version": "1.1",
+    "ksp_version_min": "1.1.0",
+    "ksp_version_max": "1.1.2",
     "depends": [
         {
             "name": "ModuleManager",

--- a/KerbalKrashSystem/KerbalKrashSystem-1-0.3.4.ckan
+++ b/KerbalKrashSystem/KerbalKrashSystem-1-0.3.4.ckan
@@ -10,7 +10,8 @@
         "repository": "https://github.com/EnzoMeertens/KerbalKrashSystem"
     },
     "version": "1:0.3.4",
-    "ksp_version": "1.1",
+    "ksp_version_min": "1.1.0",
+    "ksp_version_max": "1.1.2",
     "depends": [
         {
             "name": "ModuleManager",

--- a/KerbalKrashSystem/KerbalKrashSystem-1-0.3.5.ckan
+++ b/KerbalKrashSystem/KerbalKrashSystem-1-0.3.5.ckan
@@ -10,7 +10,8 @@
         "repository": "https://github.com/EnzoMeertens/KerbalKrashSystem"
     },
     "version": "1:0.3.5",
-    "ksp_version": "1.1",
+    "ksp_version_min": "1.1.0",
+    "ksp_version_max": "1.1.2",
     "depends": [
         {
             "name": "ModuleManager",


### PR DESCRIPTION
1:0.3.6 has been released with 1.1.3
1:0.3.1 has KSP 1.1.0
In between releases had KSP 1.1 on Curse
Setting in between releases to 1.1.0 - 1.1.2