### PR TITLE
Index KSPIE 1.15.4 (fixes KSP-CKAN/CKAN#2196)

### DIFF
--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.15.4.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.15.4.ckan
@@ -1,0 +1,80 @@
+{
+    "spec_version": "v1.4",
+    "comment": "return vref when .version file is valid",
+    "identifier": "KSPInterstellarExtended",
+    "name": "KSP Interstellar Extended",
+    "abstract": "KSP Interstellar Extended (KSPI-E) is a plugin for Kerbal Space Program, designed to encourage bootstrapping toward ever more advanced levels of technology as well as utilizing In-Situ resources to expand the reach of Kerbal civilization. KSP Interstellar Extended aims to continue in Fractals original KSPI vision in providing a realistic road to the stars. Note: requires CTT 3.0.1",
+    "author": "FreeThinker",
+    "license": "GPL-3.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/155255-12213-kspi-extended",
+        "spacedock": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended",
+        "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/KSP_Interstellar_Extended/KSP_Interstellar_Extended-1470128568.7429862.png"
+    },
+    "version": "1.15.4",
+    "ksp_version": "1.3.0",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "2.6.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.3"
+        },
+        {
+            "name": "ModuleManager",
+            "min_version": "2.8.0"
+        },
+        {
+            "name": "CommunityTechTree",
+            "min_version": "1:3.1.0"
+        },
+        {
+            "name": "UniversalStorage",
+            "min_version": "1.2.2"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "InterstellarFuelSwitch",
+            "min_version": "2.6.1"
+        },
+        {
+            "name": "FilterExtensions",
+            "min_version": "3.0.0"
+        },
+        {
+            "name": "HideEmptyTechNodes",
+            "min_version": "0.8.0"
+        },
+        {
+            "name": "KerbalJointReinforcement"
+        },
+        {
+            "name": "UniversalStorage"
+        },
+        {
+            "name": "PersistentRotation"
+        }
+    ],
+    "install": [
+        {
+            "find": "GameData/WarpPlugin",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.15.4",
+    "download_size": 117676552,
+    "download_hash": {
+        "sha1": "905C0AE637A66C2DF1520849FA45A5F212457A8F",
+        "sha256": "A7601FFEE0EB993826D13C23507845AB44D5811C3380DF8597665D709D4A718E"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
KSPInterstellarExtended 1.15.3 was removed from SpaceDock and effectively replaced by 1.15.4 as the latest release for KSP 1.3.0. However, the CKAN index still has 1.15.3, so users get failed download messages even with an up to date registry as per KSP-CKAN/CKAN#2196. This pull request adds 1.15.4.