### PR TITLE
Move RadialHeatShields downloads to GitHub

### DIFF
--- a/RadialHeatShields/RadialHeatShields-0.9.1.4.1.ckan
+++ b/RadialHeatShields/RadialHeatShields-0.9.1.4.1.ckan
@@ -20,7 +20,7 @@
             "filter": ".DS_Store"
         }
     ],
-    "download": "http://ckan1.spacedock.info/storage/CliftonM_12500/Radial_Heat_Shields/Radial_Heat_Shields-0.9.1.4.1.zip",
+    "download": "https://github.com/CliftonMarien/RadialHeatShields/releases/download/0.9.1.4.1/GameData.zip",
     "download_size": 2518164,
     "download_hash": {
         "sha1": "D331428626692C823B556357A4874F38D478ED18",

--- a/RadialHeatShields/RadialHeatShields-1.0.ckan
+++ b/RadialHeatShields/RadialHeatShields-1.0.ckan
@@ -6,7 +6,8 @@
     "author": "CliftonM",
     "license": "unrestricted",
     "resources": {
-        "spacedock": "https://spacedock.info/mod/428/Radial%20Heat%20Shields"
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/130057-Radial-Heat-Shields",
+        "repository": "https://github.com/clintmm/RadialHeatShields"
     },
     "version": "1.0",
     "ksp_version": "1.0.5",
@@ -28,7 +29,7 @@
             ]
         }
     ],
-    "download": "https://spacedock.info/mod/428/Radial%20Heat%20Shields/download/1.0",
+    "download": "https://github.com/CliftonMarien/RadialHeatShields/releases/download/1.0/GameData.zip",
     "download_size": 704358,
     "download_hash": {
         "sha1": "3E6CFE565AA73AB754B4137E0A69229308870B97",


### PR DESCRIPTION
Mod removed from Spacedock. No further development expected. The last two releases are on GitHub, so users of KSP 1.0.5 can grab them from there if they have some requirement.

