### PR TITLE
Fixes ChopShop for KSP 1.1.3

### DIFF
--- a/ChopShop/ChopShop-0.10.0.2.ckan
+++ b/ChopShop/ChopShop-0.10.0.2.ckan
@@ -10,7 +10,7 @@
         "spacedock": "https://spacedock.info/mod/530/Dr.%20Jet's%20Chop%20Shop",
         "x_screenshot": "https://spacedock.info/content/Dr_Jet_1604/Dr._Jets_Chop_Shop/Dr._Jets_Chop_Shop-1460886808.2428079.png"
     },
-    "version": "1.10.0.2",
+    "version": "0.10.0.2",
     "ksp_version": "1.1.3",
     "depends": [
         {
@@ -61,7 +61,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "https://spacedock.info/mod/530/Dr.%20Jet%27s%20Chop%20Shop/download/1.10.0.2",
+    "download": "https://spacedock.info/mod/530/Dr.%20Jet%27s%20Chop%20Shop/download/0.10.0.2",
     "download_size": 3793191,
     "download_hash": {
         "sha1": "E37BFAF392164621C2A8A9AF5F339D4243353833",

--- a/ChopShop/ChopShop-0.10.0.3.ckan
+++ b/ChopShop/ChopShop-0.10.0.3.ckan
@@ -1,0 +1,72 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "ChopShop",
+    "name": "Dr. Jet's Chop Shop",
+    "abstract": "Properly oriented rover bodies, deployable skycranes, dual-axis solar panels, SpacePlane+ (Mk2) parts, blisters, structural hubs and other useful parts.",
+    "author": "Dr_Jet",
+    "license": "GPL-3.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/76248-105",
+        "spacedock": "https://spacedock.info/mod/530/Dr.%20Jet's%20Chop%20Shop",
+        "x_screenshot": "https://spacedock.info/content/Dr_Jet_1604/Dr._Jets_Chop_Shop/Dr._Jets_Chop_Shop-1460886808.2428079.png"
+    },
+    "version": "0.10.0.3",
+    "ksp_version": "1.1.3",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "TweakScale"
+        },
+        {
+            "name": "RealFuels"
+        },
+        {
+            "name": "RemoteTech"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "ModuleSolarTracking"
+        },
+        {
+            "name": "SETI-BalanceMod"
+        },
+        {
+            "name": "SETI-CommunityTechTree"
+        }
+    ],
+    "supports": [
+        {
+            "name": "FerramAerospaceResearch"
+        },
+        {
+            "name": "ModularFuelTanks"
+        }
+    ],
+    "install": [
+        {
+            "find": "ChopShop",
+            "install_to": "GameData"
+        },
+        {
+            "find": "SPH",
+            "install_to": "Ships"
+        },
+        {
+            "find": "VAB",
+            "install_to": "Ships"
+        }
+    ],
+    "download": "https://spacedock.info/mod/530/Dr.%20Jet%27s%20Chop%20Shop/download/0.10.0.3",
+    "download_size": 3764336,
+    "download_hash": {
+        "sha1": "8AC81D3D28948E5B16BE99D00482B7940A96465B",
+        "sha256": "54D0711B5D3642C5279D50D5D23C57B6B4CE2C66504D4D859F8535BE48FE6E24"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/ChopShop/ChopShop-0.10.0.3.ckan
+++ b/ChopShop/ChopShop-0.10.0.3.ckan
@@ -10,7 +10,7 @@
         "spacedock": "https://spacedock.info/mod/530/Dr.%20Jet's%20Chop%20Shop",
         "x_screenshot": "https://spacedock.info/content/Dr_Jet_1604/Dr._Jets_Chop_Shop/Dr._Jets_Chop_Shop-1460886808.2428079.png"
     },
