### PR TITLE
Fix old LaserDist version

### DIFF
--- a/LaserDist/LaserDist-v1.0.1.ckan
+++ b/LaserDist/LaserDist-v1.0.1.ckan
@@ -10,8 +10,7 @@
         "repository": "https://github.com/Dunbaratu/LaserDist"
     },
     "version": "v1.0.1",
-    "ksp_version_min": "1.1.0",
-    "ksp_version_max": "99.99.99",
+    "ksp_version": "1.3",
     "suggests": [
         {
             "name": "kOS",


### PR DESCRIPTION
There's a new LaserDist release, which means the previous current version is no longer covered by Dunbaratu/LaserDist#23 or KSP-CKAN/CKAN-meta#1338. This pull request fixes it.