### PR TITLE
Change KerbalXMod compatibility as per forum PM

### DIFF
--- a/KerbalXMod/KerbalXMod-0.1.2.ckan
+++ b/KerbalXMod/KerbalXMod-0.1.2.ckan
@@ -12,6 +12,7 @@
     },
     "version": "0.1.2",
     "ksp_version_min": "1.0",
+    "ksp_version_max": "1.3.1",
     "install": [
         {
             "file": "KerbalX",

--- a/KerbalXMod/KerbalXMod-0.1.3.ckan
+++ b/KerbalXMod/KerbalXMod-0.1.3.ckan
@@ -11,7 +11,8 @@
         "bugtracker": "https://github.com/Sujimichi/KerbalXMod/issues"
     },
     "version": "0.1.3",
-    "ksp_version_min": "1.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.3.1",
     "install": [
         {
             "file": "KerbalX",


### PR DESCRIPTION
>katateochi  2,892
>Started conversation: Saturday at 10:09 PM
>
>Hey Politas!
>
>Wondering if you could sort something out for me. I've updated the KerbalX mod to work with KSP 1.4.0, but that version is incompatible with KSP 1.3.x. But I've just heard from someone that CKAN updated the KXmod in their 1.3.1 install to the latest version. 
>
>Can you make it so that the 0.1.4 version of the mod is only for KSP 1.4.0, and any older versions of KSP should stick with the 0.1.3 version of the mod?
>KSP <= 1.3.1 - https://github.com/Sujimichi/KerbalXMod/releases/tag/0.1.3
>KSP == 1.4.0 - https://github.com/Sujimichi/KerbalXMod/releases/tag/0.1.4
>
>Thanks! 
>
>Kat