### PR TITLE
Deadly Reentry 7.4.6 is 404

### DIFF
--- a/DeadlyReentry/DeadlyReentry-v7.4.6.frozen
+++ b/DeadlyReentry/DeadlyReentry-v7.4.6.frozen
@@ -24,7 +24,8 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/Starwaster/DeadlyReentry/releases/download/v7.4.6/DeadlyReentry_7.4.6.zip",
+    "download": "",
+    "comment": "Release removed from GitHub",
     "download_size": 790924,
     "download_hash": {
         "sha1": "3BBB37C7BE63AAB4423D0EB5497E8DECC9BE0E31",


### PR DESCRIPTION
Ref KSP-CKAN/CKAN#1822
7.4.5.1 is now the highest available DeadlyReentry for KSP 1.1.2
