### PR TITLE
TACLS Configs - 2. Fix RealismOverhaul

### DIFF
--- a/RealismOverhaul/RealismOverhaul-v10.1.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v10.1.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/99966",
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
-    "version": "10.2.0",
+    "version": "v10.1.0",
     "ksp_version": "1.0.4",
     "provides": [
         "RealPlumeConfigs",
@@ -236,11 +236,11 @@
             "comment": "SPH craft files"
         }
     ],
-    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v10.2.0/RealismOverhaul-v10.2.0.zip",
-    "download_size": 6485510,
+    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v10.1.0/RealismOverhaul-v10.1.0.zip",
+    "download_size": 5917552,
     "download_hash": {
-        "sha1": "FA9A7C86FA47674D86C468C3EFF1922B5A847887",
-        "sha256": "B33BF6C9EBA12BBD4B1761BE2BF0E84F145D94962ECBEFD88A4E62E6458303FB"
+        "sha1": "42F76F87C9F4B3DE286853B13F79BAC61B4BD32F",
+        "sha256": "A9BF899F3443F74A4490D20A9C54DE227C26A2A34632B6E19B3F120E2224757F"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/RealismOverhaul/RealismOverhaul-v10.6.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v10.6.0.ckan
@@ -3,15 +3,15 @@
     "identifier": "RealismOverhaul",
     "name": "Realism Overhaul",
     "abstract": "Multipatch to KSP to give spacecraft components realistic stats and sizes, and performance based on real-world spacecraft.",
-    "author": "NathanKell",
+    "author": "stratochief66",
     "license": "CC-BY-SA",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/99966",
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
-    "version": "10.1.0",
-    "ksp_version": "1.0.4",
+    "version": "v10.6.0",
+    "ksp_version": "1.0.5",
     "provides": [
         "RealPlumeConfigs",
         "RealFuels-Engine-Configs"
@@ -21,9 +21,6 @@
             "name": "AdvancedJetEngine"
         },
         {
-            "name": "CrossFeedEnabler"
-        },
-        {
             "name": "FerramAerospaceResearch"
         },
         {
@@ -31,9 +28,6 @@
         },
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "ModuleRCSFX"
         },
         {
             "name": "RealChute"
@@ -53,10 +47,7 @@
     ],
     "recommends": [
         {
-            "name": "B9AerospaceProceduralParts"
-        },
-        {
-            "name": "BetterBuoyancy"
+            "name": "B9-PWings-Fork"
         },
         {
             "name": "ConnectedLivingSpace"
@@ -77,9 +68,6 @@
             "name": "MechJeb2"
         },
         {
-            "name": "ModuleFixer"
-        },
-        {
             "name": "ProceduralFairings"
         },
         {
@@ -89,13 +77,13 @@
             "name": "ProceduralParts"
         },
         {
+            "name": "RCSBuildAid"
+        },
+        {
             "name": "RealSolarSystem"
         },
         {
             "name": "RemoteTech"
-        },
-        {
-            "name": "RemoteTech-Config-RSS"
         },
         {
             "name": "SemiSaturatableRW"
@@ -105,12 +93,6 @@
         },
         {
             "name": "TACLS-Config-RealismOverhaul"
-        },
-        {
-            "name": "TestFlight"
-        },
-        {
-            "name": "TestFlightConfigRO"
         },
         {
             "name": "TextureReplacer"
@@ -128,6 +110,9 @@
         },
         {
             "name": "ALCOR"
+        },
+        {
+            "name": "AtomicAge"
         },
         {
             "name": "DMagicOrbitalScience"
@@ -187,6 +172,21 @@
             "name": "SovietEngines"
         },
         {
+            "name": "RN-SalyutStations-SoyuzFerries"
+        },
+        {
+            "name": "RN-Skylab"
+        },
+        {
+            "name": "RN-SovietProbes"
+        },
+        {
+            "name": "RN-SovietRockets"
+        },
+        {
+            "name": "RN-USProbesPack"
+        },
+        {
             "name": "SpaceFactory-Voskhod-unofficial"
         },
         {
@@ -194,6 +194,15 @@
         },
         {
             "name": "SXT"
+        },
+        {
+            "name": "Taerobee"
+        },
+        {
+            "name": "Tantares"
+        },
+        {
+            "name": "TantaresLV"
         },
         {
             "name": "UniversalStorage"
@@ -216,11 +225,6 @@
             "install_to": "GameData"
         },
         {
-            "file": "GameData/KAS",
-            "install_to": "GameData",
-            "comment": "KAS config, does not overwrite"
-        },
-        {
             "file": "GameData/EngineGroupController",
             "install_to": "GameData",
             "comment": "Engine Group Controller, unique to RO."
@@ -236,11 +240,11 @@
             "comment": "SPH craft files"
         }
     ],
