### PR TITLE
Fix weird Trajectories version number

### DIFF
--- a/Trajectories/Trajectories-v2.2.0.ckan
+++ b/Trajectories/Trajectories-v2.2.0.ckan
@@ -14,7 +14,7 @@
         "spacedock": "https://spacedock.info/mod/396/Trajectories",
         "repository": "https://github.com/neuoy/KSPTrajectories"
     },
-    "version": "vKSP1.4.2-v2.2.0",
+    "version": "v2.2.0",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.99",
     "depends": [


### PR DESCRIPTION
Trajectories has some weird version numbers lately that are breaking things.

![screenshot](https://i.imgur.com/AdzamLD.png)

Now that top one is changed to just "v2.2.0".