### PR TITLE
AlternisKerbolRekerjiggered, clean up old versions with bad version formats

### DIFF
--- a/AlternisKerbolRekerjiggered/AlternisKerbolRekerjiggered-1.4.1.ckan
+++ b/AlternisKerbolRekerjiggered/AlternisKerbolRekerjiggered-1.4.1.ckan
@@ -10,7 +10,7 @@
         "kerbalstuff": "https://kerbalstuff.com/mod/1143/Alternis%20Kerbol%20Rekerjiggered",
         "x_screenshot": "https://kerbalstuff.com/content/GregroxMun_8555/Alternis_Kerbol_Rekerjiggered/Alternis_Kerbol_Rekerjiggered-1443398937.4146845.png"
     },
-    "version": "Version_1.4.1",
+    "version": "1.4.1",
     "ksp_version": "1.0.4",
     "depends": [
         {

--- a/AlternisKerbolRekerjiggered/AlternisKerbolRekerjiggered-1.5.1.ckan
+++ b/AlternisKerbolRekerjiggered/AlternisKerbolRekerjiggered-1.5.1.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "repository": "https://github.com/GregroxMun/Alternis-Kerbol-Rekerjiggered"
     },
-    "version": "v1.5.1",
+    "version": "1.5.1",
     "ksp_version": "1.0.5",
     "depends": [
         {


### PR DESCRIPTION
Most versions of this mod were released with an X.Y.Z version format, but two old versions are vX.Y.Z or Version_X.Y.Z instead. This PR makes them consistent by removing the extra prefixes from the old versions.

This is one of the problems pointed out in https://github.com/KSP-CKAN/NetKAN/issues/5945.