### PR TITLE
Set compatibility for old ToolbarController versions

### DIFF
--- a/ToolbarController/ToolbarController-0.1.3.1.ckan
+++ b/ToolbarController/ToolbarController-0.1.3.1.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/linuxgurugamer/ToolbarControl"
     },
     "version": "0.1.3.1",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "Toolbar"

--- a/ToolbarController/ToolbarController-0.1.3.4.ckan
+++ b/ToolbarController/ToolbarController-0.1.3.4.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/linuxgurugamer/ToolbarControl"
     },
     "version": "0.1.3.4",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "Toolbar"

--- a/ToolbarController/ToolbarController-0.1.3.5.ckan
+++ b/ToolbarController/ToolbarController-0.1.3.5.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/linuxgurugamer/ToolbarControl"
     },
     "version": "0.1.3.5",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "Toolbar"

--- a/ToolbarController/ToolbarController-0.1.4.1.ckan
+++ b/ToolbarController/ToolbarController-0.1.4.1.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/linuxgurugamer/ToolbarControl"
     },
     "version": "0.1.4.1",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "Toolbar"

--- a/ToolbarController/ToolbarController-0.1.4.2.ckan
+++ b/ToolbarController/ToolbarController-0.1.4.2.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/linuxgurugamer/ToolbarControl"
     },
     "version": "0.1.4.2",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "Toolbar"

--- a/ToolbarController/ToolbarController-0.1.4.ckan
+++ b/ToolbarController/ToolbarController-0.1.4.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/linuxgurugamer/ToolbarControl"
     },
     "version": "0.1.4",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "Toolbar"

--- a/ToolbarController/ToolbarController-1-0.1.4.3.ckan
+++ b/ToolbarController/ToolbarController-1-0.1.4.3.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/linuxgurugamer/ToolbarControl"
     },
     "version": "1:0.1.4.3",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "Toolbar"

--- a/ToolbarController/ToolbarController-1-0.1.4.4.ckan
+++ b/ToolbarController/ToolbarController-1-0.1.4.4.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/linuxgurugamer/ToolbarControl"
     },
     "version": "1:0.1.4.4",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "Toolbar"

--- a/ToolbarController/ToolbarController-1-0.1.4.5.ckan
+++ b/ToolbarController/ToolbarController-1-0.1.4.5.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/linuxgurugamer/ToolbarControl"
     },
     "version": "1:0.1.4.5",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "Toolbar"

--- a/ToolbarController/ToolbarController-1-0.1.4.6.ckan
+++ b/ToolbarController/ToolbarController-1-0.1.4.6.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/linuxgurugamer/ToolbarControl"
     },
     "version": "1:0.1.4.6",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "Toolbar"

--- a/ToolbarController/ToolbarController-1-0.1.4.7.ckan
+++ b/ToolbarController/ToolbarController-1-0.1.4.7.ckan
@@ -9,6 +9,7 @@
         "repository": "https://github.com/linuxgurugamer/ToolbarControl"
     },
     "version": "1:0.1.4.7",
+    "ksp_version": "1.3.1",
     "recommends": [
         {
             "name": "Toolbar"


### PR DESCRIPTION
## Problem

Several old versions of ToolbarController are indexed as compatible with all game versions, while the later ones have specific game versions:

![image](https://user-images.githubusercontent.com/1559108/53040548-4404d300-3447-11e9-8125-2a2cf80ec4f5.png)

This means that anytime KSP updates, users end up installing ToolbarController 0.1.4.7 until there's a new release or a metadata update.

## Changes

Now those old versions are marked as compatible with KSP 1.3.1, which was the current game version when they were released.