### PR TITLE
allow warpeverywhere on ksp 1.2.x

### DIFF
--- a/WarpEverywhere/WarpEverywhere-0.1.ckan
+++ b/WarpEverywhere/WarpEverywhere-0.1.ckan
@@ -12,7 +12,8 @@
         "x_screenshot": "https://spacedock.info/content/HMV_4317/Warp_Everywhere/Warp_Everywhere-1476286666.876909.jpg"
     },
     "version": "0.1",
-    "ksp_version": "1.2.0",
+    "ksp_version_min": "1.2.0",
+    "ksp_version_max": "1.2.99",
     "install": [
         {
             "find": "WarpEverywhere",


### PR DESCRIPTION
this mod is simple, works on 1.2.0/1.2.1/1.2.2 and is likely to not
need recompiles for patch revs of KSP.