### PR TITLE
Update GravityTurnContinued-2-1.7.7.ckan

### DIFF
--- a/GravityTurnContinued/GravityTurnContinued-2-1.7.7.ckan
+++ b/GravityTurnContinued/GravityTurnContinued-2-1.7.7.ckan
@@ -13,7 +13,7 @@
         "repository": "https://github.com/AndyMt/GravityTurn/"
     },
     "version": "2:1.7.7",
-    "ksp_version": "1.3",
+    "ksp_version": "1.4",
     "conflicts": [
         {
             "name": "GravityTurn"


### PR DESCRIPTION
Update for KSP version 1.4.x

Actually the minimum version is 1.4, too.