### PR TITLE
Add skipped KerbalKonstructs release

### DIFF
--- a/KerbalKonstructs/KerbalKonstructs-1.3.9.12.ckan
+++ b/KerbalKonstructs/KerbalKonstructs-1.3.9.12.ckan
@@ -1,0 +1,45 @@
+{
+    "spec_version": "v1.4",
+    "comment": "Plugin is MIT, but Static Assets, Artwork & Models are ARR",
+    "identifier": "KerbalKonstructs",
+    "name": "Kerbal-Konstructs",
+    "abstract": "Kerbal Konstructs for KSP 1.2 and onwards",
+    "author": [
+        "AlphaAsh",
+        "ozraven",
+        "Ger_space"
+    ],
+    "license": "restricted",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151818-12x-kerbal-konstructs/",
+        "spacedock": "https://spacedock.info/mod/1052/Kerbal-Konstructs",
+        "repository": "https://github.com/GER-Space/Kerbal-Konstructs",
+        "x_screenshot": "https://spacedock.info/content/GER_Space_8909/Kerbal-Konstructs/Kerbal-Konstructs-1479250625.5826087.png"
+    },
+    "version": "1.3.9.12",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KKtoSD"
+        }
+    ],
+    "install": [
+        {
+            "find": "KerbalKonstructs",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/GER-Space/Kerbal-Konstructs/releases/download/1.3.9.12/Kerbal-Konstructs-1.3.9.12.zip",
+    "download_size": 3073004,
+    "download_hash": {
+        "sha1": "AF766C11BDD18D3D9EF7B3E1C868BC5BE676634C",
+        "sha256": "CC96DA7548B2E441B9ED8B894DB1B21E4C4F1E77F7E47C594549FDC26C35846C"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
This is one of those mods that puts out several releases at once for different versions, so the bot misses some of them.

Fixes KSP-CKAN/NetKAN#6574.