### PR TITLE
Fix old SXTContinued versions

### DIFF
--- a/SXTContinued/SXTContinued-1-0.3.23.4.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.23.4.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/linuxgurugamer/SXTContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/SXTContinued/SXTContinued-1477802930.9760618.png"
     },
-    "version": "1:3.2.23.4",
+    "version": "1:0.3.23.4",
     "ksp_version": "1.4.1",
     "depends": [
         {

--- a/SXTContinued/SXTContinued-1-0.3.23.7.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.23.7.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/linuxgurugamer/SXTContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/SXTContinued/SXTContinued-1477802930.9760618.png"
     },
-    "version": "1:03.23.7",
+    "version": "1:0.3.23.7",
     "ksp_version_min": "1.4.1",
     "ksp_version_max": "1.4.99",
     "depends": [


### PR DESCRIPTION
## Problem

Two old versions of SXTContinued are out of order:

![screenshot](https://user-images.githubusercontent.com/1559108/48667037-59bfd080-eac5-11e8-8945-8e61fd40a6d4.png)

## Changes

Now these entries are updated to their intended versions:

| Old | New |
| --- | --- |
| 1:3.2.23.4 | 1:0.3.23.4 |
| 1:03.23.7 | 1:0.3.23.7 |

Fixes KSP-CKAN/CKAN#2581.

@linuxgurugamer, does this look OK?