### PR TITLE
Remove Fwiffos Dev Repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -15,13 +15,6 @@
         },
 
         {
-            "name":      "Fwiffos-Dev-Repo",
-            "uri":       "https://github.com/rkagerer/KSP-Fwiffo-Repository/raw/master/CKAN-meta-fwiffo.zip",
-            "x_mirror":  false,
-            "x_comment": "Development releases of selected mods as managed by Fwiffo"
-        },
-
-        {
             "name":      "MechJeb2-dev",
             "uri":       "https://ksp.sarbian.com/ckan/MechJeb2-ci.tar.gz",
             "x_mirror":  false,


### PR DESCRIPTION
It was useful for a while, but as was stated from the start, this repository is not being maintained, and is now almost completely useless.