### PR TITLE
Add conflict

### DIFF
--- a/KerbalEnvironmentalEffectsStudy/KerbalEnvironmentalEffectsStudy-0.7b2.ckan
+++ b/KerbalEnvironmentalEffectsStudy/KerbalEnvironmentalEffectsStudy-0.7b2.ckan
@@ -16,25 +16,17 @@
     "version": "0.7b2",
     "ksp_version_min": "1.3.0",
     "ksp_version_max": "1.3.99",
+    "conflicts": [
+        { "name": "NehemiahInc-Complete" }
+    ],
     "depends": [
-        {
-            "name": "KIS"
-        },
-        {
-            "name": "NehemiahScienceCommon",
-            "min_version": "1:0.7b2"
-        }
+        { "name": "KIS" },
+        { "name": "NehemiahScienceCommon", "min_version": "1:0.7b2" }
     ],
     "recommends": [
-        {
-            "name": "Corvus125mTwoKerbalPod"
-        },
-        {
-            "name": "K2CommandPodCont"
-        },
-        {
-            "name": "UniversalStorage"
-        }
+        { "name": "Corvus125mTwoKerbalPod" },
+        { "name": "K2CommandPodCont" },
+        { "name": "UniversalStorage" }
     ],
     "install": [
         {


### PR DESCRIPTION
KEES is part of NehemiahInc-Complete, but currently they're not marked as conflicting, so the user gets a file overwrite message. Now they explicitly conflict.

These mods were frozen and replaced by NehemiahEngineeringOrbitalScience in KSP-CKAN/NetKAN#6071.

Fixes KSP-CKAN/NetKAN#6186.