### PR TITLE
Fix old versions for ProceduralFairings

### DIFF
--- a/ProceduralFairings/ProceduralFairings-1.4.3.1.ckan
+++ b/ProceduralFairings/ProceduralFairings-1.4.3.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/rsparkyc/ProceduralFairings"
     },
     "version": "1.4.3.1",
-    "ksp_version": "1.3",
+    "ksp_version": "1.4.3",
     "suggests": [
         {
             "name": "PFTextures"

--- a/ProceduralFairings/ProceduralFairings-v5.0.ckan
+++ b/ProceduralFairings/ProceduralFairings-v5.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/rsparkyc/ProceduralFairings"
     },
     "version": "v5.0",
-    "ksp_version": "1.3",
+    "ksp_version": "1.4.3",
     "suggests": [
         {
             "name": "PFTextures"


### PR DESCRIPTION
Before ProceduralFairings had a version file, two of its releases for 1.4.3 were marked as compatible with 1.3. This pull request updates them.

Closes #1348, which was deleting one of these instead.