### PR TITLE
Fix ksp_version_min for OPM 2.1

### DIFF
--- a/OuterPlanetsMod/OuterPlanetsMod-1-2.1.ckan
+++ b/OuterPlanetsMod/OuterPlanetsMod-1-2.1.ckan
@@ -11,7 +11,7 @@
         "x_screenshot": "https://spacedock.info/content/CaptRobau_1263/Outer_Planets_Mod/Outer_Planets_Mod-1456783713.5496085.png"
     },
     "version": "1:2.1",
-    "ksp_version_min": "1.1.2",
+    "ksp_version_min": "1.2.1",
     "ksp_version_max": "1.2.2",
     "provides": [
         "CustomAsteroids-Pops"


### PR DESCRIPTION
This version of OPM was released to work on KSP 1.2, but the ksp_version_min is listed as 1.1.2, which is currently causing CKAN to try to install this version on KSP 1.1.3, which fortunately fails because the Kopernicus dependency specifies a min_version of 1.2.1-1, which is only compatible with KSP 1.2.1.

https://forum.kerbalspaceprogram.com/index.php?/topic/93999-121-outer-planets-mod-21-biome-overhaul-more-biomes-more-interesting-names-better-looking-etc-17-nov/&do=findComment&comment=2853267

This pull request fixes the transposed digits.