### PR TITLE
Remove MiniAVC filters from old mod versions

### DIFF
--- a/AGroupOnStage/AGroupOnStage-2.0.10.ckan
+++ b/AGroupOnStage/AGroupOnStage-2.0.10.ckan
@@ -26,11 +26,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/AGroupOnStage/releases/download/2.0.10/AGroupOnStage2.0.10.zip",

--- a/AGroupOnStage/AGroupOnStage-2.0.11.ckan
+++ b/AGroupOnStage/AGroupOnStage-2.0.11.ckan
@@ -26,11 +26,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/AGroupOnStage/releases/download/2.0.11/AGroupOnStage2.0.11.zip",

--- a/AGroupOnStage/AGroupOnStage-2.0.7a.ckan
+++ b/AGroupOnStage/AGroupOnStage-2.0.7a.ckan
@@ -25,11 +25,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/AGroupOnStage/releases/download/2.0.7a/AGroupOnStage2.0.7.zip",

--- a/AGroupOnStage/AGroupOnStage-2.0.8.ckan
+++ b/AGroupOnStage/AGroupOnStage-2.0.8.ckan
@@ -25,11 +25,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/AGroupOnStage/releases/download/2.0.8/AGroupOnStage2.0.8.zip",

--- a/AGroupOnStage/AGroupOnStage-2.0.9.1.ckan
+++ b/AGroupOnStage/AGroupOnStage-2.0.9.1.ckan
@@ -26,11 +26,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/AGroupOnStage/releases/download/2.0.9.1/AGroupOnStage2.0.9.1.zip",

--- a/AGroupOnStage/AGroupOnStage-2.0.9.ckan
+++ b/AGroupOnStage/AGroupOnStage-2.0.9.ckan
@@ -25,11 +25,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/AGroupOnStage/releases/download/2.0.9.1/AGroupOnStage2.0.9.1.zip",

--- a/AnyRes/AnyRes-1.1.ckan
+++ b/AnyRes/AnyRes-1.1.ckan
@@ -17,8 +17,7 @@
             "file": "AnyRes",
             "install_to": "GameData",
             "filter": [
-                ".DS_Store",
-                "MiniAVC.xml"
+                ".DS_Store"
             ]
         }
     ],

