### PR TITLE
Remove extra period / dot / full stop from version

### DIFF
--- a/AnimatedAttachment/AnimatedAttachment-v1.2.2.ckan
+++ b/AnimatedAttachment/AnimatedAttachment-v1.2.2.ckan
@@ -10,7 +10,7 @@
     },
     "version": "v1.2.2",
     "ksp_version": "1.4.4",
-    "download": "https://github.com/KSPKatten/AnimatedAttachment/releases/download/v.1.2.2/AnimatedAttachment_v1.2.2.zip",
+    "download": "https://github.com/KSPKatten/AnimatedAttachment/releases/download/v1.2.2/AnimatedAttachment_v1.2.2.zip",
     "download_size": 13328,
     "download_hash": {
         "sha1": "E845C367D4C790222B4F5C6301F0A481FC32D4D7",

--- a/AnimatedAttachment/AnimatedAttachment-v1.2.2.ckan
+++ b/AnimatedAttachment/AnimatedAttachment-v1.2.2.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "repository": "https://github.com/KSPKatten/AnimatedAttachment"
     },
-    "version": "v.1.2.2",
+    "version": "v1.2.2",
     "ksp_version": "1.4.4",
     "download": "https://github.com/KSPKatten/AnimatedAttachment/releases/download/v.1.2.2/AnimatedAttachment_v1.2.2.zip",
     "download_size": 13328,


### PR DESCRIPTION
This version was entered incorrectly [as per the author](https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1251-broglio/&do=findComment&comment=3421531); it should start with `v1` instead of `v.1`.

This pull request renames the file and updates the version in the metadata.