-    "version": "0.10.0.3",
+    "version": "1:0.10.0.3",
     "ksp_version": "1.1.3",
     "depends": [
         {

--- a/ChopShop/ChopShop-0.10.1.1.ckan
+++ b/ChopShop/ChopShop-0.10.1.1.ckan
@@ -10,7 +10,7 @@
         "spacedock": "https://spacedock.info/mod/530/Dr.%20Jet's%20Chop%20Shop",
         "x_screenshot": "https://spacedock.info/content/Dr_Jet_1604/Dr._Jets_Chop_Shop/Dr._Jets_Chop_Shop-1460886808.2428079.png"
     },
-    "version": "0.10.1.1",
+    "version": "1:0.10.1.1",
     "ksp_version": "1.2.2",
     "depends": [
         {

--- a/ChopShop/ChopShop-0.10.1.2.ckan
+++ b/ChopShop/ChopShop-0.10.1.2.ckan
@@ -10,7 +10,7 @@
         "spacedock": "https://spacedock.info/mod/530/Dr.%20Jet's%20Chop%20Shop",
         "x_screenshot": "https://spacedock.info/content/Dr_Jet_1604/Dr._Jets_Chop_Shop/Dr._Jets_Chop_Shop-1460886808.2428079.png"
     },
-    "version": "0.10.1.2",
+    "version": "1:0.10.1.2",
     "ksp_version": "1.2.2",
     "depends": [
         {

--- a/ChopShop/ChopShop-0.10.1.ckan
+++ b/ChopShop/ChopShop-0.10.1.ckan
@@ -10,7 +10,7 @@
         "spacedock": "https://spacedock.info/mod/530/Dr.%20Jet's%20Chop%20Shop",
         "x_screenshot": "https://spacedock.info/content/Dr_Jet_1604/Dr._Jets_Chop_Shop/Dr._Jets_Chop_Shop-1460886808.2428079.png"
     },
-    "version": "0.10.1",
+    "version": "1:0.10.1",
     "ksp_version": "1.2.0",
     "depends": [
         {

--- a/ChopShop/ChopShop-0.10.1.ckan
+++ b/ChopShop/ChopShop-0.10.1.ckan
@@ -61,7 +61,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "https://spacedock.info/mod/530/Dr.%20Jet%27s%20Chop%20Shop/download/0.10.1",
+    "download": "https://addons-origin.cursecdn.com/files/2336/657/ChopShop_0.10.1.zip",
     "download_size": 3788508,
     "download_hash": {
         "sha1": "E10C0F743031F73F74407A87E7D69EDCD5597061",

--- a/ChopShop/ChopShop-1.10.0.2.ckan
+++ b/ChopShop/ChopShop-1.10.0.2.ckan
@@ -10,7 +10,7 @@
         "spacedock": "https://spacedock.info/mod/530/Dr.%20Jet's%20Chop%20Shop",
         "x_screenshot": "https://spacedock.info/content/Dr_Jet_1604/Dr._Jets_Chop_Shop/Dr._Jets_Chop_Shop-1460886808.2428079.png"
     },
-    "version": "0.10.0.2",
+    "version": "1.10.0.2",
     "ksp_version": "1.1.3",
     "depends": [
         {
@@ -61,7 +61,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "https://spacedock.info/mod/530/Dr.%20Jet%27s%20Chop%20Shop/download/0.10.0.2",
+    "download": "https://spacedock.info/mod/530/Dr.%20Jet%27s%20Chop%20Shop/download/1.10.0.2",
     "download_size": 3793191,
     "download_hash": {
         "sha1": "E37BFAF392164621C2A8A9AF5F339D4243353833",

--- a/ChopShop/ChopShop-1.10.0.2.ckan
+++ b/ChopShop/ChopShop-1.10.0.2.ckan
@@ -61,7 +61,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "https://spacedock.info/mod/530/Dr.%20Jet%27s%20Chop%20Shop/download/1.10.0.2",
+    "download": "https://addons-origin.cursecdn.com/files/2336/616/ChopShop_0.10.0.2.zip",
     "download_size": 3793191,
     "download_hash": {
         "sha1": "E37BFAF392164621C2A8A9AF5F339D4243353833",


### PR DESCRIPTION
The misnaming of ChopShop 0.10.0.2 as 1.10.0.2 caused the most recent version (0.10.0.3) for KSP 1.1.3 not to be picked up by NetKAN. It is renamed here to the correct version and adds a .ckan for 0.10.0.3. Since the download 0.10.0.2 is no longer available, ChopShop will not install for KSP 1.1.3. This pull request fixes these issues.