--- a/CactEye2/CactEye2-BETA_5.2.ckan
+++ b/CactEye2/CactEye2-BETA_5.2.ckan
@@ -17,8 +17,7 @@
     "install": [
         {
             "find": "CactEye",
-            "install_to": "GameData",
-            "filter": "MiniAVC.dll"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/CactEye2-BETA_5.2/5D1BCE98-CactEye2-BETA_5.2.zip",

--- a/CactEyeTelescopesContinued/CactEyeTelescopesContinued-0.6.10.frozen
+++ b/CactEyeTelescopesContinued/CactEyeTelescopesContinued-0.6.10.frozen
@@ -20,8 +20,7 @@
     "install": [
         {
             "file": "CactEyeOptics/GameData/CactEye",
-            "install_to": "GameData",
-            "filter": "MiniAVC.dll"
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/Angel-125/CactEye-2/releases/download/0.6.10/CactEye_0_6_10.zip",

--- a/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.10.frozen
+++ b/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.10.frozen
@@ -21,8 +21,7 @@
     "install": [
         {
             "file": "CactEyeOptics/GameData/CactEye",
-            "install_to": "GameData",
-            "filter": "MiniAVC.dll"
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/Angel-125/CactEye-2/releases/download/0.6.10/CactEye_0_6_10.zip",

--- a/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.11.frozen
+++ b/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.11.frozen
@@ -20,8 +20,7 @@
     "install": [
         {
             "file": "CactEyeOptics/GameData/CactEye",
-            "install_to": "GameData",
-            "filter": "MiniAVC.dll"
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/Angel-125/CactEye-2/releases/download/v0.6.11/CactEye2_0_6_11.zip",

--- a/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.8.frozen
+++ b/CactEyeTelescopesContinued/CactEyeTelescopesContinued-v0.6.8.frozen
@@ -20,8 +20,7 @@
     "install": [
         {
             "file": "CactEyeOptics/GameData/CactEye",
-            "install_to": "GameData",
-            "filter": "MiniAVC.dll"
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/Angel-125/CactEye-2/releases/download/v0.6.8/CactEye2_0_6_8.zip",

--- a/ClampsBeGone/ClampsBeGone-1.0.0.ckan
+++ b/ClampsBeGone/ClampsBeGone-1.0.0.ckan
@@ -16,11 +16,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/ClampsBeGone/releases/download/1.0/ClampsBeGone1.0.zip",

--- a/ClampsBeGone/ClampsBeGone-1.1.0.ckan
+++ b/ClampsBeGone/ClampsBeGone-1.1.0.ckan
@@ -16,11 +16,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/ClampsBeGone/releases/download/1.1/ClampsBeGone1.1.zip",

--- a/ClampsBeGone/ClampsBeGone-1.1.1.ckan
+++ b/ClampsBeGone/ClampsBeGone-1.1.1.ckan
@@ -16,11 +16,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/ClampsBeGone/releases/download/1.1.1/ClampsBeGone1.1.1.zip",

--- a/ClampsBeGone/ClampsBeGone-1.1.2.ckan
+++ b/ClampsBeGone/ClampsBeGone-1.1.2.ckan
@@ -16,11 +16,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/ClampsBeGone/releases/download/1.1.2/ClampsBeGone1.1.2.zip",

--- a/ContractConfigurator-UsefulSpaceStations/ContractConfigurator-UsefulSpaceStations-1.0.0.ckan
+++ b/ContractConfigurator-UsefulSpaceStations/ContractConfigurator-UsefulSpaceStations-1.0.0.ckan
@@ -29,8 +29,7 @@
     "install": [
         {
             "find": "UsefulSpaceStations",
-            "install_to": "GameData/ContractPacks",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/ContractPacks"
         }
     ],
     "download": "https://github.com/severedsolo/UsefulSpaceStations/releases/download/1.0.1/UsefulSpaceStations1.0.1.zip",

--- a/ContractConfigurator-UsefulSpaceStations/ContractConfigurator-UsefulSpaceStations-1.0.1.ckan
+++ b/ContractConfigurator-UsefulSpaceStations/ContractConfigurator-UsefulSpaceStations-1.0.1.ckan
@@ -29,8 +29,7 @@
     "install": [
         {
             "find": "UsefulSpaceStations",
-            "install_to": "GameData/ContractPacks",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/ContractPacks"
         }
     ],
     "download": "https://github.com/severedsolo/UsefulSpaceStations/releases/download/1.0.1/UsefulSpaceStations1.0.1.zip",

--- a/ContractConfigurator-UsefulSpaceStations/ContractConfigurator-UsefulSpaceStations-1.0.2.ckan
+++ b/ContractConfigurator-UsefulSpaceStations/ContractConfigurator-UsefulSpaceStations-1.0.2.ckan
@@ -29,8 +29,7 @@
     "install": [
         {
             "find": "UsefulSpaceStations",
-            "install_to": "GameData/ContractPacks",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/ContractPacks"
         }
     ],
     "download": "https://github.com/severedsolo/UsefulSpaceStations/releases/download/1.0.2/UsefulSpaceStations1.0.2.zip",

--- a/ContractConfigurator-UsefulSpaceStations/ContractConfigurator-UsefulSpaceStations-1.1.ckan
+++ b/ContractConfigurator-UsefulSpaceStations/ContractConfigurator-UsefulSpaceStations-1.1.ckan
@@ -29,8 +29,7 @@
     "install": [
         {
             "find": "UsefulSpaceStations",
-            "install_to": "GameData/ContractPacks",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/ContractPacks"
         }
     ],
     "download": "https://github.com/severedsolo/UsefulSpaceStations/releases/download/1.1/UsefulSpaceStations1.1.zip",

--- a/EnduranceSpaceExplorationSystem/EnduranceSpaceExplorationSystem-V0.92.ckan
+++ b/EnduranceSpaceExplorationSystem/EnduranceSpaceExplorationSystem-V0.92.ckan
@@ -42,8 +42,7 @@
             "find": "Endurance",
             "install_to": "GameData",
             "filter": [
-                ".DS_Store",
-                "MiniAVC.xml"
+                ".DS_Store"
             ]
         }
     ],

--- a/InFlightFlagSwitcher/InFlightFlagSwitcher-1.0.0.ckan
+++ b/InFlightFlagSwitcher/InFlightFlagSwitcher-1.0.0.ckan
@@ -21,11 +21,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/InFlightFlagSwitcher/releases/download/1.0/InFlightFlagSwitcher1.0.zip",

--- a/InFlightFlagSwitcher/InFlightFlagSwitcher-1.0.1.ckan
+++ b/InFlightFlagSwitcher/InFlightFlagSwitcher-1.0.1.ckan
@@ -21,11 +21,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/InFlightFlagSwitcher/releases/download/1.0.1/InFlightFlagSwitcher1.0.1.zip",

--- a/InFlightFlagSwitcher/InFlightFlagSwitcher-1.0.ckan
+++ b/InFlightFlagSwitcher/InFlightFlagSwitcher-1.0.ckan
@@ -21,11 +21,7 @@
     "install": [
         {
             "find": "iPeer",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.dll",
-                "LICENSE-MiniAVC.txt"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/iPeer/InFlightFlagSwitcher/releases/download/1.0/InFlightFlagSwitcher1.0.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.10.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.10.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.10/04CA8AE7-InterstellarFuelSwitch-Core-1.10.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.11.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.11.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.11/2C0399F7-InterstellarFuelSwitch-Core-1.11.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.12.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.12.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.12/7FA7BC3E-InterstellarFuelSwitch-Core-1.12.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.14.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.14.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.14/F8C8F175-InterstellarFuelSwitch-Core-1.14.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.15.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.15.ckan
@@ -15,8 +15,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.15/9738065A-InterstellarFuelSwitch-Core-1.15.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.16.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.16.ckan
@@ -15,8 +15,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.16/B9D82C64-InterstellarFuelSwitch-Core-1.16.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.17.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.17.ckan
@@ -15,8 +15,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.17/255AF349-InterstellarFuelSwitch-Core-1.17.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.18.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.18.ckan
@@ -21,8 +21,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/1.18",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.2.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.2.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.2/43CAD10C-InterstellarFuelSwitch-Core-1.2.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.20.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.20.ckan
@@ -21,8 +21,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/1.20",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.21.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.21.ckan
@@ -21,8 +21,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/1.21",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.22.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.22.ckan
@@ -21,8 +21,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/1.22",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.23.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.23.ckan
@@ -21,8 +21,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/1.23",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.24.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.24.ckan
@@ -21,8 +21,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/1.24",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.25.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.25.ckan
@@ -21,8 +21,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/1.25",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.26.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.26.ckan
@@ -21,8 +21,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/1.26",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.27.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.27.ckan
@@ -21,8 +21,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/1.27",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.28.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.28.ckan
@@ -15,8 +15,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/1.28",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.29.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.29.ckan
@@ -15,8 +15,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/1.29",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.4.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.4.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.4/82C3649B-InterstellarFuelSwitch-Core-1.4.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.5.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.5.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.5/59274916-InterstellarFuelSwitch-Core-1.5.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.6.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.6.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.6/3B99E3D7-InterstellarFuelSwitch-Core-1.6.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.7.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.7.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.7/3D15DE87-InterstellarFuelSwitch-Core-1.7.zip",

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.8.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-1.8.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/InterstellarFuelSwitch/Plugins",
-            "install_to": "GameData/InterstellarFuelSwitch",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/InterstellarFuelSwitch"
         }
     ],
     "download": "https://archive.org/download/InterstellarFuelSwitch-Core-1.8/15876DF7-InterstellarFuelSwitch-Core-1.8.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.10.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.10.ckan
@@ -45,8 +45,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.10/B928FF14-KSPInterstellarExtended-1.1.10.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.11.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.11.ckan
@@ -45,8 +45,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.11/3A7EA489-KSPInterstellarExtended-1.1.11.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.12.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.12.ckan
@@ -46,8 +46,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.12/B13EAF2D-KSPInterstellarExtended-1.1.12.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.13.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.13.ckan
@@ -46,8 +46,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.13/B85CA6FA-KSPInterstellarExtended-1.1.13.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.14.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.14.ckan
@@ -46,8 +46,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.14/9AAC9AD7-KSPInterstellarExtended-1.1.14.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.15.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.15.ckan
@@ -46,8 +46,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.15/0988DAF7-KSPInterstellarExtended-1.1.15.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.16.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.16.ckan
@@ -49,8 +49,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.16/4D02586C-KSPInterstellarExtended-1.1.16.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.17.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.17.ckan
@@ -49,8 +49,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.17/E4CFD55B-KSPInterstellarExtended-1.1.17.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.18.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.18.ckan
@@ -49,8 +49,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.18/52B8EFE2-KSPInterstellarExtended-1.1.18.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.19.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.19.ckan
@@ -49,8 +49,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.19/A9D16ABC-KSPInterstellarExtended-1.1.19.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.20.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.20.ckan
@@ -49,8 +49,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.20/C02C36BE-KSPInterstellarExtended-1.1.20.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.21.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.21.ckan
@@ -50,8 +50,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.21/92F7B87B-KSPInterstellarExtended-1.1.21.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.1.9.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.1.9.ckan
@@ -45,8 +45,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.1.9/65E2CBB0-KSPInterstellarExtended-1.1.9.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.2.1.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.2.1.ckan
@@ -50,8 +50,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.2.1/220A0199-KSPInterstellarExtended-1.2.1.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.2.2.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.2.2.ckan
@@ -50,8 +50,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.2.2/BA28A602-KSPInterstellarExtended-1.2.2.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.2.3.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.2.3.ckan
@@ -50,8 +50,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.2.3/43DB5D61-KSPInterstellarExtended-1.2.3.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.2.4.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.2.4.ckan
@@ -50,8 +50,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.2.4/E4DAF45D-KSPInterstellarExtended-1.2.4.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.2.5.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.2.5.ckan
@@ -50,8 +50,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.2.5/1FA4A69E-KSPInterstellarExtended-1.2.5.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.2.6.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.2.6.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.2.6/8E9805C9-KSPInterstellarExtended-1.2.6.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.0.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.0.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.0/3ED899B5-KSPInterstellarExtended-1.3.0.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.1.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.1.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.1/EF362911-KSPInterstellarExtended-1.3.1.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.10.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.10.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.10/5204AA28-KSPInterstellarExtended-1.3.10.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.11.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.11.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.11/B061D6C7-KSPInterstellarExtended-1.3.11.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.12.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.12.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.12/D88E84BD-KSPInterstellarExtended-1.3.12.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.13.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.13.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.13/75615A02-KSPInterstellarExtended-1.3.13.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.14.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.14.ckan
@@ -55,8 +55,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.14/A9AED667-KSPInterstellarExtended-1.3.14.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.16.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.16.ckan
@@ -55,8 +55,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.16/DA227EB8-KSPInterstellarExtended-1.3.16.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.17.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.17.ckan
@@ -55,8 +55,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.17/F96BBFB3-KSPInterstellarExtended-1.3.17.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.2.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.2.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.2/B4A18B39-KSPInterstellarExtended-1.3.2.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.3.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.3.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.3/372F25A7-KSPInterstellarExtended-1.3.3.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.4.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.4.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.4/C23403E8-KSPInterstellarExtended-1.3.4.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.5.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.5.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.5/13F23531-KSPInterstellarExtended-1.3.5.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.6.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.6.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.6/7BA5D29C-KSPInterstellarExtended-1.3.6.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.7.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.7.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.7/BF2573F6-KSPInterstellarExtended-1.3.7.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.8.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.8.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.8/360AB7BF-KSPInterstellarExtended-1.3.8.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.3.9.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.3.9.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.3.9/72CDCBDC-KSPInterstellarExtended-1.3.9.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.0.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.0.ckan
@@ -55,8 +55,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.4.0/3D2AF379-KSPInterstellarExtended-1.4.0.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.10.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.10.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.4.10/B404FD65-KSPInterstellarExtended-1.4.10.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.11.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.11.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.4.11/C2C2B8AC-KSPInterstellarExtended-1.4.11.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.2.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.2.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.4.2/9A18332F-KSPInterstellarExtended-1.4.2.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.3.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.3.ckan
@@ -51,8 +51,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.4.3/67B69B06-KSPInterstellarExtended-1.4.3.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.4.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.4.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.4.4/D37537E7-KSPInterstellarExtended-1.4.4.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.5.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.5.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.4.5/2B2F874D-KSPInterstellarExtended-1.4.5.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.6.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.6.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.4.6/BE530AD6-KSPInterstellarExtended-1.4.6.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.7.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.7.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.4.7/828B527E-KSPInterstellarExtended-1.4.7.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.8.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.8.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.4.8/FE4971B4-KSPInterstellarExtended-1.4.8.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.4.9.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.4.9.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.4.9/541C0EAE-KSPInterstellarExtended-1.4.9.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.1.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.1.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.1/DB8D4D91-KSPInterstellarExtended-1.5.1.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.10.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.10.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.10/867903BC-KSPInterstellarExtended-1.5.10.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.11.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.11.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.11/CEEA170C-KSPInterstellarExtended-1.5.11.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.12.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.12.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.12/B2A4393E-KSPInterstellarExtended-1.5.12.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.13.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.13.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.13/D340DA3C-KSPInterstellarExtended-1.5.13.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.14.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.14.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.14/C549FC2E-KSPInterstellarExtended-1.5.14.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.15.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.15.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.15/B1D582A4-KSPInterstellarExtended-1.5.15.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.16.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.16.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.16/F3604AD8-KSPInterstellarExtended-1.5.16.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.2.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.2.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.2/3249C545-KSPInterstellarExtended-1.5.2.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.3.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.3.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.3/3D74C14F-KSPInterstellarExtended-1.5.3.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.4.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.4.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.4/BF071C4B-KSPInterstellarExtended-1.5.4.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.5.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.5.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.5/D2D109A1-KSPInterstellarExtended-1.5.5.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.6.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.6.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.6/71443656-KSPInterstellarExtended-1.5.6.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.7.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.7.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.7/0791AD02-KSPInterstellarExtended-1.5.7.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.8.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.8.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.8/9E859480-KSPInterstellarExtended-1.5.8.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.9.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.9.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5.9/CA57965D-KSPInterstellarExtended-1.5.9.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.5.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.5.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.5/9DAF6497-KSPInterstellarExtended-1.5.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.6.1.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.6.1.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.6.1/426D71DB-KSPInterstellarExtended-1.6.1.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.6.2.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.6.2.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.6.2/9498ECA8-KSPInterstellarExtended-1.6.2.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.6.3.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.6.3.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.6.3/CFC83258-KSPInterstellarExtended-1.6.3.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.6.4.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.6.4.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.6.4/9ED603BD-KSPInterstellarExtended-1.6.4.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.6.5.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.6.5.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.6.5/8D3A99A6-KSPInterstellarExtended-1.6.5.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.6.6.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.6.6.ckan
@@ -48,8 +48,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/KSPInterstellarExtended-1.6.6/97398B61-KSPInterstellarExtended-1.6.6.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.6.7.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.6.7.ckan
@@ -45,8 +45,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/sswelm/KSPInterstellar/releases/download/1.6.7/KSPI_Extended_1.6.7.zip",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.6.8.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.6.8.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.6.8",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.6.9.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.6.9.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.6.9",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.7.0.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.7.0.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.7.0",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.7.2.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.7.2.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "file": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.7.2",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.7.4.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.7.4.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.7.4",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.7.6.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.7.6.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.7.6",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.8.10.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.8.10.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.8.10",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.8.11.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.8.11.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.8.11",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.8.12.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.8.12.ckan
@@ -43,8 +43,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.8.12",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.8.14.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.8.14.ckan
@@ -43,8 +43,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.8.14",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.8.3.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.8.3.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.8.3",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.8.4.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.8.4.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.8.4",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.8.6.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.8.6.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.8.6",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.8.7.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.8.7.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.8.7",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.8.8.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.8.8.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.8.8",

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.8.9.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.8.9.ckan
@@ -47,8 +47,7 @@
     "install": [
         {
             "find": "GameData/WarpPlugin",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.8.9",

--- a/KustomKerbals/KustomKerbals-1.0.1.ckan
+++ b/KustomKerbals/KustomKerbals-1.0.1.ckan
@@ -19,8 +19,7 @@
             "file": "KustomKerbals",
             "install_to": "GameData",
             "filter": [
-                ".DS_Store",
-                "MiniAVC.xml"
+                ".DS_Store"
             ]
         }
     ],

--- a/KustomKerbals/KustomKerbals-1.0.2.ckan
+++ b/KustomKerbals/KustomKerbals-1.0.2.ckan
@@ -19,8 +19,7 @@
             "file": "KustomKerbals",
             "install_to": "GameData",
             "filter": [
-                ".DS_Store",
-                "MiniAVC.xml"
+                ".DS_Store"
             ]
         }
     ],

--- a/PlanetShine/PlanetShine-0.2.3.1.ckan
+++ b/PlanetShine/PlanetShine-0.2.3.1.ckan
@@ -26,8 +26,7 @@
         },
         {
             "file": "GameData/PlanetShine/Plugins",
-            "install_to": "GameData/PlanetShine",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData/PlanetShine"
         },
         {
             "file": "GameData/PlanetShine/LICENSE",

--- a/SmartParts/SmartParts-1.6.5.ckan
+++ b/SmartParts/SmartParts-1.6.5.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/SmartParts",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/BrettWebb/KerbalSmartParts/releases/download/1.6.5/SmartParts-1.6.5.zip",

--- a/SmartParts/SmartParts-1.6.6.ckan
+++ b/SmartParts/SmartParts-1.6.6.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "GameData/SmartParts",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/BrettWebb/KerbalSmartParts/releases/download/1.6.6/SmartParts-1.6.6.zip",

--- a/SmartParts/SmartParts-1.7.0.ckan
+++ b/SmartParts/SmartParts-1.7.0.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "SmartParts",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/henrybauer/KerbalSmartParts/releases/download/1.7.0/SmartParts-1.7.0.zip",

--- a/SmartParts/SmartParts-1.7.1.ckan
+++ b/SmartParts/SmartParts-1.7.1.ckan
@@ -14,8 +14,7 @@
     "install": [
         {
             "file": "SmartParts",
-            "install_to": "GameData",
-            "filter": "MiniAVC.xml"
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/henrybauer/KerbalSmartParts/releases/download/1.7.1/SmartParts-1.7.1.zip",

--- a/TACLS/TACLS-v0.10.1.ckan
+++ b/TACLS/TACLS-v0.10.1.ckan
@@ -19,11 +19,6 @@
             "name": "TACLS-Config"
         }
     ],
-    "recommends": [
-        {
-            "name": "MiniAVC"
-        }
-    ],
     "suggests": [
         {
             "name": "KSP-AVC"
@@ -33,8 +28,8 @@
         {
             "file": "GameData/ThunderAerospace",
             "install_to": "GameData",
-            "filter_regexp": "PluginData/TacLifeSupport/LifeSupport\\.cfg$"
-        }
+	    "filter_regexp": "PluginData/TacLifeSupport/LifeSupport\\.cfg$"
+	}
     ],
     "download": "https://github.com/taraniselsu/TacLifeSupport/releases/download/v0.10.1/TacLifeSupport_0.10.1.13.zip",
     "download_size": 5997448,

--- a/TweakScale/TweakScale-v2.2.6.ckan
+++ b/TweakScale/TweakScale-v2.2.6.ckan
@@ -14,7 +14,8 @@
         "repository": "https://github.com/pellinor0/TweakScale"
     },
     "version": "v2.2.6",
-    "ksp_version": "1.0.5",
+    "ksp_version_min": "1.0.2",
+    "ksp_version_max": "1.0.5",
     "depends": [
         {
             "name": "ModuleManager",

--- a/UniversalStorage/UniversalStorage-1.1.0.10.ckan
+++ b/UniversalStorage/UniversalStorage-1.1.0.10.ckan
@@ -34,10 +34,7 @@
     "install": [
         {
             "find": "UniversalStorage",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/329/Universal%20Storage/download/1.1.0.10",

--- a/UniversalStorage/UniversalStorage-1.1.0.11.ckan
+++ b/UniversalStorage/UniversalStorage-1.1.0.11.ckan
@@ -34,10 +34,7 @@
     "install": [
         {
             "find": "UniversalStorage",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/329/Universal%20Storage/download/1.1.0.11",

--- a/UniversalStorage/UniversalStorage-1.1.0.3.kerbalstuff
+++ b/UniversalStorage/UniversalStorage-1.1.0.3.kerbalstuff
@@ -30,10 +30,7 @@
     "install": [
         {
             "find": "UniversalStorage",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "resources": {

--- a/UniversalStorage/UniversalStorage-1.1.0.4.kerbalstuff
+++ b/UniversalStorage/UniversalStorage-1.1.0.4.kerbalstuff
@@ -30,10 +30,7 @@
     "install": [
         {
             "find": "UniversalStorage",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "resources": {

--- a/UniversalStorage/UniversalStorage-1.1.0.5.kerbalstuff
+++ b/UniversalStorage/UniversalStorage-1.1.0.5.kerbalstuff
@@ -30,10 +30,7 @@
     "install": [
         {
             "find": "UniversalStorage",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "resources": {

--- a/UniversalStorage/UniversalStorage-1.1.0.6.kerbalstuff
+++ b/UniversalStorage/UniversalStorage-1.1.0.6.kerbalstuff
@@ -30,10 +30,7 @@
     "install": [
         {
             "find": "UniversalStorage",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "resources": {

--- a/UniversalStorage/UniversalStorage-1.1.0.7.kerbalstuff
+++ b/UniversalStorage/UniversalStorage-1.1.0.7.kerbalstuff
@@ -23,10 +23,7 @@
     "install": [
         {
             "find": "UniversalStorage",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://kerbalstuff.com/mod/250/Universal%20Storage/download/1.1.0.7",

--- a/UniversalStorage/UniversalStorage-1.1.0.8.ckan
+++ b/UniversalStorage/UniversalStorage-1.1.0.8.ckan
@@ -34,10 +34,7 @@
     "install": [
         {
             "find": "UniversalStorage",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/329/Universal%20Storage/download/1.1.0.8",

--- a/UniversalStorage/UniversalStorage-1.1.0.9.ckan
+++ b/UniversalStorage/UniversalStorage-1.1.0.9.ckan
@@ -34,10 +34,7 @@
     "install": [
         {
             "find": "UniversalStorage",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://spacedock.info/mod/329/Universal%20Storage/download/1.1.0.9",

--- a/WildBlueTools/WildBlueTools-0.1.10.ckan
+++ b/WildBlueTools/WildBlueTools-0.1.10.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-0.1.10/9F5E1F8C-WildBlueTools-0.1.10.zip",

--- a/WildBlueTools/WildBlueTools-0.1.16.ckan
+++ b/WildBlueTools/WildBlueTools-0.1.16.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-0.1.16/F59DBEDD-WildBlueTools-0.1.16.zip",

--- a/WildBlueTools/WildBlueTools-1.0.11.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.11.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.11/BD331FF3-WildBlueTools-1.0.11.zip",

--- a/WildBlueTools/WildBlueTools-1.0.12.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.12.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.12/6BBDB73D-WildBlueTools-1.0.12.zip",

--- a/WildBlueTools/WildBlueTools-1.0.15.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.15.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.15/DFC46C15-WildBlueTools-1.0.15.zip",

--- a/WildBlueTools/WildBlueTools-1.0.17.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.17.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.17/56ABD460-WildBlueTools-1.0.17.zip",

--- a/WildBlueTools/WildBlueTools-1.0.18.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.18.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.18/75C3EBE2-WildBlueTools-1.0.18.zip",

--- a/WildBlueTools/WildBlueTools-1.0.19.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.19.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.19/214E5538-WildBlueTools-1.0.19.zip",

--- a/WildBlueTools/WildBlueTools-1.0.20.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.20.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/51B2E97B.zip",

--- a/WildBlueTools/WildBlueTools-1.0.21.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.21.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3310BF83.zip",

--- a/WildBlueTools/WildBlueTools-1.0.22.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.22.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/4EF742D4.zip",

--- a/WildBlueTools/WildBlueTools-1.0.23.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.23.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/B784F8A9.zip",

--- a/WildBlueTools/WildBlueTools-1.0.24.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.24.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/7F27869B.zip",

--- a/WildBlueTools/WildBlueTools-1.0.25.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.25.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/34545588.zip",

--- a/WildBlueTools/WildBlueTools-1.0.26.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.26.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/3269412C.zip",

--- a/WildBlueTools/WildBlueTools-1.0.27.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.27.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/53182985.zip",

--- a/WildBlueTools/WildBlueTools-1.0.28.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.28.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/EA07C48F.zip",

--- a/WildBlueTools/WildBlueTools-1.0.29.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.29.ckan
@@ -20,10 +20,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://s3-us-west-2.amazonaws.com/ksp-ckan/E9E2E9C6.zip",

--- a/WildBlueTools/WildBlueTools-1.0.4.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.4.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.4/1DAA85E6-WildBlueTools-1.0.4.zip",

--- a/WildBlueTools/WildBlueTools-1.0.5.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.5.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.5/4BAE9F31-WildBlueTools-1.0.5.zip",

--- a/WildBlueTools/WildBlueTools-1.0.6.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.6.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.6/04034A02-WildBlueTools-1.0.6.zip",

--- a/WildBlueTools/WildBlueTools-1.0.7.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.7.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.7/AAAC254B-WildBlueTools-1.0.7.zip",

--- a/WildBlueTools/WildBlueTools-1.0.8.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.8.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.8/AEA32098-WildBlueTools-1.0.8.zip",

--- a/WildBlueTools/WildBlueTools-1.0.9.ckan
+++ b/WildBlueTools/WildBlueTools-1.0.9.ckan
@@ -15,10 +15,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries",
-            "install_to": "GameData",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData"
         }
     ],
     "download": "https://archive.org/download/WildBlueTools-1.0.9/4725D913-WildBlueTools-1.0.9.zip",

--- a/WildBlueTools/WildBlueTools-v1.0.32.ckan
+++ b/WildBlueTools/WildBlueTools-v1.0.32.ckan
@@ -23,10 +23,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries/000WildBlueTools",
-            "install_to": "GameData/WildBlueIndustries",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData/WildBlueIndustries"
         }
     ],
     "download": "https://github.com/Angel-125/WildBlueTools/releases/download/v1.0.32/WildBlueTools_1_0_32.zip",

--- a/WildBlueTools/WildBlueTools-v1.0.33.ckan
+++ b/WildBlueTools/WildBlueTools-v1.0.33.ckan
@@ -23,10 +23,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries/000WildBlueTools",
-            "install_to": "GameData/WildBlueIndustries",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData/WildBlueIndustries"
         }
     ],
     "download": "https://github.com/Angel-125/WildBlueTools/releases/download/v1.0.33/WildBlueTools_1_0_33.zip",

--- a/WildBlueTools/WildBlueTools-v1.1.0.ckan
+++ b/WildBlueTools/WildBlueTools-v1.1.0.ckan
@@ -23,11 +23,8 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries/000WildBlueTools",
-            "install_to": "GameData/WildBlueIndustries",
-            "filter": [
-                "MiniAVC.xml"
-            ]
-        }
+	    "install_to": "GameData/WildBlueIndustries"
+	}
     ],
     "download": "https://github.com/Angel-125/WildBlueTools/releases/download/v1.1.0/WildBlueTools_1_1_0.zip",
     "download_size": 2638149,

--- a/WildBlueTools/WildBlueTools-v1.1.1.ckan
+++ b/WildBlueTools/WildBlueTools-v1.1.1.ckan
@@ -23,10 +23,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries/000WildBlueTools",
-            "install_to": "GameData/WildBlueIndustries",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData/WildBlueIndustries"
         }
     ],
     "download": "https://github.com/Angel-125/WildBlueTools/releases/download/v1.1.1/WildBlueTools_1_1_1.zip",

--- a/WildBlueTools/WildBlueTools-v1.1.2.ckan
+++ b/WildBlueTools/WildBlueTools-v1.1.2.ckan
@@ -23,10 +23,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries/000WildBlueTools",
-            "install_to": "GameData/WildBlueIndustries",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData/WildBlueIndustries"
         }
     ],
     "download": "https://github.com/Angel-125/WildBlueTools/releases/download/v1.1.2/WildBlueTools_1_1_2.zip",

--- a/WildBlueTools/WildBlueTools-v1.1.3.ckan
+++ b/WildBlueTools/WildBlueTools-v1.1.3.ckan
@@ -23,10 +23,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries/000WildBlueTools",
-            "install_to": "GameData/WildBlueIndustries",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData/WildBlueIndustries"
         }
     ],
     "download": "https://github.com/Angel-125/WildBlueTools/releases/download/v1.1.3/WildBlueTools_1_1_3.zip",

--- a/WildBlueTools/WildBlueTools-v1.1.4.ckan
+++ b/WildBlueTools/WildBlueTools-v1.1.4.ckan
@@ -23,10 +23,7 @@
     "install": [
         {
             "file": "GameData/WildBlueIndustries/000WildBlueTools",
-            "install_to": "GameData/WildBlueIndustries",
-            "filter": [
-                "MiniAVC.xml"
-            ]
+            "install_to": "GameData/WildBlueIndustries"
         }
     ],
     "download": "https://github.com/Angel-125/WildBlueTools/releases/download/v1.1.4/WildBlueTools_1_1_4.zip",


### PR DESCRIPTION
## Background

KSP-CKAN/NetKAN#1455 outlines the MiniAVC saga. It ends with KSP-CKAN/NetKAN#3934 removing MiniAVC filters from all .netkan files.

## Problem

These filters still survive in many old .ckan files. This means that if a player spins up an old game version, they might end up with an install that doesn't conform to current CKAN policy. It's also confusing for new metadata maintainers trying to figure out what to do with MiniAVC.

An old version of TACLS `suggests` MiniAVC, even though [it's no longer indexed as a standalone mod](https://github.com/KSP-CKAN/CKAN-meta/commit/6cd629492ab5c35e02137b93ecb20b9d8f3dcb1a).

## Changes

Now all the MiniAVC filters are removed, and there are no remaining references to the aborted standalone MiniAVC module.