### PR TITLE
Use any_of depends for old ScottManleyHeadPack version

### DIFF
--- a/ScottManleyHeadPack/ScottManleyHeadPack-1.0.0.ckan
+++ b/ScottManleyHeadPack/ScottManleyHeadPack-1.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.16",
+    "spec_version": "v1.26",
     "identifier": "ScottManleyHeadPack",
     "name": "Scott Manley Head Pack",
     "abstract": "Are you tired of not having Scott Manley in game? Are you tired of not looking at his pretty face while you playing KSP? ENOUGH! NOW YOU CAN LOOK AT HIM AS MUCH AS YOU WANT! Download our Scott Manley Head Pack today and get 50% more Scott!!!",
@@ -16,17 +16,11 @@
     "depends": [
         {
             "name": "ModuleManager"
-        }
-    ],
-    "recommends": [
-        {
-            "name": "SigmaReplacements-Heads"
-        }
-    ],
-    "suggests": [
-        {
-            "name": "TextureReplacerReplaced"
-        }
+        },
+        { "any_of": [
+            { "name": "SigmaReplacements-Heads" },
+            { "name": "TextureReplacerReplaced" }
+        ] }
     ],
     "download": "https://drive.google.com/uc?export=download&id=1X9vBLb9C5t2G5qfPCmtN_R-kF035UBPo",
     "download_size": 781384,


### PR DESCRIPTION
The version of the Scott Manley Head Pack for KSP 1.3 worked equally well for SigmaReplacements-Heads or TextureReplacerReplaced, but at the time there was no way to express that directly, so one of them is a suggestion and the other is a recommendation. This could make it easy to install both or neither, which would result in the mod not working.

Now this module is updated to have an `any_of` dependency on these two mods. This will prompt the user to choose one of them at install.

The `spec_version` is updated to v1.26, which will make this version disappear for anyone not using the pre-release, but probably no one will miss it.

Sort of related to KSP-CKAN/NetKAN#7027 in that this is a new feature in 1.26, but strictly speaking that issue is focused on `replaced_by`.