### PR TITLE
Update KSP versions on old versions of NewTantares

### DIFF
--- a/NewTantares/NewTantares-v6.0.ckan
+++ b/NewTantares/NewTantares-v6.0.ckan
@@ -10,7 +10,8 @@
         "repository": "https://github.com/Tantares/Tantares"
     },
     "version": "v6.0",
-    "ksp_version": "1.2.2",
+    "ksp_version_min": "1.3.0",
+    "ksp_version_max": "1.3.8",
     "recommends": [
         {
             "name": "NewTantaresLV"

--- a/NewTantares/NewTantares-v7.0.ckan
+++ b/NewTantares/NewTantares-v7.0.ckan
@@ -10,7 +10,8 @@
         "repository": "https://github.com/Tantares/Tantares"
     },
     "version": "v7.0",
-    "ksp_version": "1.2.2",
+    "ksp_version_min": "1.3.0",
+    "ksp_version_max": "1.3.8",
     "recommends": [
         {
             "name": "NewTantaresLV"


### PR DESCRIPTION
v7.0 and v6.0 are explicitly stated to be 1.3 compatible:

https://github.com/Tantares/Tantares/releases

v8.0 already fixed by updating the netkan.