### PR TITLE
Revert KSP Interstellar version error

### DIFF
--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.3.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.3.ckan
@@ -13,7 +13,7 @@
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/KSP_Interstellar_Extended/KSP_Interstellar_Extended-1470128568.7429862.png"
     },
     "version": "1.4.3",
-    "ksp_version": "1.3.0",
+    "ksp_version": "1.0.4",
     "depends": [
         {
             "name": "CommunityResourcePack",


### PR DESCRIPTION
This will solve https://github.com/KSP-CKAN/NetKAN/issues/5635 , at least making CKAN clients able to download KSP Interstellar 1.14 without 404 error, while waiting for the Spacedock indexer to index KSP Interstellar 1.14.3