### PR TITLE
Fix bad min version syntax

### DIFF
--- a/IR-Model-Rework-Core/IR-Model-Rework-Core-v01a.kerbalstuff
+++ b/IR-Model-Rework-Core/IR-Model-Rework-Core-v01a.kerbalstuff
@@ -5,7 +5,7 @@
     "depends": [
         {
             "name": "InfernalRobotics",
-            "version_min": "0.19.4"
+            "min_version": "0.19.4"
         }
     ],
     "recommends": [

--- a/IR-Model-Rework-Core/IR-Model-Rework-Core-v01b.kerbalstuff
+++ b/IR-Model-Rework-Core/IR-Model-Rework-Core-v01b.kerbalstuff
@@ -16,7 +16,7 @@
     "depends": [
         {
             "name": "InfernalRobotics",
-            "version_min": "0.19.4"
+            "min_version": "0.19.4"
         }
     ],
     "recommends": [

--- a/IR-Model-Rework-Expansion/IR-Model-Rework-Expansion-v01a.kerbalstuff
+++ b/IR-Model-Rework-Expansion/IR-Model-Rework-Expansion-v01a.kerbalstuff
@@ -5,7 +5,7 @@
     "depends": [
         {
             "name": "InfernalRobotics",
-            "version_min": "0.19.4"
+            "min_version": "0.19.4"
         },
         {
             "name": "IR-Model-Rework-Core"

--- a/IR-Model-Rework-Expansion/IR-Model-Rework-Expansion-v01b.kerbalstuff
+++ b/IR-Model-Rework-Expansion/IR-Model-Rework-Expansion-v01b.kerbalstuff
@@ -16,7 +16,7 @@
     "depends": [
         {
             "name": "InfernalRobotics",
-            "version_min": "0.19.4"
+            "min_version": "0.19.4"
         },
         {
             "name": "IR-Model-Rework-Core"


### PR DESCRIPTION
This is the CKAN-meta correlate of KSP-CKAN/NetKAN#7058.

Some modules have `version_min` instead of `min_version` in their relationships. The live data was all fixed by the commit hook of the above PR, but there are a few old `.kerbalstuff` files that still have the problem. This has no functional impact, but it might confuse metadata maintainers looking through files to see how to do things.

Now they're cleaned up.