### PR TITLE
Add missing version of adopted ScienceSituationInfo

### DIFF
--- a/ScienceSituationInfo/ScienceSituationInfo-1-1.3.3.ckan
+++ b/ScienceSituationInfo/ScienceSituationInfo-1-1.3.3.ckan
@@ -1,0 +1,31 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "ScienceSituationInfo",
+    "name": "Extended information about scientific experiments in VAB",
+    "abstract": "Extended information about Scientific Experiments in VAB/SPH",
+    "author": "linuxgurugamer",
+    "license": "CC-BY-SA",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179661-15-extended-information-about-scientific-experiments-in-vab-sph/",
+        "spacedock": "https://spacedock.info/mod/2000/Extended%20information%20about%20scientific%20experiments%20in%20VAB",
+        "repository": "https://github.com/linuxgurugamer/SituationModuleInfo",
+        "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/Extended_information_about_scientific_experiments_in_VAB/Extended_information_about_scientific_experiments_in_VAB-1541772336.0604234.png"
+    },
+    "version": "1:1.3.3",
+    "ksp_version_min": "1.4.0",
+    "ksp_version_max": "1.4.9",
+    "install": [
+        {
+            "find": "SituationModuleInfo",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://spacedock.info/mod/2000/Extended%20information%20about%20scientific%20experiments%20in%20VAB/download/1.3.3",
+    "download_size": 25593,
+    "download_hash": {
+        "sha1": "3967C1D76CB2C73F728566F706041CC1CDF95F3D",
+        "sha256": "AB4A6248856E1D433D042BDC78456522E5B447DF6DD9E30542EE2BBEFB1414E6"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
This mod wasn't indexed when this version was uploaded. Now it's added for completeness.

Part of the fix to KSP-CKAN/NetKAN#6980.