### PR TITLE
Limit ShowFPS to game version 1.1

### DIFF
--- a/ShowFPS/ShowFPS-v1.1.ckan
+++ b/ShowFPS/ShowFPS-v1.1.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://www.curse.com/ksp-mods/kerbal/220663-showfps"
     },
     "version": "v1.1",
-    "ksp_version_min": "1.1",
+    "ksp_version": "1.1",
     "install": [
         {
             "file": "ShowFPS",


### PR DESCRIPTION
This mod has not been updated in a long time, and it's marked as compatible with KSP 1.1 and later even though there's a comment on its Curse page saying it doesn't work with 1.2.0.

Now it's 1.1-only.

Fixes https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1240-bruce/&do=findComment&comment=3325096