### PR TITLE
Change author dbb to Dwayne Bent

### DIFF
--- a/HotSpot/HotSpot-0.2.0.ckan
+++ b/HotSpot/HotSpot-0.2.0.ckan
@@ -3,7 +3,7 @@
     "identifier": "HotSpot",
     "name": "Hot Spot",
     "abstract": "Display better thermal data.",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/123967",

--- a/HotSpot/HotSpot-0.3.0.ckan
+++ b/HotSpot/HotSpot-0.3.0.ckan
@@ -3,7 +3,7 @@
     "identifier": "HotSpot",
     "name": "Hot Spot",
     "abstract": "Display better thermal data.",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/123967",

--- a/HotSpot/HotSpot-0.4.1.ckan
+++ b/HotSpot/HotSpot-0.4.1.ckan
@@ -3,7 +3,7 @@
     "identifier": "HotSpot",
     "name": "Hot Spot",
     "abstract": "Display better thermal data.",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/123967",

--- a/HotSpot/HotSpot-0.4.2.ckan
+++ b/HotSpot/HotSpot-0.4.2.ckan
@@ -3,7 +3,7 @@
     "identifier": "HotSpot",
     "name": "Hot Spot",
     "abstract": "Display better thermal data.",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/123967",

--- a/HotSpot/HotSpot-0.4.3.ckan
+++ b/HotSpot/HotSpot-0.4.3.ckan
@@ -3,7 +3,7 @@
     "identifier": "HotSpot",
     "name": "Hot Spot",
     "abstract": "Display better thermal data.",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/123967",

--- a/HotSpot/HotSpot-0.4.4.ckan
+++ b/HotSpot/HotSpot-0.4.4.ckan
@@ -3,7 +3,7 @@
     "identifier": "HotSpot",
     "name": "Hot Spot",
     "abstract": "Display better thermal data.",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/123967",

--- a/PlaneMode/PlaneMode-0.3.0.ckan
+++ b/PlaneMode/PlaneMode-0.3.0.ckan
@@ -3,7 +3,7 @@
     "identifier": "PlaneMode",
     "name": "Plane Mode",
     "abstract": "Swap Yaw/Roll in Flight",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106934",

--- a/PlaneMode/PlaneMode-0.4.0.ckan
+++ b/PlaneMode/PlaneMode-0.4.0.ckan
@@ -3,7 +3,7 @@
     "identifier": "PlaneMode",
     "name": "Plane Mode",
     "abstract": "Swap Yaw/Roll in Flight",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106934",

--- a/PlaneMode/PlaneMode-0.4.1.ckan
+++ b/PlaneMode/PlaneMode-0.4.1.ckan
@@ -3,7 +3,7 @@
     "identifier": "PlaneMode",
     "name": "Plane Mode",
     "abstract": "Swap Yaw/Roll in Flight",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106934",

--- a/PlaneMode/PlaneMode-1.0.0.ckan
+++ b/PlaneMode/PlaneMode-1.0.0.ckan
@@ -3,7 +3,7 @@
     "identifier": "PlaneMode",
     "name": "Plane Mode",
     "abstract": "Swap Yaw/Roll in Flight",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106934",

--- a/PlaneMode/PlaneMode-1.1.0.ckan
+++ b/PlaneMode/PlaneMode-1.1.0.ckan
@@ -3,7 +3,7 @@
     "identifier": "PlaneMode",
     "name": "Plane Mode",
     "abstract": "Swap Yaw/Roll in Flight",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106934",

--- a/PlaneMode/PlaneMode-1.2.0.ckan
+++ b/PlaneMode/PlaneMode-1.2.0.ckan
@@ -3,7 +3,7 @@
     "identifier": "PlaneMode",
     "name": "Plane Mode",
     "abstract": "Swap Yaw/Roll in Flight",
-    "author": "dbb",
+    "author": "Dwayne Bent",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106934",


### PR DESCRIPTION
Latest releases of PlaneMode and HotSpot have an author of "Dwayne Bent."
Earliest releases are by "dbb".

I think it's fair to infer this is the same person. This PR replaces the older name with the newer name in old metadata to make author searches easier.