### PR TITLE
Add missing Near Future dependencies

### DIFF
--- a/ModuleManager/ModuleManager-2.5.1.ckan
+++ b/ModuleManager/ModuleManager-2.5.1.ckan
@@ -3,7 +3,7 @@
     "name"           : "Module Manager",
     "identifier"     : "ModuleManager",
     "abstract"       : "Modify KSP configs without conflict",
-    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/lastSuccessfulBuild/artifact/ModuleManager-2.5.1.zip",
+    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/82/artifact/ModuleManager-2.5.1.zip",
     "license"        : "CC-BY-SA",
     "author"         : [ "ialdabaoth", "Sarbian" ],
     "version"        : "2.5.1",

--- a/ModuleManager/ModuleManager-2.5.10.ckan
+++ b/ModuleManager/ModuleManager-2.5.10.ckan
@@ -22,7 +22,7 @@
         }
     ],
     "version": "2.5.10",
-    "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/lastStableBuild/artifact/ModuleManager-2.5.10.zip",
+    "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/82/artifact/ModuleManager-2.5.10.zip",
     "x_generated_by": "not netkan",
     "download_size": 24244
 }

--- a/ModuleManager/ModuleManager-2.5.2.ckan
+++ b/ModuleManager/ModuleManager-2.5.2.ckan
@@ -3,7 +3,7 @@
     "name"           : "Module Manager",
     "identifier"     : "ModuleManager",
     "abstract"       : "Modify KSP configs without conflict",
-    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/lastSuccessfulBuild/artifact/ModuleManager-2.5.2.zip",
+    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/82/artifact/ModuleManager-2.5.2.zip",
     "license"        : "CC-BY-SA",
     "author"         : [ "ialdabaoth", "Sarbian" ],
     "version"        : "2.5.2",

--- a/ModuleManager/ModuleManager-2.5.3.ckan
+++ b/ModuleManager/ModuleManager-2.5.3.ckan
@@ -3,7 +3,7 @@
     "name"           : "Module Manager",
     "identifier"     : "ModuleManager",
     "abstract"       : "Modify KSP configs without conflict",
-    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/lastSuccessfulBuild/artifact/ModuleManager-2.5.3.zip",
+    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/82/artifact/ModuleManager-2.5.3.zip",
     "license"        : "CC-BY-SA",
     "author"         : [ "ialdabaoth", "Sarbian" ],
     "version"        : "2.5.3",

--- a/ModuleManager/ModuleManager-2.5.4.ckan
+++ b/ModuleManager/ModuleManager-2.5.4.ckan
@@ -3,7 +3,7 @@
     "name"           : "Module Manager",
     "identifier"     : "ModuleManager",
     "abstract"       : "Modify KSP configs without conflict",
-    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/lastSuccessfulBuild/artifact/ModuleManager-2.5.4.zip",
+    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/82/artifact/ModuleManager-2.5.4.zip",
     "license"        : "CC-BY-SA",
     "author"         : [ "ialdabaoth", "Sarbian" ],
     "version"        : "2.5.4",

--- a/ModuleManager/ModuleManager-2.5.6.ckan
+++ b/ModuleManager/ModuleManager-2.5.6.ckan
@@ -3,7 +3,7 @@
     "name"           : "Module Manager",
     "identifier"     : "ModuleManager",
     "abstract"       : "Modify KSP configs without conflict",
-    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/lastSuccessfulBuild/artifact/ModuleManager-2.5.6.zip",
+    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/82/artifact/ModuleManager-2.5.6.zip",
     "license"        : "CC-BY-SA",
     "author"         : [ "ialdabaoth", "Sarbian" ],
     "version"        : "2.5.6",

--- a/ModuleManager/ModuleManager-2.5.8.ckan
+++ b/ModuleManager/ModuleManager-2.5.8.ckan
@@ -3,7 +3,7 @@
     "name"           : "Module Manager",
     "identifier"     : "ModuleManager",
     "abstract"       : "Modify KSP configs without conflict",
