### PR TITLE
TACLS Configs - 4. Fix TACLS-Config-RealismOverhaul

### DIFF
--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.0.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.0.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.0.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.2",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.1.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.1.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.1.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.4",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.2.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.2.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.2.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.4",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.3.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.3.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.3.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.4",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.3.1.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.3.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.3.1",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.4",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.4.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.4.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.4.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.4",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.4.1.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.4.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.4.1",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.4",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.5.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.5.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.5.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.4",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.6.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.6.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.6.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.7.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.7.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.7.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.7.1.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.7.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.7.1",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.7.3.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.7.3.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.7.3",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.8.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.8.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.8.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.9.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.1.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.9.1",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.2.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.2.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.9.2",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.3.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.3.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.9.3",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.4.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.4.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.9.4",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.5.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.5.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.9.5",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.6.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v10.9.6.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v10.9.6",
-    "ksp_version": "any",
+    "ksp_version_max": "1.0.5",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.0.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.0.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v11.0.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.1.2",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.0.1.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.0.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v11.0.1",
-    "ksp_version": "any",
+    "ksp_version_max": "1.1.2",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.1.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.1.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v11.1.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.1.2",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.2.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.2.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v11.2.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.1.3",
     "provides": [
         "TACLS-Config"
     ],
@@ -34,10 +34,10 @@
         }
     ],
     "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v11.2.0/RealismOverhaul-v11.2.0.zip",
