### PR TITLE
Update hashes for InterstellarFuelSwitch-Core

### DIFF
--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.15.1.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.15.1.ckan
@@ -41,10 +41,10 @@
         }
     ],
     "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.15.1",
-    "download_size": 8903643,
+    "download_size": 8911023,
     "download_hash": {
-        "sha1": "8F7C975DEEA87D1B0147F4736F3072DDC911694E",
-        "sha256": "2F3B3DA07549DB8CAD9CF97A842CC34DB64756641711A978607AC8A0DC4DFF30"
+        "sha1": "DE60F8E943841F2A8840AC5353B64BB810C49AB0",
+        "sha256": "3C4375CF85129C4A61BD74C15CF0DD4F65EF28E7C4D4780DB8C593CB71AA5222"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
This download was replaced on SpaceDock.
Now the size and hashes are updated. This will work because there's a already newer version to distract the bot.

Fixes KSP-CKAN/CKAN#2568.