### PR TITLE
Missing commas in frozen CactEyeTelescopesContinued files

### DIFF
--- a/CactEyeTelescopesContinued/CactEyeTelescopesContinued-0.6.10.frozen
+++ b/CactEyeTelescopesContinued/CactEyeTelescopesContinued-0.6.10.frozen
@@ -1,5 +1,5 @@
 {
-    "comment": "GitHub Repo has been deleted or made private"
+    "comment": "GitHub Repo has been deleted or made private",
     "spec_version": "v1.4",
     "identifier": "CactEyeTelescopesContinued",
     "name": "CactEye Telescopes Continued",

--- a/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.10.frozen
+++ b/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.10.frozen
@@ -1,5 +1,5 @@
 {
-    "comment": "GitHub Repo has been deleted or made private"
+    "comment": "GitHub Repo has been deleted or made private",
     "spec_version": "v1.4",
     "identifier": "CactEyeTelescopesContinued",
     "name": "CactEye Telescopes Continued",

--- a/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.11.frozen
+++ b/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.11.frozen
@@ -1,5 +1,5 @@
 {
-    "comment": "GitHub Repo has been deleted or made private"
+    "comment": "GitHub Repo has been deleted or made private",
     "spec_version": "v1.4",
     "identifier": "CactEyeTelescopesContinued",
     "name": "CactEye Telescopes Continued",

--- a/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.8.frozen
+++ b/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.8.frozen
@@ -1,5 +1,5 @@
 {
-    "comment": "GitHub Repo has been deleted or made private"
+    "comment": "GitHub Repo has been deleted or made private",
     "spec_version": "v1.4",
     "identifier": "CactEyeTelescopesContinued",
     "name": "CactEye Telescopes Continued",

--- a/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v7.1.0.frozen
+++ b/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v7.1.0.frozen
@@ -1,5 +1,5 @@
 {
-    "comment": "GitHub Repo has been deleted or made private"
+    "comment": "GitHub Repo has been deleted or made private",
     "spec_version": "v1.4",
     "identifier": "CactEyeTelescopesContinued",
     "name": "CactEye Telescopes Continued",


### PR DESCRIPTION
This mod was frozen in #1198 and comments were added to the CKAN-meta files, but a comma was missing between the JSON properties. Now it's added.

Fixes KSP-CKAN/CKAN#2261.