### PR TITLE
Constrain AJE v2.11.4.1 to KSP 1.4.5

### DIFF
--- a/AdvancedJetEngine/AdvancedJetEngine-v2.11.4.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.11.4.1.ckan
@@ -14,7 +14,7 @@
         "repository": "https://github.com/KSP-RO/AJE"
     },
     "version": "v2.11.4.1",
-    "ksp_version_max": "1.4.5",
+    "ksp_version": "1.4.5",
     "depends": [
         {
             "name": "FAR"


### PR DESCRIPTION
No minimum verison means that CKAN wants to install in on KSP 1.3.x where it's incompatible.  This version was mainly for RO support and there seems to be no real reason to support anything other than KSP 1.4.5