### PR TITLE
Add KerbalEngineerRedux 1.1.3.0

### DIFF
--- a/KerbalEngineerRedux/KerbalEngineerRedux-1.1.3.0.ckan
+++ b/KerbalEngineerRedux/KerbalEngineerRedux-1.1.3.0.ckan
@@ -1,0 +1,33 @@
+{
+    "spec_version": 1,
+    "identifier": "KerbalEngineerRedux",
+    "name": "Kerbal Engineer Redux",
+    "abstract": "Reveals important statistics about your ship and its orbit during building and flight",
+    "author": "CYBUTEK",
+    "license": "GPL-3.0",
+    "release_status": "testing",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/18230",
+        "repository": "https://github.com/CYBUTEK/KerbalEngineer",
+        "github": {
+            "url": "https://github.com/CYBUTEK/KerbalEngineer"
+        }
+    },
+    "version": "1.1.3.0",
+    "ksp_version_min": "1.2.9",
+    "ksp_version_max": "1.3.0",
+    "install": [
+        {
+            "file": "KerbalEngineer",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/CYBUTEK/KerbalEngineer/releases/download/1.1.3.0/KerbalEngineer-1.1.3.0.zip",
+    "download_size": 909377,
+    "download_hash": {
+        "sha1": "339C4DC270A4F071B29C9841B77F0206E667976F",
+        "sha256": "A4C9301734D66FE736B5792B880DFFC34F293BE78EA3640EC50DEC17F783243E"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
Zip file for this release was updated and reloaded, we are stuck with a failing cached copy, it seems.