### PR TITLE
Update HyperEdit version_max and version_min

### DIFF
--- a/HyperEdit/HyperEdit-1.5.8.0.ckan
+++ b/HyperEdit/HyperEdit-1.5.8.0.ckan
@@ -15,8 +15,8 @@
         "homepage": "http://www.Kerbaltek.com/hyperedit"
     },
     "version": "1.5.8.0",
-    "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.99",
+    "ksp_version_min": "1.4.1",
+    "ksp_version_max": "1.6.99",
     "install": [
         {
             "file": "GameData/Kerbaltek",


### PR DESCRIPTION
HyperEdits vref is set to its .version, which is not updated since 1.4 because no mod update was released.
https://forum.kerbalspaceprogram.com/index.php?/topic/34785-16-hyperedit-v158-july-10-2018-cheat-teleporter-orbitplanet-editor-more/& states 1.5.8 is compatible from KSP 1.4.1 to 1.6.

Closes https://github.com/KSP-CKAN/CKAN/issues/2631 (but I don't think this works across projects)