### PR TITLE
Fix FAR v0.15.9 KSP compatibility

### DIFF
--- a/FerramAerospaceResearch/FerramAerospaceResearch-3-0.15.9.ckan
+++ b/FerramAerospaceResearch/FerramAerospaceResearch-3-0.15.9.ckan
@@ -10,8 +10,8 @@
         "repository": "https://github.com/ferram4/Ferram-Aerospace-Research"
     },
     "version": "3:0.15.9",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.2",
+    "ksp_version_min": "1.3.0",
+    "ksp_version_max": "1.3.99",
     "provides": [
         "AerodynamicModel",
         "FAR"


### PR DESCRIPTION
For some reason, it says that FAR v0.15.9 is for KSP 1.2.  It is not; it is for KSP 1.3.