### PR TITLE
Point old ASET downloads to archive.org

### DIFF
--- a/ASETAvionics/ASETAvionics-1.0.ckan
+++ b/ASETAvionics/ASETAvionics-1.0.ckan
@@ -6,7 +6,7 @@
     "author": "alexustas",
     "license": "CC-BY-NC-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/116479-/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/116479-*"
     },
     "version": "1.0",
     "ksp_version_min": "1.0.4",
@@ -26,7 +26,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://www.dropbox.com/s/6kma0xo8xx1g9g2/ASET_Avionics-1.0.zip?dl=1",
+    "download": "https://archive.org/download/ASETAvionics-1.0/7B7284A1-ASETAvionics-1.0.zip",
     "download_size": 2641182,
     "download_hash": {
         "sha1": "7B7284A19C064BCCC4A793E82A55AD68A35197DF",

--- a/ASETProps/ASETProps-1.3.ckan
+++ b/ASETProps/ASETProps-1.3.ckan
@@ -6,7 +6,7 @@
     "author": "alexustas",
     "license": "CC-BY-NC-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/116430-/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/116430-*"
     },
     "version": "1.3",
     "ksp_version_min": "1.0.4",
@@ -24,7 +24,7 @@
             "filter": "Source"
         }
     ],
-    "download": "https://www.dropbox.com/s/jsduxb9tdifdefj/ASET_Props-1.3.zip?dl=1",
+    "download": "https://archive.org/download/ASETProps-1.3/FCF9618A-ASETProps-1.3.zip",
     "download_size": 9871158,
     "download_hash": {
         "sha1": "FCF9618A1DA9CA5F51AE5EAF1FE67D4C8A1985D4",

--- a/Astrogator/Astrogator-v0.1.1.ckan
+++ b/Astrogator/Astrogator-v0.1.1.ckan
@@ -12,7 +12,7 @@
     },
     "version": "v0.1.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "download": "https://github.com/HebaruSan/Astrogator/releases/download/v0.1.1/Astrogator.zip",
     "download_size": 75930,
     "download_hash": {

--- a/Astrogator/Astrogator-v0.2.0.ckan
+++ b/Astrogator/Astrogator-v0.2.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.2.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.3.0.ckan
+++ b/Astrogator/Astrogator-v0.3.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.3.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.3.1.ckan
+++ b/Astrogator/Astrogator-v0.3.1.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.3.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.4.0.ckan
+++ b/Astrogator/Astrogator-v0.4.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.4.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.5.0.ckan
+++ b/Astrogator/Astrogator-v0.5.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.5.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.5.1.ckan
+++ b/Astrogator/Astrogator-v0.5.1.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.5.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "suggests": [
         {
             "name": "GravityTurn"

--- a/Astrogator/Astrogator-v0.5.2.ckan
+++ b/Astrogator/Astrogator-v0.5.2.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.5.2",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "depends": [
         {
             "name": "ModuleManager"

--- a/Astrogator/Astrogator-v0.6.0.ckan
+++ b/Astrogator/Astrogator-v0.6.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.6.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "depends": [
         {
             "name": "ModuleManager"

--- a/Astrogator/Astrogator-v0.6.1.ckan
+++ b/Astrogator/Astrogator-v0.6.1.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.6.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "depends": [
         {
             "name": "ModuleManager"

--- a/Astrogator/Astrogator-v0.6.2.ckan
+++ b/Astrogator/Astrogator-v0.6.2.ckan
@@ -15,7 +15,7 @@
     },
     "version": "v0.6.2",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.99",
+    "ksp_version_max": "1.2.8",
     "depends": [
         {
             "name": "ModuleManager"


### PR DESCRIPTION
ASETAvionics 1.0 and ASETProps 1.3 were using dropbox links that are now broken, but they're still on archive.org. Also their homepage URLs weren't valid, even though the forum threads didn't move.

Fixes KSP-CKAN/NetKAN#6114.