### PR TITLE
RN fix my mods that are set for all ksp versions

### DIFF
--- a/AntaresCygnus/AntaresCygnus-1-v1.3.ckan
+++ b/AntaresCygnus/AntaresCygnus-1-v1.3.ckan
@@ -14,6 +14,8 @@
         "repository": "https://github.com/KSP-RO/Antares-Cygnus"
     },
     "version": "1:v1.3",
+    "ksp_version_min": "1.1.1",
+    "ksp_version_max": "1.3.99",
     "install": [
         {
             "find": "KK_Antares",

--- a/RN-MiscParts/RN-MiscParts-1-v1.2.ckan
+++ b/RN-MiscParts/RN-MiscParts-1-v1.2.ckan
@@ -10,6 +10,8 @@
         "repository": "https://github.com/KSP-RO/RNMisc"
     },
     "version": "1:v1.2",
+    "ksp_version_min": "1.2.0",
+    "ksp_version_max": "1.3.99",
     "depends": [
         {
             "name": "BDAnimationModules"

--- a/RN-SPP/RN-SPP-1-v1.4.ckan
+++ b/RN-SPP/RN-SPP-1-v1.4.ckan
@@ -10,6 +10,8 @@
         "repository": "https://github.com/KSP-RO/USSovietSolarPanelsPack"
     },
     "version": "1:v1.4",
+    "ksp_version_min": "1.1.1",
+    "ksp_version_max": "1.3.99",
     "install": [
         {
             "find": "RN_Solar_Panels",


### PR DESCRIPTION
Somehow these 3 releases gt set for "all ksp versions", this is
extremely incorrect as they absolutely do NOT work in all versions. This
is making ckan install the older releases in 1.4.2 even though the
latest release only supports up to 1.3.1.

-These mods DID contain version files when these meta data files were
generated and for some reason ignored my versioning in them