### PR TITLE
Update max ksp version setting for smokescreen

### DIFF
--- a/SmokeScreen/SmokeScreen-2.6.18.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.18.0.ckan
@@ -11,7 +11,7 @@
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.6.18.0",
-    "ksp_version": "1.1",
+    "ksp_version": "1.2",
     "install": [
         {
             "find": "SmokeScreen",


### PR DESCRIPTION
sarbian says that smokescreen 2.6.18 is a build for version 1.2.
see: http://forum.kerbalspaceprogram.com/index.php?/topic/64987-12-smokescreen-2618-extended-fx-plugin-oct-15th/