### PR TITLE
Clean up old version of pwings

### DIFF
--- a/B9-PWings-Fork/B9-PWings-Fork-1-0.50.ckan
+++ b/B9-PWings-Fork/B9-PWings-Fork-1-0.50.ckan
@@ -13,7 +13,7 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/117236-*",
         "repository": "https://github.com/jrodrigv/B9-PWings-Fork"
     },
-    "version": "1:v0.50",
+    "version": "1:0.50",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.9",
     "conflicts": [


### PR DESCRIPTION
This mod mostly doesn't have 'v' prefixes in versions, but one version does, which is messing things up. Now it's fixed.

Fixes https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1254-kennedy/&do=findComment&comment=3537829