### PR TITLE
Add DynamicBatteryStorage dependency to CryoTanks and NearFutureElectrical

### DIFF
--- a/CryoTanks/CryoTanks-0.1.0.ckan
+++ b/CryoTanks/CryoTanks-0.1.0.ckan
@@ -9,6 +9,7 @@
     "resources": {
         "repository": "https://github.com/ChrisAdderley",
         "kerbalstuff": "https://kerbalstuff.com/mod/1422/Kerbal%20Atomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://kerbalstuff.com/content/Nertea_3884/Kerbal_Atomics/Kerbal_Atomics-1453504774.0092812.png"
     },
     "version": "0.1.0",

--- a/CryoTanks/CryoTanks-0.1.1.ckan
+++ b/CryoTanks/CryoTanks-0.1.1.ckan
@@ -9,6 +9,7 @@
     "resources": {
         "repository": "https://github.com/ChrisAdderley",
         "kerbalstuff": "https://kerbalstuff.com/mod/1422/Kerbal%20Atomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://kerbalstuff.com/content/Nertea_3884/Kerbal_Atomics/Kerbal_Atomics-1453504774.0092812.png"
     },
     "version": "0.1.1",

--- a/CryoTanks/CryoTanks-0.2.2.ckan
+++ b/CryoTanks/CryoTanks-0.2.2.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
         "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
-        "repository": "https://github.com/ChrisAdderley/KerbalAtomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
     },
     "version": "0.2.2",

--- a/CryoTanks/CryoTanks-0.2.3.ckan
+++ b/CryoTanks/CryoTanks-0.2.3.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
         "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
-        "repository": "https://github.com/ChrisAdderley/KerbalAtomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
     },
     "version": "0.2.3",

--- a/CryoTanks/CryoTanks-0.2.4.ckan
+++ b/CryoTanks/CryoTanks-0.2.4.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
         "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
-        "repository": "https://github.com/ChrisAdderley/KerbalAtomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
     },
     "version": "0.2.4",

--- a/CryoTanks/CryoTanks-0.2.5.ckan
+++ b/CryoTanks/CryoTanks-0.2.5.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
         "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
-        "repository": "https://github.com/ChrisAdderley/KerbalAtomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
     },
     "version": "0.2.5",

--- a/CryoTanks/CryoTanks-0.2.6.ckan
+++ b/CryoTanks/CryoTanks-0.2.6.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
         "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
-        "repository": "https://github.com/ChrisAdderley/KerbalAtomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
     },
     "version": "0.2.6",

--- a/CryoTanks/CryoTanks-0.3.0.ckan
+++ b/CryoTanks/CryoTanks-0.3.0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
         "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
-        "repository": "https://github.com/ChrisAdderley/KerbalAtomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
     },
     "version": "0.3.0",

--- a/CryoTanks/CryoTanks-0.3.2.ckan
+++ b/CryoTanks/CryoTanks-0.3.2.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
         "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
-        "repository": "https://github.com/ChrisAdderley/KerbalAtomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
     },
     "version": "0.3.2",

--- a/CryoTanks/CryoTanks-0.3.3.ckan
+++ b/CryoTanks/CryoTanks-0.3.3.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
         "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
-        "repository": "https://github.com/ChrisAdderley/KerbalAtomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
     },
     "version": "0.3.3",

--- a/CryoTanks/CryoTanks-0.3.4.ckan
+++ b/CryoTanks/CryoTanks-0.3.4.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
         "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
-        "repository": "https://github.com/ChrisAdderley/KerbalAtomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
     },
     "version": "0.3.4",

--- a/CryoTanks/CryoTanks-0.3.5.ckan
+++ b/CryoTanks/CryoTanks-0.3.5.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
         "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
-        "repository": "https://github.com/ChrisAdderley/KerbalAtomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
     },
     "version": "0.3.5",

--- a/CryoTanks/CryoTanks-0.4.2.ckan
+++ b/CryoTanks/CryoTanks-0.4.2.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
         "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
-        "repository": "https://github.com/ChrisAdderley/KerbalAtomics",
+        "repository": "https://github.com/ChrisAdderley/CryoTanks",
         "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
     },
     "version": "0.4.2",

--- a/CryoTanks/CryoTanks-0.4.2.ckan
+++ b/CryoTanks/CryoTanks-0.4.2.ckan
@@ -20,6 +20,9 @@
         },
         {
             "name": "ModuleManager"
+        },
+        {
+            "name": "DynamicBatteryStorage"
         }
     ],
     "supports": [

--- a/DynamicBatteryStorage/DynamicBatteryStorage-1.0.0.ckan
+++ b/DynamicBatteryStorage/DynamicBatteryStorage-1.0.0.ckan
@@ -1,0 +1,31 @@
+{
+    "spec_version": "v1.4",
+    "comment": "Dynamic Battery Storage does not have its own release. Sourced from the KerbalAtomics archive.",
+    "identifier": "DynamicBatteryStorage",
+    "name": "Dynamic Battery Storage",
+    "abstract": "A plugin that works around the problems of stock electricity consumption/generation at high time warp.",
+    "author": "Nertea",
+    "license": "CC-BY-NC-SA-4.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/130503-10511-kerbal-atomics-fancy-nuclear-engines-initial-11-test/",
+        "spacedock": "https://spacedock.info/mod/710/Kerbal%20Atomics",
+        "repository": "https://github.com/ChrisAdderley/DynamicBatteryStorage",
+        "x_screenshot": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-1463537395.8438432.png"
+    },
+    "version": "1.0.0",
+    "ksp_version": "1.3.0",
+    "install": [
+        {
+            "file": "GameData/DynamicBatteryStorage",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://spacedock.info/mod/710/Kerbal%20Atomics/download/0.4.2",
+    "download_size": 56855146,
+    "download_hash": {
+        "sha1": "AA53121FF12550FED323C85A14B4557641B79B75",
+        "sha256": "44F84EB0BEE960ABED6E26DE508E5DA14D5213EE682F86F2FF3E7143991F2469"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/NearFutureElectrical/NearFutureElectrical-0.9.1.ckan
+++ b/NearFutureElectrical/NearFutureElectrical-0.9.1.ckan
@@ -25,6 +25,9 @@
         },
         {
             "name": "ModuleManager"
+        },
+        {
+            "name": "DynamicBatteryStorage"
         }
     ],
     "recommends": [


### PR DESCRIPTION
New dependency that was added to the downloads but not to the metadata

Forum discussion: http://forum.kerbalspaceprogram.com/index.php?/topic/106089-130-cryogenic-engines-high-isp-chemical-rockets-june-26/&do=findComment&comment=3106561

I'm doing this one manually because the most recent versions of CryoTanks and NFE have already been indexed, also the fact that the first version of DynamicBatteryStorage does not have a `.version` file so the version will have to be set manually.  I will create a separate PR in NetKAN to make these changes permanent.