### PR TITLE
Get SamBelanger mods from archive.org

### DIFF
--- a/DoubleDouble/DoubleDouble-1.0.ckan
+++ b/DoubleDouble/DoubleDouble-1.0.ckan
@@ -43,7 +43,7 @@
             "install_to": "GameData/SamBelanger"
         }
     ],
-    "download": "https://spacedock.info/mod/1553/DoubleDouble/download/1.0",
+    "download": "https://archive.org/download/DoubleDouble-1.0/6690B3DE-DoubleDouble-1.0.zip",
     "download_size": 955054463,
     "download_hash": {
         "sha1": "6690B3DEE67EC4AA0DEDACB28DB3A838F680CAEE",

--- a/DoubleDouble/DoubleDouble-v1.1.ckan
+++ b/DoubleDouble/DoubleDouble-v1.1.ckan
@@ -46,7 +46,7 @@
             "install_to": "GameData/SamBelanger"
         }
     ],
-    "download": "https://spacedock.info/mod/1553/DoubleDouble/download/v1.1",
+    "download": "https://archive.org/download/DoubleDouble-v1.1/039E482F-DoubleDouble-v1.1.zip",
     "download_size": 976730308,
     "download_hash": {
         "sha1": "039E482F447FA9C60B99F24D26119210A9BCA35F",

--- a/SamBelangerFlags/SamBelangerFlags-1-v1.0.ckan
+++ b/SamBelangerFlags/SamBelangerFlags-1-v1.0.ckan
@@ -19,7 +19,7 @@
             "install_to": "GameData/SamBelanger"
         }
     ],
-    "download": "https://github.com/SamBelanger/SamBelangerFlags/releases/download/v1.0/SamBelangerFlags.zip",
+    "download": "https://archive.org/download/SamBelangerFlags-1-v1.0/1BF2F9DF-SamBelangerFlags-1-v1.0.zip",
     "download_size": 10137,
     "download_hash": {
         "sha1": "1BF2F9DFB26FF96887DAB3CA4F6672CEEE68A513",

--- a/SamBelangerFlags/SamBelangerFlags-1.4.9.1.ckan
+++ b/SamBelangerFlags/SamBelangerFlags-1.4.9.1.ckan
@@ -22,7 +22,7 @@
             "install_to": "GameData/SamBelanger"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2480/493/OptionalAtms.V1.4.9.1.zip",
+    "download": "https://archive.org/download/SamBelangerFlags-1.4.9.1/4CCA7451-SamBelangerFlags-1.4.9.1.zip",
     "download_size": 96568,
     "download_hash": {
         "sha1": "4CCA7451D746ED2679C7FD36C853D13A65280325",


### PR DESCRIPTION
These mods have been removed from GitHub and SpaceDock.
This pull request updates them to download from the archive.org locations.