### PR TITLE
Update and rename PicoPort-v0.1.4.ckan to PicoPort-0.1.4.ckan

### DIFF
--- a/PicoPort/PicoPort-0.1.4.ckan
+++ b/PicoPort/PicoPort-0.1.4.ckan
@@ -14,7 +14,7 @@
         "repository": "https://github.com/steedcrugeon/PicoPort",
         "x_screenshot": "https://spacedock.info/content/steedcrugeon_8650/PicoPort/PicoPort-1484439960.4712257.png"
     },
-    "version": "v0.1.4",
+    "version": "0.1.4",
     "ksp_version": "1.4.3",
     "depends": [
         {


### PR DESCRIPTION
An old version of PicoPort was uploaded with a 'v' prefix, which none of the other versions have. This pull request removes it.

Fixes KSP-CKAN/NetKAN#6988