### PR TITLE
Add old CraftManger version

### DIFF
--- a/CraftManager/CraftManager-1.0.1.ckan
+++ b/CraftManager/CraftManager-1.0.1.ckan
@@ -1,0 +1,22 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "CraftManager",
+    "name": "Craft Manager",
+    "abstract": "Craft Manager is a replacement for the stock craft list in the editors that adds a bunch features the stock list lacks and opens much faster.\nSearch, Sort and Organize your craft, view and load craft from any save, move/copy them between saves, transfer them between editors, load your subassemblies in the same interface.\nCraft can be tagged with custom tags which you can manually assign. Tags can also be given a rule so they also auto associate with craft.",
+    "author": "Sujimichi",
+    "license": "CC-BY-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/174596-*",
+        "repository": "https://github.com/Sujimichi/CraftManager"
+    },
+    "version": "1.0.1",
+    "ksp_version": "1.3",
+    "download": "https://github.com/Sujimichi/CraftManager/releases/download/1.0.1/CraftManager.zip",
+    "download_size": 272495,
+    "download_hash": {
+        "sha1": "E67648917FF0A393F5D0DF0975D318AFF781AF4D",
+        "sha256": "8DF08AF3C1AB3BAAB4E1E6197AF6BE7E6F013C1B83C8576CDC2D1F7BA15A7CEE"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
CraftManager has two release streams; 1.0.X is for KSP 1.3, and 1.1.X is for KSP 1.4.

KSP-CKAN/NetKAN#6528 added the current 1.1.X stream with an override for the 1.0.X stream.

This pull request adds the most recent 1.0.X version.

Closes Sujimichi/CraftManager#2.