### PR TITLE
Update hashes for DRE for KSP 1.3.0

### DIFF
--- a/DeadlyReentry/DeadlyReentry-v7.6.1.ckan
+++ b/DeadlyReentry/DeadlyReentry-v7.6.1.ckan
@@ -24,10 +24,10 @@
         }
     ],
     "download": "https://github.com/Starwaster/DeadlyReentry/releases/download/v7.6.1/DeadlyReentry_7.6.1.zip",
-    "download_size": 844922,
+    "download_size": 844924,
     "download_hash": {
-        "sha1": "18E08DEBD9080A2E9572234076E660184D2E641F",
-        "sha256": "6FE2E20F5B38BB673F5C54504027EF4501074099462472992DFFDA796771F8C4"
+        "sha1": "96E83F5E117D4954A9CFE5AB2CD2B2D9C6FDB0F2",
+        "sha256": "BB7353BE4E235D10A322D22EFF570435BC6201D879DA8EA6BCBFDD2492C3847A"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
An old release of DeadlyReentry seems to have been updated in-place as we try to handle now in KSP-CKAN/CKAN#2337, but that method only fixes the issue when it happens to the most recent release, since netkan only checks the most recent release.

This pull request updates the download size and hashes to match the current download.

Fixes https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1240-bruce/&do=findComment&comment=3317213