### PR TITLE
Fix game versions for old LaserDist releases

### DIFF
--- a/LaserDist/LaserDist-v0.9.1.ckan
+++ b/LaserDist/LaserDist-v0.9.1.ckan
@@ -11,7 +11,7 @@
     },
     "version": "v0.9.1",
     "ksp_version_min": "1.1.0",
-    "ksp_version_max": "99.99.99",
+    "ksp_version_max": "1.1.2",
     "suggests": [
         {
             "name": "kOS",

--- a/LaserDist/LaserDist-v0.9.2.ckan
+++ b/LaserDist/LaserDist-v0.9.2.ckan
@@ -11,7 +11,7 @@
     },
     "version": "v0.9.2",
     "ksp_version_min": "1.1.0",
-    "ksp_version_max": "99.99.99",
+    "ksp_version_max": "1.1.2",
     "suggests": [
         {
             "name": "kOS",

--- a/LaserDist/LaserDist-v0.9.3.ckan
+++ b/LaserDist/LaserDist-v0.9.3.ckan
@@ -9,8 +9,8 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141697-laserdist-a-distance-measuring-laser-part-for-kos/",
         "repository": "https://github.com/Dunbaratu/LaserDist"
     },
-    "version": "v1.0.0",
-    "ksp_version": "1.2.2",
+    "version": "v0.9.3",
+    "ksp_version": "1.2.1",
     "suggests": [
         {
             "name": "kOS",
@@ -18,11 +18,11 @@
             "comment": "LaserDist was intended to give distance data to kOS scripts."
         }
     ],
-    "download": "https://github.com/Dunbaratu/LaserDist/releases/download/v1.0.0/LaserDist.zip",
-    "download_size": 104034,
+    "download": "https://github.com/Dunbaratu/LaserDist/files/634581/LaserDist.zip",
+    "download_size": 103537,
     "download_hash": {
-        "sha1": "F564DFB2D8C1735D84ADD84B7CE644CCA181A4A7",
-        "sha256": "C5423E43FD8C1C681F515E0AE851912A0EF45AA5605754AF2BC3A81515477BFC"
+        "sha1": "31A7A8AD00F5A4172FBF3CF589113E4FC3870F07",
+        "sha256": "61993130E9080B0080EA292C4BF82EB29EC777D716AB4E03E784F06A35952DEF"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/LaserDist/LaserDist-v0.9.4.ckan
+++ b/LaserDist/LaserDist-v0.9.4.ckan
@@ -10,8 +10,7 @@
         "repository": "https://github.com/Dunbaratu/LaserDist"
     },
     "version": "v0.9.4",
-    "ksp_version_min": "1.1.0",
-    "ksp_version_max": "99.99.99",
+    "ksp_version": "1.2.2",
     "suggests": [
         {
             "name": "kOS",


### PR DESCRIPTION
This mod is marked as compatible with KSP 1.1.0–99.99.99, but that doesn't appear to be accurate. The forum thread regularly features reports of crashes after new game versions are released, followed by new recompiled releases (e.g., the latest release is entitled, "Recompile for KSP 1.3").

This pull request updates the metadata for the old versions to reflect their apparent actual compatibility based on the descriptions in the release listing of the GitHub repo. It also adds an old version, v0.9.3, which was skipped because the download was done via a hyperlink in the description rather than a proper asset.

This will help users of KSP-AVC, CKAN, and any other tools that parse .version files to avoid installing incompatible mod versions.

Current release to be fixed by Dunbaratu/LaserDist#23.