### PR TITLE
Remove extra dot from DecoupleWithControl version

### DIFF
--- a/DecoupleWithControl/DecoupleWithControl-v1.2.1.ckan
+++ b/DecoupleWithControl/DecoupleWithControl-v1.2.1.ckan
@@ -9,7 +9,7 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/170148-131-decouple-with-control/",
         "repository": "https://github.com/cmheisel/ksp-decouple-with-control"
     },
-    "version": "v.1.2.1",
+    "version": "v1.2.1",
     "ksp_version_min": "1.3.1",
     "ksp_version_max": "1.4.99",
     "depends": [


### PR DESCRIPTION
This mod's 1.2.1 version was entered on GitHub as v.1.2.1. The dot after the 'v' is causing CKAN to consider it newer than later versions.

This pull request removes the extra dot.

Fixes KSP-CKAN/CKAN#2479.