### PR TITLE
Update Kerbalism-1.4.1.4.ckan

### DIFF
--- a/Kerbalism/Kerbalism-1.4.1.4.ckan
+++ b/Kerbalism/Kerbalism-1.4.1.4.ckan
@@ -75,10 +75,10 @@
         }
     ],
     "download": "https://spacedock.info/mod/1774/Kerbalism/download/1.4.1.4",
-    "download_size": 3728673,
+    "download_size": 3728336,
     "download_hash": {
-        "sha1": "90578BD9B9ED48858119DFFAD576040302EF10C6",
-        "sha256": "95934F6CC10526574042E733AF1AC81FA263DDAAD669913A15E300CBC81D056C"
+        "sha1": "694B0982ADB38402B3325E274611F5AD15224970",
+        "sha256": "760B2A439EABE90498F0C25C0F588BEE90BA76A2F5C8F85A7EB72C64222BFE04"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
For some reason this metadata is incorrect. I have inflated this version locally using the latest NetKAN and it works for me while the one currently in CKAN-meta does not. I'm not sure how we fix these things anymore so I'm creating this PR in hopes of someone more knowledgable telling me whether this is the correct way or not. If netkan-bot overwrites this on the next run and puts back the incorrect values I guess we'll need to take another look.