-    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/lastSuccessfulBuild/artifact/ModuleManager-2.5.8.zip",
+    "download"       : "https://ksp.sarbian.com/jenkins/job/ModuleManager/82/artifact/ModuleManager-2.5.8.zip",
     "license"        : "CC-BY-SA",
     "author"         : [ "ialdabaoth", "Sarbian" ],
     "version"        : "2.5.8",

--- a/ModuleManager/ModuleManager-2.5.9.ckan
+++ b/ModuleManager/ModuleManager-2.5.9.ckan
@@ -24,5 +24,5 @@
     "version": "2.5.9",
     "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/82/artifact/ModuleManager-2.5.9.zip",
     "x_generated_by": "not netkan",
-    "download_size": 24087
+    "download_size": 24088
 }

--- a/ModuleManager/ModuleManager-2.5.9.ckan
+++ b/ModuleManager/ModuleManager-2.5.9.ckan
@@ -22,7 +22,7 @@
         }
     ],
     "version": "2.5.9",
-    "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/lastStableBuild/artifact/ModuleManager-2.5.9.zip",
+    "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/82/artifact/ModuleManager-2.5.9.zip",
     "x_generated_by": "not netkan",
     "download_size": 24087
 }

--- a/NearFutureConstruction/NearFutureConstruction-0.3.1.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.3.1.ckan
@@ -11,6 +11,11 @@
     },
     "version": "0.3.1",
     "ksp_version": "0.25",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "CommunityTechTree"

--- a/NearFutureConstruction/NearFutureConstruction-0.4.0.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.4.0.ckan
@@ -11,6 +11,11 @@
     },
     "version": "0.4.0",
     "ksp_version": "0.90",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "CommunityTechTree"

--- a/NearFutureConstruction/NearFutureConstruction-0.5.0.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.5.0.ckan
@@ -13,6 +13,9 @@
     "ksp_version": "1.0.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "InterstellarFuelSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.5.1.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.5.1.ckan
@@ -13,6 +13,9 @@
     "ksp_version": "1.0.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "InterstellarFuelSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.5.2.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.5.2.ckan
@@ -13,6 +13,9 @@
     "ksp_version": "1.0.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "InterstellarFuelSwitch-Core"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.5.2.repackaged0.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.5.2.repackaged0.ckan
@@ -13,6 +13,9 @@
     "ksp_version": "1.0.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "InterstellarFuelSwitch-Core"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.5.3.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.5.3.ckan
@@ -14,6 +14,9 @@
     "ksp_version": "1.0.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "InterstellarFuelSwitch-Core"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.5.4.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.5.4.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.4",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "InterstellarFuelSwitch-Core"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.5.5.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.5.5.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "InterstellarFuelSwitch-Core"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.6.0.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.6.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.6.1.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.6.1.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.6.2.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.6.2.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.6.3.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.6.3.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.6.4.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.6.4.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.3",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.7.0.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.7.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.7.1.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.7.1.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.7.2.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.7.2.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.1",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.7.3.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.7.3.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.7.4.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.7.4.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.7.5.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.7.5.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.7.6.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.7.6.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.8.0.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.8.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.8.1.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.8.1.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.8.2.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.8.2.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.8.3.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.8.3.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-0.8.4.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-0.8.4.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.1",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-1.0.0.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-1.0.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.4.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-1.0.2.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-1.0.2.ckan
@@ -16,6 +16,9 @@
     "ksp_version_max": "1.4.9",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-1.0.3.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-1.0.3.ckan
@@ -16,6 +16,9 @@
     "ksp_version_max": "1.4.99",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-1.0.4.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-1.0.4.ckan
@@ -16,6 +16,9 @@
     "ksp_version_max": "1.5.99",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureConstruction/NearFutureConstruction-1.0.5.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-1.0.5.ckan