-    "download_size": 7787421,
+    "download_size": 7787343,
     "download_hash": {
-        "sha1": "8E060D1E64D9B6130E31DD0DD8A77CEE7EC737AB",
-        "sha256": "C77A84B4CEDAAF99A1A0D4FD15363648D1E416ABD83F86B72AEBF1B5228181F7"
+        "sha1": "4F04ED5E3B63C0B3ED016ED041238DDBA0DB3924",
+        "sha256": "F0B684AAB2D19B5623CA6C3FF9FE03ECA4BEB7C2E25F970022A3A6C682017051"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.3.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.3.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v11.3.0",
-    "ksp_version": "any",
+    "ksp_version_max": "1.1.3",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.3.1.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.3.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v11.3.1",
-    "ksp_version": "any",
+    "ksp_version_max": "1.1.3",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.3.2.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v11.3.2.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v11.3.2",
-    "ksp_version": "any",
+    "ksp_version_max": "1.1.3",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v6.1.2c.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v6.1.2c.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v6.1.2c",
-    "ksp_version": "any",
+    "ksp_version_max": "0.25",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.0.ckan
@@ -3,14 +3,14 @@
     "identifier": "TACLS-Config-RealismOverhaul",
     "name": "TAC Life Support (TACLS) - Realism Overhaul Config",
     "abstract": "Realism Overhaul config for TACLS",
-    "author": "NathanKell",
+    "author": "Felger",
     "license": "CC-BY-SA",
     "release_status": "stable",
     "resources": {
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
-    "version": "v10.7.2",
-    "ksp_version_max": "1.0.5",
+    "version": "v7.0.0",
+    "ksp_version_max": "0.25",
     "provides": [
         "TACLS-Config"
     ],
@@ -29,15 +29,15 @@
     ],
     "install": [
         {
-            "file": "GameData/ThunderAerospace",
+            "file": "ThunderAerospace",
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v10.7.2/RealismOverhaul-v10.7.2.zip",
-    "download_size": 6945152,
+    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v7.0.0/RealismOverhaul_7_0_0.zip",
+    "download_size": 1399370,
     "download_hash": {
-        "sha1": "2156454496264D0A3C6397EEF8E50756BE5D1B83",
-        "sha256": "FB744D460093C05F1DDA4F396111E28E4E03DC861ED138ACA72EF195DA45CDC2"
+        "sha1": "D04C896074B7A94B5F5E6727E151F30828715016",
+        "sha256": "6489AC591E5D752FDFB36E8E854630DC306518C9651412C5EFF3C84F858F9D27"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.0a.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.0a.ckan
@@ -1,39 +1,44 @@
 {
-  "spec_version": 1,
-  "ksp_version": "any",
-  "name": "TAC Life Support (TACLS) - Realism Overhaul Config",
-  "identifier": "TACLS-Config-RealismOverhaul",
-  "abstract": "Realism Overhaul config for TACLS",
-  "license": "CC-BY-SA",
-  "release_status": "stable",
-  "depends": [
-    {
-      "name": "RealismOverhaul"
+    "spec_version": 1,
+    "identifier": "TACLS-Config-RealismOverhaul",
+    "name": "TAC Life Support (TACLS) - Realism Overhaul Config",
+    "abstract": "Realism Overhaul config for TACLS",
+    "author": "Felger",
+    "license": "CC-BY-SA",
+    "release_status": "stable",
+    "resources": {
+        "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
-    {
-      "name": "TACLS"
-    }
-  ],
-  "provides": [
-    "TACLS-Config"
-  ],
-  "conflicts": [
-    {
-      "name": "TACLS-Config"
-    }
-  ],
-  "install": [
-    {
-      "file": "ThunderAerospace",
-      "install_to": "GameData"
-    }
-  ],
-  "resources": {
-    "repository": "https://github.com/KSP-RO/RealismOverhaul"
-  },
-  "author": "Felger",
-  "version": "v7.0.0a",
-  "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/7.0.0a/RealismOverhaul_7_0_0a.zip",
-  "x_generated_by": "netkan",
-  "download_size": 1389944
+    "version": "v7.0.0a",
+    "ksp_version_max": "0.25",
+    "provides": [
+        "TACLS-Config"
+    ],
+    "depends": [
+        {
+            "name": "RealismOverhaul"
+        },
+        {
+            "name": "TACLS"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "TACLS-Config"
+        }
+    ],
+    "install": [
+        {
+            "file": "ThunderAerospace",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v7.0.0a/RealismOverhaul_7_0_0a.zip",
+    "download_size": 1389944,
+    "download_hash": {
+        "sha1": "6AB3402E738208D9CA8EB864E6F423D25C8ABEAC",
+        "sha256": "742E4C0C0C476773FD92939A84D46218587638A12BAD71CDD8D10C83021E0CEE"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
 }

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.0b.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.0b.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.0b",
-    "ksp_version": "any",
+    "ksp_version_max": "0.25",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.1.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.1",
-    "ksp_version": "any",
+    "ksp_version_max": "0.25",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.2.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.2.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.2",
-    "ksp_version": "any",
+    "ksp_version_max": "0.25",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.3.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.3.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.3",
-    "ksp_version": "any",
+    "ksp_version_max": "0.25",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.4.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.4.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.4",
-    "ksp_version": "any",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.5.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.5.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.5",
-    "ksp_version": "any",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.6.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.6.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.6",
-    "ksp_version": "any",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.7.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v7.0.7.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.7",
-    "ksp_version": "any",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.0.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.0.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.0.0",
-    "ksp_version": "any",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.0.1.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.0.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.0.1",
-    "ksp_version": "any",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.1.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.1.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.1.0",
-    "ksp_version": "any",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.1.1.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.1.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.1.1",
-    "ksp_version": "any",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.2.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.2.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.2.0",
-    "ksp_version": "any",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.3.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.3.0.ckan
@@ -3,7 +3,7 @@
     "identifier": "TACLS-Config-RealismOverhaul",
     "name": "TAC Life Support (TACLS) - Realism Overhaul Config",
     "abstract": "Realism Overhaul config for TACLS",
-    "author": "NathanKell",
+    "author": "Felger",
     "license": "CC-BY-SA",
     "release_status": "stable",
     "resources": {

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.3.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.3.0.ckan
@@ -9,8 +9,8 @@
     "resources": {
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
-    "version": "v10.7.2",
-    "ksp_version_max": "1.0.5",
+    "version": "v8.3.0",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],
@@ -33,11 +33,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v10.7.2/RealismOverhaul-v10.7.2.zip",
-    "download_size": 6945152,
+    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v8.3.0/RealismOverhaul-v8.3.0.zip",
+    "download_size": 17532171,
     "download_hash": {
-        "sha1": "2156454496264D0A3C6397EEF8E50756BE5D1B83",
-        "sha256": "FB744D460093C05F1DDA4F396111E28E4E03DC861ED138ACA72EF195DA45CDC2"
+        "sha1": "9A2A128BDEA33A1459D24535604BFC30B1094800",
+        "sha256": "9BBB015CF31BF2AEC9A590E0060A175DB1B395B163A55A29DB2603872A9AE2B9"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.3.1.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.3.1.ckan
@@ -9,8 +9,8 @@
     "resources": {
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
-    "version": "v10.7.2",
-    "ksp_version_max": "1.0.5",
+    "version": "v8.3.1",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],
@@ -33,11 +33,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v10.7.2/RealismOverhaul-v10.7.2.zip",
-    "download_size": 6945152,
+    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v8.3.1/RealismOverhaul-v8.3.1.zip",
+    "download_size": 17533120,
     "download_hash": {
-        "sha1": "2156454496264D0A3C6397EEF8E50756BE5D1B83",
-        "sha256": "FB744D460093C05F1DDA4F396111E28E4E03DC861ED138ACA72EF195DA45CDC2"
+        "sha1": "C8029F137973023C1846982928FE7CF5B59A2DC1",
+        "sha256": "93CB280625BC8F63F9A21EC819239E631C5B76DD904377D5E674FF08BA9129CA"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.4.0.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.4.0.ckan
@@ -9,8 +9,8 @@
     "resources": {
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
-    "version": "v10.7.2",
-    "ksp_version_max": "1.0.5",
+    "version": "v8.4.0",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],
@@ -33,11 +33,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v10.7.2/RealismOverhaul-v10.7.2.zip",
-    "download_size": 6945152,
+    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v8.4.0/RealismOverhaul-v8.4.0.zip",
+    "download_size": 17539093,
     "download_hash": {
-        "sha1": "2156454496264D0A3C6397EEF8E50756BE5D1B83",
-        "sha256": "FB744D460093C05F1DDA4F396111E28E4E03DC861ED138ACA72EF195DA45CDC2"
+        "sha1": "EE7BF935B745545ECFA7993CDF46AA98AB7210EB",
+        "sha256": "A4DCA8612C71F53D41D90184FA61F8B925D652B93F6E73A82DFB77D0987D23C3"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.4.1.ckan
+++ b/TACLS-Config-RealismOverhaul/TACLS-Config-RealismOverhaul-v8.4.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.4.1",
-    "ksp_version": "any",
+    "ksp_version_max": "0.90",
     "provides": [
         "TACLS-Config"
     ],


### PR DESCRIPTION
- Added missing versions v7.0.0, v8.3.0 to v8.4.0
- Added a `ksp_version_max` to restrict installs in 1.2
