### PR TITLE
1.2 versions incompatible with 1.2.9 prerelease

### DIFF
--- a/Astrogator/Astrogator-v0.1.1.ckan
+++ b/Astrogator/Astrogator-v0.1.1.ckan
@@ -12,7 +12,7 @@
     },
     "version": "v0.1.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "download": "https://github.com/HebaruSan/Astrogator/releases/download/v0.1.1/Astrogator.zip",
     "download_size": 75930,
     "download_hash": {

--- a/Astrogator/Astrogator-v0.2.0.ckan
+++ b/Astrogator/Astrogator-v0.2.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.2.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.3.0.ckan
+++ b/Astrogator/Astrogator-v0.3.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.3.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.3.1.ckan
+++ b/Astrogator/Astrogator-v0.3.1.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.3.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.4.0.ckan
+++ b/Astrogator/Astrogator-v0.4.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.4.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.5.0.ckan
+++ b/Astrogator/Astrogator-v0.5.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.5.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.5.1.ckan
+++ b/Astrogator/Astrogator-v0.5.1.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.5.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.5.2.ckan
+++ b/Astrogator/Astrogator-v0.5.2.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.5.2",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "depends": [
         {
             "name": "ModuleManager"

--- a/Astrogator/Astrogator-v0.6.0.ckan
+++ b/Astrogator/Astrogator-v0.6.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.6.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "depends": [
         {
             "name": "ModuleManager"

--- a/Astrogator/Astrogator-v0.6.1.ckan
+++ b/Astrogator/Astrogator-v0.6.1.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.6.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "depends": [
         {
             "name": "ModuleManager"

--- a/Astrogator/Astrogator-v0.6.2.ckan
+++ b/Astrogator/Astrogator-v0.6.2.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.6.2",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "depends": [
         {
             "name": "ModuleManager"


### PR DESCRIPTION
Just in case anyone still has the 1.2.9 prerelease, this marks the 1.2 editions of Astrogator as incompatible with it. Previously it would have been possible to install them with CKAN and crash KSP, since 1.2.9 made backwards incompatible changes with 1.2.2.