### PR TITLE
Update KerbalJointReinforcementContinued-v3.3.5.ckan

### DIFF
--- a/KerbalJointReinforcementContinued/KerbalJointReinforcementContinued-v3.3.5.ckan
+++ b/KerbalJointReinforcementContinued/KerbalJointReinforcementContinued-v3.3.5.ckan
@@ -31,10 +31,10 @@
         }
     ],
     "download": "https://github.com/KSP-RO/Kerbal-Joint-Reinforcement-Continued/releases/download/v3.3.5/KerbalJointReinforcement_v3.3.5.zip",
-    "download_size": 38239,
+    "download_size": 38236,
     "download_hash": {
-        "sha1": "D8D733C19492D9BA020A6650E41C7147F5D2F003",
-        "sha256": "8BF523A62B5BE43916A4E3A73E1BDF1CB135FD2FCAF21EA81FCED3310AE95105"
+        "sha1": "f72116fb80df5cb66cd7226a1a228d9df05f0fe5",
+        "sha256": "7abdd5f22e6382b5e6e7e4952a190af03de4fb4fb4d5d54628b91805f39e4673"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
updated hash/size values due to hot patched zip archive.