@@ -16,6 +16,9 @@
     "ksp_version_max": "1.6.99",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "B9PartSwitch"
         },
         {

--- a/NearFutureSolar/NearFutureSolar-0.3.1.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.3.1.ckan
@@ -11,6 +11,11 @@
     },
     "version": "0.3.1",
     "ksp_version": "0.25",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "CommunityTechTree"

--- a/NearFutureSolar/NearFutureSolar-0.4.0.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.4.0.ckan
@@ -11,6 +11,11 @@
     },
     "version": "0.4.0",
     "ksp_version": "0.90",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "CommunityTechTree"

--- a/NearFutureSolar/NearFutureSolar-0.5.0.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.5.0.ckan
@@ -11,6 +11,11 @@
     },
     "version": "0.5.0",
     "ksp_version": "1.0.0",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "CommunityTechTree"

--- a/NearFutureSolar/NearFutureSolar-0.5.1.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.5.1.ckan
@@ -11,6 +11,11 @@
     },
     "version": "0.5.1",
     "ksp_version": "1.0.0",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "CommunityTechTree"

--- a/NearFutureSolar/NearFutureSolar-0.5.2.1.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.5.2.1.ckan
@@ -13,6 +13,11 @@
     },
     "version": "0.5.2.1",
     "ksp_version": "1.0.2",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "CommunityTechTree"

--- a/NearFutureSolar/NearFutureSolar-0.5.2.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.5.2.ckan
@@ -11,6 +11,11 @@
     },
     "version": "0.5.2",
     "ksp_version": "1.0.2",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "CommunityTechTree"

--- a/NearFutureSolar/NearFutureSolar-0.5.3.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.5.3.ckan
@@ -14,6 +14,11 @@
     },
     "version": "0.5.3",
     "ksp_version": "1.0.4",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "CommunityTechTree"

--- a/NearFutureSolar/NearFutureSolar-0.5.4.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.5.4.ckan
@@ -14,6 +14,11 @@
     },
     "version": "0.5.4",
     "ksp_version": "1.0.5",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "CommunityTechTree"

--- a/NearFutureSolar/NearFutureSolar-0.5.5.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.5.5.ckan
@@ -16,6 +16,9 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.6.0.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.6.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.6.1.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.6.1.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.6.2.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.6.2.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.3",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.7.0.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.7.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.7.1.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.7.1.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.1",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.7.2.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.7.2.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.0.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.1.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.1.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.10.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.10.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.4.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.11.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.11.ckan
@@ -16,6 +16,9 @@
     "ksp_version_max": "1.4.9",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.12.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.12.ckan
@@ -16,6 +16,9 @@
     "ksp_version_max": "1.4.99",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.13.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.13.ckan
@@ -16,6 +16,9 @@
     "ksp_version_max": "1.5.99",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.14.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.14.ckan
@@ -16,6 +16,9 @@
     "ksp_version_max": "1.6.99",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.2.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.2.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.3.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.3.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.4.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.4.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.5.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.5.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.6.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.6.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.7.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.7.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.1",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.8.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.8.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.1",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],

--- a/NearFutureSolar/NearFutureSolar-0.8.9.ckan
+++ b/NearFutureSolar/NearFutureSolar-0.8.9.ckan
@@ -16,6 +16,9 @@
     "ksp_version_max": "1.4.2",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "NearFutureSolar-Core"
         }
     ],


### PR DESCRIPTION
NearFutureSolar and NearFutureConstruction both bundle ModuleManager and list it as required on their forum pages, but it's not a dependency in CKAN. This pull request adds it for historical versions.

Fixes KSP-CKAN/NetKAN#7091.

Also several old ModuleManager downloads used URLs including lastStableBuild or lastSuccessfulBuild. As you might imagine, these are "moving target" URLs that only include the desired artifact until another build is completed. Luckily all of the missing files seem to be in build 82, so they use that now:

https://ksp.sarbian.com/jenkins/job/ModuleManager/82/artifact/