### PR TITLE
Update version error for FAR v0.15.8

### DIFF
--- a/FerramAerospaceResearch/FerramAerospaceResearch-3-0.15.8.ckan
+++ b/FerramAerospaceResearch/FerramAerospaceResearch-3-0.15.8.ckan
@@ -10,7 +10,8 @@
         "repository": "https://github.com/ferram4/Ferram-Aerospace-Research"
     },
     "version": "3:0.15.8",
-    "ksp_version": "1.2.0",
+    "ksp_version_min": "1.2.0",
+    "ksp_version_max": "1.2.2",
     "provides": [
         "AerodynamicModel",
         "FAR"


### PR DESCRIPTION
There was an error in the .version file used to create the current metadata for FAR v0.15.8.  FAR v0.15.8 should be compatible with KSP 1.2.0, 1.2.1 and 1.2.2; this change should address that.