### PR TITLE
Add CraftManager 1.0.2

### DIFF
--- a/CraftManager/CraftManager-1.0.2.ckan
+++ b/CraftManager/CraftManager-1.0.2.ckan
@@ -1,0 +1,22 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "CraftManager",
+    "name": "Craft Manager",
+    "abstract": "Craft Manager is a replacement for the stock craft list in the editors that adds a bunch features the stock list lacks and opens much faster.\nSearch, Sort and Organize your craft, view and load craft from any save, move/copy them between saves, transfer them between editors, load your subassemblies in the same interface.\nCraft can be tagged with custom tags which you can manually assign. Tags can also be given a rule so they also auto associate with craft.",
+    "author": "Katateochi",
+    "license": "CC-BY-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/174596-*",
+        "repository": "https://github.com/Sujimichi/CraftManager"
+    },
+    "version": "1.0.2",
+    "ksp_version": "1.3",
+    "download": "https://github.com/Sujimichi/CraftManager/releases/download/1.0.2/CraftManager.zip",
+    "download_size": 273937,
+    "download_hash": {
+        "sha1": "C94ED90646D700AC389DC4F20302871317B343F7",
+        "sha256": "6F60EBE43C6CB968800E7FAFAC80F7AA3F606168E42A12CCC84590A5285B5C6A"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
CraftManager 1.0.2 and 1.1.2 were uploaded in the same pass of the bot, so only 1.1.2 got indexed.
This pull request adds 1.0.2.