### PR TITLE
Fix faulty NFP 0.3.4 version

### DIFF
--- a/NearFutureProps/NearFutureProps-1-0.3.4.ckan
+++ b/NearFutureProps/NearFutureProps-1-0.3.4.ckan
@@ -9,7 +9,7 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166941-*",
         "repository": "https://github.com/ChrisAdderley/NearFutureProps"
     },
-    "version": "1:0.4.4",
+    "version": "1:0.3.4",
     "ksp_version_min": "1.4.2",
     "ksp_version_max": "1.4.9",
     "supports": [


### PR DESCRIPTION
NearFutureProps 0.3.4 was released as 0.4.4:

[![image](https://user-images.githubusercontent.com/1559108/48396367-130f5680-e712-11e8-838b-a166e7143e8d.png)](https://github.com/ChrisAdderley/NearFutureProps/releases)

Now the metadata is fixed.

Fixes KSP-CKAN/NetKAN#6840.