### PR TITLE
Backfill UniversalStorage2

### DIFF
--- a/UniversalStorage2/UniversalStorage2-1.3.1.2.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.2.ckan
@@ -15,9 +15,8 @@
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
-    "version": "1.4.5.4",
-    "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.9",
+    "version": "1.3.1.2",
+    "ksp_version": "1.3.1",
     "depends": [
         {
             "name": "ModuleManager"
@@ -26,11 +25,11 @@
             "name": "CommunityResourcePack"
         }
     ],
-    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.4.5.4",
-    "download_size": 33088790,
+    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.3.1.2",
+    "download_size": 30753712,
     "download_hash": {
-        "sha1": "6C8E27083AADD47735D2AFDC29423389C58BEBAF",
-        "sha256": "7B2AD038B49F04B826AB89A4C5C64E6C17DD9A9683D7841BD3021F7953E454D4"
+        "sha1": "E03953ACE5C78FD4A006A5BF80695E412A54E411",
+        "sha256": "6AA2C94406FC297704DB3C292B80CFE10EEDEBDAF8A433FBD9456B17E21BEED1"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/UniversalStorage2/UniversalStorage2-1.3.1.3.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.3.ckan
@@ -15,8 +15,8 @@
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
-    "version": "1.4.5.4",
-    "ksp_version_min": "1.4.0",
+    "version": "1.3.1.3",
+    "ksp_version_min": "1.3.1",
     "ksp_version_max": "1.4.9",
     "depends": [
         {
@@ -26,11 +26,11 @@
             "name": "CommunityResourcePack"
         }
     ],
-    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.4.5.4",
-    "download_size": 33088790,
+    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.3.1.3",
+    "download_size": 30808741,
     "download_hash": {
-        "sha1": "6C8E27083AADD47735D2AFDC29423389C58BEBAF",
-        "sha256": "7B2AD038B49F04B826AB89A4C5C64E6C17DD9A9683D7841BD3021F7953E454D4"
+        "sha1": "369D0D7199465A07233015842F9133027B65D846",
+        "sha256": "24767776ABA9B23AF2AEA0894228448F02A200218658EA189AFD400799260888"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/UniversalStorage2/UniversalStorage2-1.3.1.4.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.4.ckan
@@ -15,8 +15,8 @@
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
-    "version": "1.4.5.4",
-    "ksp_version_min": "1.4.0",
+    "version": "1.3.1.4",
+    "ksp_version_min": "1.3.1",
     "ksp_version_max": "1.4.9",
     "depends": [
         {
@@ -26,11 +26,11 @@
             "name": "CommunityResourcePack"
         }
     ],
-    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.4.5.4",
-    "download_size": 33088790,
+    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.3.1.4",
+    "download_size": 30808970,
     "download_hash": {
-        "sha1": "6C8E27083AADD47735D2AFDC29423389C58BEBAF",
-        "sha256": "7B2AD038B49F04B826AB89A4C5C64E6C17DD9A9683D7841BD3021F7953E454D4"
+        "sha1": "C0B0E9A0A621143ABE04DD2DD60268AEEAC0E556",
+        "sha256": "FD6CB79B583F9F541165260FDB2FE838AF7A747A3FFFFB21653E0F2B4352A678"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/UniversalStorage2/UniversalStorage2-1.3.1.5.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.5.ckan
@@ -13,10 +13,11 @@
         "homepage": "http://www.kingtiger.online/uvsii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
-        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1540455649.9425209.png"
+        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.3.1.5",
-    "ksp_version": "1.3.1",
+    "ksp_version_min": "1.3.1",
+    "ksp_version_max": "1.5.9",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UniversalStorage2/UniversalStorage2-1.3.1.6.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.6.ckan
@@ -13,10 +13,11 @@
         "homepage": "http://www.kingtiger.online/uvsii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
-        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1540455649.9425209.png"
+        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.3.1.6",
-    "ksp_version": "1.3.1",
+    "ksp_version_min": "1.3.1",
+    "ksp_version_max": "1.5.9",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UniversalStorage2/UniversalStorage2-1.3.1.7.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.7.ckan
@@ -13,7 +13,7 @@
         "homepage": "http://www.kingtiger.online/uvsii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
-        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1540455649.9425209.png"
+        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.3.1.7",
     "ksp_version": "1.3.1",

--- a/UniversalStorage2/UniversalStorage2-1.3.1.8.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.8.ckan
@@ -15,9 +15,8 @@
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
-    "version": "1.4.5.4",
-    "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.9",
+    "version": "1.3.1.8",
+    "ksp_version": "1.3.1",
     "depends": [
         {
             "name": "ModuleManager"
@@ -26,11 +25,11 @@
             "name": "CommunityResourcePack"
         }
     ],
-    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.4.5.4",
-    "download_size": 33088790,
+    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.3.1.8",
+    "download_size": 39230747,
     "download_hash": {
-        "sha1": "6C8E27083AADD47735D2AFDC29423389C58BEBAF",
-        "sha256": "7B2AD038B49F04B826AB89A4C5C64E6C17DD9A9683D7841BD3021F7953E454D4"
+        "sha1": "84A038CA51B4032E1316BD10AC7563BB5D553CAB",
+        "sha256": "EDBC03E151C662934CE6E777033AF7D3BA948F186BD30D34850BDAD6CFD29612"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/UniversalStorage2/UniversalStorage2-1.3.1.9.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.9.ckan
@@ -15,9 +15,8 @@
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
-    "version": "1.4.5.4",
-    "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.9",
+    "version": "1.3.1.9",
+    "ksp_version": "1.3.1",
     "depends": [
         {
             "name": "ModuleManager"
@@ -26,11 +25,11 @@
             "name": "CommunityResourcePack"
         }
     ],
-    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.4.5.4",
-    "download_size": 33088790,
+    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.3.1.9",
+    "download_size": 39230793,
     "download_hash": {
-        "sha1": "6C8E27083AADD47735D2AFDC29423389C58BEBAF",
-        "sha256": "7B2AD038B49F04B826AB89A4C5C64E6C17DD9A9683D7841BD3021F7953E454D4"
+        "sha1": "3845322342C161235DF5D08DC78887D9EFA8229D",
+        "sha256": "43F0806BBCF854721D4AB810BE02B7ED8E4AF79992307BBB0AC244DE093D981F"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/UniversalStorage2/UniversalStorage2-1.4.5.2.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.4.5.2.ckan
@@ -15,9 +15,8 @@
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
-    "version": "1.4.5.4",
-    "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.9",
+    "version": "1.4.5.2",
+    "ksp_version": "1.4.4",
     "depends": [
         {
             "name": "ModuleManager"
@@ -26,11 +25,11 @@
             "name": "CommunityResourcePack"
         }
     ],
-    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.4.5.4",
-    "download_size": 33088790,
+    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.4.5.2",
+    "download_size": 33033358,
     "download_hash": {
-        "sha1": "6C8E27083AADD47735D2AFDC29423389C58BEBAF",
-        "sha256": "7B2AD038B49F04B826AB89A4C5C64E6C17DD9A9683D7841BD3021F7953E454D4"
+        "sha1": "42F1E0C455562B0753C79D7E528AB76FCF467E76",
+        "sha256": "12CDBCA3F9D0A8364F3891537E2F2CFF49F675E9A958441E89DA41F84C818316"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/UniversalStorage2/UniversalStorage2-1.4.5.3.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.4.5.3.ckan
@@ -15,7 +15,7 @@
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
-    "version": "1.4.5.4",
+    "version": "1.4.5.3",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.9",
     "depends": [
@@ -26,11 +26,11 @@
             "name": "CommunityResourcePack"
         }
     ],
-    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.4.5.4",
-    "download_size": 33088790,
+    "download": "https://spacedock.info/mod/1933/Universal%20Storage%20II/download/1.4.5.3",
+    "download_size": 33088561,
     "download_hash": {
-        "sha1": "6C8E27083AADD47735D2AFDC29423389C58BEBAF",
-        "sha256": "7B2AD038B49F04B826AB89A4C5C64E6C17DD9A9683D7841BD3021F7953E454D4"
+        "sha1": "9658767DC453F279C918840406A92D12221B5389",
+        "sha256": "EE31F403CE2F9AF970ACED78C8CC6782565E3F4B4101D9DD776E3F5BE91B0242"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/UniversalStorage2/UniversalStorage2-1.5.1.5.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.5.1.5.ckan
@@ -13,10 +13,11 @@
         "homepage": "http://www.kingtiger.online/uvsii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
-        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1540455649.9425209.png"
+        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.5.1.5",
-    "ksp_version": "1.5.1",
+    "ksp_version_min": "1.5.0",
+    "ksp_version_max": "1.5.9",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UniversalStorage2/UniversalStorage2-1.5.1.6.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.5.1.6.ckan
@@ -13,10 +13,11 @@
         "homepage": "http://www.kingtiger.online/uvsii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
-        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1540455649.9425209.png"
+        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.5.1.6",
-    "ksp_version": "1.5.1",
+    "ksp_version_min": "1.5.0",
+    "ksp_version_max": "1.5.9",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UniversalStorage2/UniversalStorage2-1.5.1.7.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.5.1.7.ckan
@@ -13,10 +13,11 @@
         "homepage": "http://www.kingtiger.online/uvsii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
-        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1540455649.9425209.png"
+        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.5.1.7",
-    "ksp_version": "1.5.1",
+    "ksp_version_min": "1.4.5",
+    "ksp_version_max": "1.5.99",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UniversalStorage2/UniversalStorage2-1.5.1.8.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.5.1.8.ckan
@@ -13,10 +13,11 @@
         "homepage": "http://www.kingtiger.online/uvsii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
         "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
-        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1540455649.9425209.png"
+        "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.5.1.8",
-    "ksp_version": "1.5.1",
+    "ksp_version_min": "1.4.5",
+    "ksp_version_max": "1.5.99",
     "depends": [
         {
             "name": "ModuleManager"


### PR DESCRIPTION
## Problem

Some versions of UniversalStorage2 are missing (partly due to KSP-SpaceDock/SpaceDock#192), and others have too narrow game compatibility.

## Changes

Now KSP-CKAN/CKAN#2681's `--backfill` option is used to regenerate all versions of UniversalStorage2.

Some old versions are newly added:

- 1.3.1.2
- 1.3.1.3
- 1.3.1.4
- 1.3.1.8
- 1.3.1.9
- 1.4.5.2
- 1.4.5.3

Existing versions have their `resources.x_screenshot` updated and game versions revised based on the .version files (since a `$vref` has been added to the netkan in KSP-CKAN/NetKAN#7005):

- 1.3.1.5
- 1.3.1.6
- 1.3.1.7
- 1.4.5.4
- 1.5.1.5
- 1.5.1.6
- 1.5.1.7
- 1.5.1.8

Fixes KSP-CKAN/NetKAN#7003.