### PR TITLE
Fix GPP hashes

### DIFF
--- a/GPP/GPP-1-1.6.1.1.ckan
+++ b/GPP/GPP-1-1.6.1.1.ckan
@@ -112,8 +112,8 @@
     "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.6.1.1/Galileos-Planet-Pack-1.6.1.1.zip",
     "download_size": 308789987,
     "download_hash": {
-        "sha1": "95BB6B4ECDCAC1B7F0A62E352AE0B5787720893D",
-        "sha256": "66AF7E65B0EAB598C97DCC222B8047DCD675F02D8DF614D01001C2D6D88920BB"
+        "sha1": "EF179B24AF5C10E000C6AD10D3511DF8919BB594",
+        "sha256": "CD52818899070F424B8935AEC2C40AD450F08C35EFEF342C187A58047E1AA2E8"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/GPP/GPP-1.6.1.1.ckan
+++ b/GPP/GPP-1.6.1.1.ckan
@@ -112,8 +112,8 @@
     "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.6.1.1/Galileos-Planet-Pack-1.6.1.1.zip",
     "download_size": 308789987,
     "download_hash": {
-        "sha1": "95BB6B4ECDCAC1B7F0A62E352AE0B5787720893D",
-        "sha256": "66AF7E65B0EAB598C97DCC222B8047DCD675F02D8DF614D01001C2D6D88920BB"
+        "sha1": "EF179B24AF5C10E000C6AD10D3511DF8919BB594",
+        "sha256": "CD52818899070F424B8935AEC2C40AD450F08C35EFEF342C187A58047E1AA2E8"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/GPPCloudsHighRes/GPPCloudsHighRes-1.6.1.1.ckan
+++ b/GPPCloudsHighRes/GPPCloudsHighRes-1.6.1.1.ckan
@@ -34,8 +34,8 @@
     "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.6.1.1/Galileos-Planet-Pack-1.6.1.1.zip",
     "download_size": 308789987,
     "download_hash": {
-        "sha1": "95BB6B4ECDCAC1B7F0A62E352AE0B5787720893D",
-        "sha256": "66AF7E65B0EAB598C97DCC222B8047DCD675F02D8DF614D01001C2D6D88920BB"
+        "sha1": "EF179B24AF5C10E000C6AD10D3511DF8919BB594",
+        "sha256": "CD52818899070F424B8935AEC2C40AD450F08C35EFEF342C187A58047E1AA2E8"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/GPPCloudsLowRes/GPPCloudsLowRes-1.6.1.1.ckan
+++ b/GPPCloudsLowRes/GPPCloudsLowRes-1.6.1.1.ckan
@@ -34,8 +34,8 @@
     "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.6.1.1/Galileos-Planet-Pack-1.6.1.1.zip",
     "download_size": 308789987,
     "download_hash": {
-        "sha1": "95BB6B4ECDCAC1B7F0A62E352AE0B5787720893D",
-        "sha256": "66AF7E65B0EAB598C97DCC222B8047DCD675F02D8DF614D01001C2D6D88920BB"
+        "sha1": "EF179B24AF5C10E000C6AD10D3511DF8919BB594",
+        "sha256": "CD52818899070F424B8935AEC2C40AD450F08C35EFEF342C187A58047E1AA2E8"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/GPPSecondary/GPPSecondary-1.6.1.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.1.1.ckan
@@ -21,8 +21,8 @@
     "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.6.1.1/Galileos-Planet-Pack-1.6.1.1.zip",
     "download_size": 308789987,
     "download_hash": {
-        "sha1": "95BB6B4ECDCAC1B7F0A62E352AE0B5787720893D",
-        "sha256": "66AF7E65B0EAB598C97DCC222B8047DCD675F02D8DF614D01001C2D6D88920BB"
+        "sha1": "EF179B24AF5C10E000C6AD10D3511DF8919BB594",
+        "sha256": "CD52818899070F424B8935AEC2C40AD450F08C35EFEF342C187A58047E1AA2E8"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
GPP updated and had to re-upload, and the netkan bot is stuck on the original file.

This PR sets the hashes to match the new download. The bot will blow these changes away when it runs, but we can re-apply them after that. This will allow people to update GPP while we figure out the bot stuff.