### PR TITLE
Restore 1.5.3 versions of GPP side mods

### DIFF
--- a/GPPCloudsHighRes/GPPCloudsHighRes-1.5.3.ckan
+++ b/GPPCloudsHighRes/GPPCloudsHighRes-1.5.3.ckan
@@ -31,11 +31,11 @@
             "comment": "This installs the high resolution clouds configs for GPP"
         }
     ],
-    "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.5.88/Galileos.Planet.Pack.1.5.88.zip",
-    "download_size": 306975218,
+    "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.5.3/Galileos.Planet.Pack.1.5.3.zip",
+    "download_size": 253142370,
     "download_hash": {
-        "sha1": "07FECC18837A9FCD9925F909F7980EB4648B8BB5",
-        "sha256": "EF33521C943EB300DDA1FBE1A0C172D61158F06BDC6E935FF9B94C0A4C199E91"
+        "sha1": "4A5C84463BB80CB6FFF751E35CFF70D7FAE4E38B",
+        "sha256": "D652DD5F0BEE73B8F38C5940E9915270C4B8E53ABDEF770A4E2331B3039A8FC1"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/GPPCloudsLowRes/GPPCloudsLowRes-1.5.3.ckan
+++ b/GPPCloudsLowRes/GPPCloudsLowRes-1.5.3.ckan
@@ -31,11 +31,11 @@
             "comment": "This installs the low resolution clouds configs for GPP"
         }
     ],
-    "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.5.88/Galileos.Planet.Pack.1.5.88.zip",
-    "download_size": 306975218,
+    "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.5.3/Galileos.Planet.Pack.1.5.3.zip",
+    "download_size": 253142370,
     "download_hash": {
-        "sha1": "07FECC18837A9FCD9925F909F7980EB4648B8BB5",
-        "sha256": "EF33521C943EB300DDA1FBE1A0C172D61158F06BDC6E935FF9B94C0A4C199E91"
+        "sha1": "4A5C84463BB80CB6FFF751E35CFF70D7FAE4E38B",
+        "sha256": "D652DD5F0BEE73B8F38C5940E9915270C4B8E53ABDEF770A4E2331B3039A8FC1"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/GPPSecondary/GPPSecondary-1.5.3.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.3.ckan
@@ -18,11 +18,11 @@
             "comment": "This installs the GPP_Secondary configs for GPP"
         }
     ],
-    "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.5.88/Galileos.Planet.Pack.1.5.88.zip",
-    "download_size": 306975218,
+    "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.5.3/Galileos.Planet.Pack.1.5.3.zip",
+    "download_size": 253142370,
     "download_hash": {
-        "sha1": "07FECC18837A9FCD9925F909F7980EB4648B8BB5",
-        "sha256": "EF33521C943EB300DDA1FBE1A0C172D61158F06BDC6E935FF9B94C0A4C199E91"
+        "sha1": "4A5C84463BB80CB6FFF751E35CFF70D7FAE4E38B",
+        "sha256": "D652DD5F0BEE73B8F38C5940E9915270C4B8E53ABDEF770A4E2331B3039A8FC1"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
These mods were installing version 1.5.88 while CKAN said 1.5.3.

This pull request restores the actual 1.5.3 versions from the previous commits.