### PR TITLE
Fix version for SASAG 1.0.0.0

### DIFF
--- a/SASAG/SASAG-1.0.0.0.ckan
+++ b/SASAG/SASAG-1.0.0.0.ckan
@@ -5,6 +5,9 @@
     "abstract": "Control SAS functions with Action Groups",
     "author": "Xyphos",
     "license": "public-domain",
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "resources": {
         "homepage": "https://github.com/Xyphos/KSP_SASAG/wiki",
         "spacedock": "https://spacedock.info/mod/1380/SASAG",

--- a/SASAG/SASAG-1.0.0.0.ckan
+++ b/SASAG/SASAG-1.0.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/Xyphos/KSP_SASAG/"
     },
     "version": "1.0.0.0",
-    "ksp_version": "1.2.2",
+    "ksp_version": "1.4.2",
     "install": [
         {
             "find": "XyphosAerospace",


### PR DESCRIPTION
This version was incorrectly indexed for KSP 1.2.2, should be 1.4.2.