-    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v10.1.0/RealismOverhaul-v10.1.0.zip",
-    "download_size": 5917552,
+    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v10.6.0/RealismOverhaul-v10.6.0.zip",
+    "download_size": 6911247,
     "download_hash": {
-        "sha1": "42F76F87C9F4B3DE286853B13F79BAC61B4BD32F",
-        "sha256": "A9BF899F3443F74A4490D20A9C54DE227C26A2A34632B6E19B3F120E2224757F"
+        "sha1": "46C96998A100199B41A30E7420FB2D0A19B59BF7",
+        "sha256": "88C9372D4F471B6E0817DC363094A31E4FCC98028DE46A38AED6D58534494FFC"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/RealismOverhaul/RealismOverhaul-v10.9.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v10.9.0.ckan
@@ -14,7 +14,8 @@
     "ksp_version": "1.0.5",
     "provides": [
         "RealPlumeConfigs",
-        "RealFuels-Engine-Configs"
+        "RealFuels-Engine-Configs",
+        "TestFlightConfig"
     ],
     "depends": [
         {

--- a/RealismOverhaul/RealismOverhaul-v10.9.1.ckan
+++ b/RealismOverhaul/RealismOverhaul-v10.9.1.ckan
@@ -14,7 +14,8 @@
     "ksp_version": "1.0.5",
     "provides": [
         "RealPlumeConfigs",
-        "RealFuels-Engine-Configs"
+        "RealFuels-Engine-Configs",
+        "TestFlightConfig"
     ],
     "depends": [
         {

--- a/RealismOverhaul/RealismOverhaul-v10.9.2.ckan
+++ b/RealismOverhaul/RealismOverhaul-v10.9.2.ckan
@@ -14,7 +14,8 @@
     "ksp_version": "1.0.5",
     "provides": [
         "RealPlumeConfigs",
-        "RealFuels-Engine-Configs"
+        "RealFuels-Engine-Configs",
+        "TestFlightConfig"
     ],
     "depends": [
         {

--- a/RealismOverhaul/RealismOverhaul-v11.2.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v11.2.0.ckan
@@ -251,10 +251,10 @@
         }
     ],
     "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v11.2.0/RealismOverhaul-v11.2.0.zip",
-    "download_size": 7787421,
+    "download_size": 7787343,
     "download_hash": {
-        "sha1": "8E060D1E64D9B6130E31DD0DD8A77CEE7EC737AB",
-        "sha256": "C77A84B4CEDAAF99A1A0D4FD15363648D1E416ABD83F86B72AEBF1B5228181F7"
+        "sha1": "4F04ED5E3B63C0B3ED016ED041238DDBA0DB3924",
+        "sha256": "F0B684AAB2D19B5623CA6C3FF9FE03ECA4BEB7C2E25F970022A3A6C682017051"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/RealismOverhaul/RealismOverhaul-v6.1.2c.ckan
+++ b/RealismOverhaul/RealismOverhaul-v6.1.2c.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v6.1.2c",
-    "ksp_version": "0.25.0",
+    "ksp_version": "0.25",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v7.0.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v7.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.0",
-    "ksp_version": "0.25.0",
+    "ksp_version": "0.25",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v7.0.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v7.0.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/84689",
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
-    "version": "v7.0.0a",
+    "version": "v7.0.0",
     "ksp_version": "0.25.0",
     "provides": [
         "RealFuels-Engine-Configs"
@@ -93,11 +93,11 @@
             "comment": "KAS config, does not overwrite"
         }
     ],
-    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v7.0.0a/RealismOverhaul_7_0_0a.zip",
-    "download_size": 1389944,
+    "download": "https://github.com/KSP-RO/RealismOverhaul/releases/download/v7.0.0/RealismOverhaul_7_0_0.zip",
+    "download_size": 1399370,
     "download_hash": {
-        "sha1": "6AB3402E738208D9CA8EB864E6F423D25C8ABEAC",
-        "sha256": "742E4C0C0C476773FD92939A84D46218587638A12BAD71CDD8D10C83021E0CEE"
+        "sha1": "D04C896074B7A94B5F5E6727E151F30828715016",
+        "sha256": "6489AC591E5D752FDFB36E8E854630DC306518C9651412C5EFF3C84F858F9D27"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/RealismOverhaul/RealismOverhaul-v7.0.0a.ckan
+++ b/RealismOverhaul/RealismOverhaul-v7.0.0a.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.0a",
-    "ksp_version": "0.25.0",
+    "ksp_version": "0.25",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v7.0.0b.ckan
+++ b/RealismOverhaul/RealismOverhaul-v7.0.0b.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.0b",
-    "ksp_version": "0.25.0",
+    "ksp_version": "0.25",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v7.0.1.ckan
+++ b/RealismOverhaul/RealismOverhaul-v7.0.1.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.1",
-    "ksp_version": "0.25.0",
+    "ksp_version": "0.25",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v7.0.2.ckan
+++ b/RealismOverhaul/RealismOverhaul-v7.0.2.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.2",
-    "ksp_version": "0.25.0",
+    "ksp_version": "0.25",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v7.0.3.ckan
+++ b/RealismOverhaul/RealismOverhaul-v7.0.3.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.3",
-    "ksp_version": "0.25.0",
+    "ksp_version": "0.25",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v7.0.4.ckan
+++ b/RealismOverhaul/RealismOverhaul-v7.0.4.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.4",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v7.0.5.ckan
+++ b/RealismOverhaul/RealismOverhaul-v7.0.5.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.5",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v7.0.6.ckan
+++ b/RealismOverhaul/RealismOverhaul-v7.0.6.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.6",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v7.0.7.ckan
+++ b/RealismOverhaul/RealismOverhaul-v7.0.7.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v7.0.7",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v8.0.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v8.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.0.0",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v8.0.1.ckan
+++ b/RealismOverhaul/RealismOverhaul-v8.0.1.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.0.1",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v8.1.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v8.1.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.1.0",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v8.1.1.ckan
+++ b/RealismOverhaul/RealismOverhaul-v8.1.1.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.1.1",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v8.2.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v8.2.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.2.0",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v8.3.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v8.3.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.3.0",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v8.3.1.ckan
+++ b/RealismOverhaul/RealismOverhaul-v8.3.1.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.3.1",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v8.4.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v8.4.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.4.0",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],

--- a/RealismOverhaul/RealismOverhaul-v8.4.1.ckan
+++ b/RealismOverhaul/RealismOverhaul-v8.4.1.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/KSP-RO/RealismOverhaul"
     },
     "version": "v8.4.1",
-    "ksp_version": "0.90.0",
+    "ksp_version": "0.90",
     "provides": [
         "RealFuels-Engine-Configs"
     ],


### PR DESCRIPTION
* Added missing versions v7.0.0, v10.1.0 and v10.6.0
* Added missing provides `TestFlightConfig` for v10.9.0 to v10.9.2
* Reformated `.ckan` file of v7.0.0a
* Removed duplicate versions (git sees them as renamed)
* Removed all trailing zeros for `0.25` and `0.90`