### PR TITLE
Fix NewTantaresLV versions

### DIFF
--- a/NewTantaresLV/NewTantaresLV-v4.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-v4.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/Tantares/TantaresLV"
     },
     "version": "v4.0",
-    "ksp_version": "1.2.2",
+    "ksp_version": "1.3.0",
     "recommends": [
         {
             "name": "NewTantares"

--- a/NewTantaresLV/NewTantaresLV-v5.1.ckan
+++ b/NewTantaresLV/NewTantaresLV-v5.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/Tantares/TantaresLV"
     },
     "version": "v5.1",
-    "ksp_version": "1.2.2",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "NewTantares"


### PR DESCRIPTION
This mod supported KSP 1.3 in its 4.0 version and KSP 1.3.1 in 5.0 and 5.1:

https://github.com/Tantares/TantaresLV/releases

The netkan is updated in https://github.com/KSP-CKAN/NetKAN/pull/6095 to fix the latest version, and this pull request handles the older versions.