### PR TITLE
Set game version to 1.3 for ThroughTheEyes 2.0.0.2

### DIFF
--- a/ThroughTheEyesOfaKerbal/ThroughTheEyesOfaKerbal-2.0.0.2.ckan
+++ b/ThroughTheEyesOfaKerbal/ThroughTheEyesOfaKerbal-2.0.0.2.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/Virindi-AC/Through-The-Eyes"
     },
     "version": "2.0.0.2",
+    "ksp_version": "1.3",
     "install": [
         {
             "find": "ThroughTheEyes",


### PR DESCRIPTION
KSP 1.4 has wiped the slate clean; with an unupdated registry, all you can see are mods that are compatible with all versions.

This mod jumped out at me because the Max KSP Version column shows as 1.3.1, but it still shows up to install with 1.4. Turns out one of the older versions has no version specified. I checked the release announcement for that version, and it says it's for 1.3, so this pull request sets it to that version.

