### PR TITLE
Fix licenses for old versions of Tundra

### DIFF
--- a/TundraExploration/TundraExploration-0.7.2.ckan
+++ b/TundraExploration/TundraExploration-0.7.2.ckan
@@ -4,7 +4,7 @@
     "name": "Tundra Exploration - Stockalike Dragon V2 and Falcon 9",
     "abstract": "This is a mod that adds parts like the Dragon V2, Falcon 9 and more!",
     "author": "tygoo7",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/74988-wip105-tundra-exploration-v072-stockalike-dragon-v2-and-falcon-9/&page=1",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-0.8.1.ckan
+++ b/TundraExploration/TundraExploration-0.8.1.ckan
@@ -4,7 +4,7 @@
     "name": "Tundra Exploration - Stockalike Dragon V2 and Falcon 9",
     "abstract": "This is a mod that adds parts like the Dragon V2, Falcon 9 and more!",
     "author": "tygoo7",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/74988-wip105-tundra-exploration-v072-stockalike-dragon-v2-and-falcon-9/&page=1",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-0.8.5.ckan
+++ b/TundraExploration/TundraExploration-0.8.5.ckan
@@ -4,7 +4,7 @@
     "name": "Tundra Exploration - Stockalike Dragon V2 and Falcon 9",
     "abstract": "This is a mod that adds parts like the Dragon V2, Falcon 9 and more!",
     "author": "tygoo7",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/74988-wip105-tundra-exploration-v072-stockalike-dragon-v2-and-falcon-9/&page=1",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-0.8.6.ckan
+++ b/TundraExploration/TundraExploration-0.8.6.ckan
@@ -4,7 +4,7 @@
     "name": "Tundra Exploration - Stockalike Dragon V2 and Falcon 9",
     "abstract": "This is a mod that adds parts like the Dragon V2, Falcon 9 and more!",
     "author": "tygoo7",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/74988-wip105-tundra-exploration-v072-stockalike-dragon-v2-and-falcon-9/&page=1",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-0.8.ckan
+++ b/TundraExploration/TundraExploration-0.8.ckan
@@ -4,7 +4,7 @@
     "name": "Tundra Exploration - Stockalike Dragon V2 and Falcon 9",
     "abstract": "This is a mod that adds parts like the Dragon V2, Falcon 9 and more!",
     "author": "tygoo7",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/74988-wip105-tundra-exploration-v072-stockalike-dragon-v2-and-falcon-9/&page=1",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-0.9.2.ckan
+++ b/TundraExploration/TundraExploration-0.9.2.ckan
@@ -4,7 +4,7 @@
     "name": "Tundra Exploration - Stockalike Dragon V2 and Falcon 9",
     "abstract": "This is a mod that adds parts like the Dragon V2, Falcon 9 and more!",
     "author": "tygoo7",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/74988-wip105-tundra-exploration-v072-stockalike-dragon-v2-and-falcon-9/&page=1",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-0.9.3.ckan
+++ b/TundraExploration/TundraExploration-0.9.3.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-0.9.ckan
+++ b/TundraExploration/TundraExploration-0.9.ckan
@@ -4,7 +4,7 @@
     "name": "Tundra Exploration - Stockalike Dragon V2 and Falcon 9",
     "abstract": "This is a mod that adds parts like the Dragon V2, Falcon 9 and more!",
     "author": "tygoo7",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/74988-wip105-tundra-exploration-v072-stockalike-dragon-v2-and-falcon-9/&page=1",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.0.1.ckan
+++ b/TundraExploration/TundraExploration-1.0.1.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.0.2.ckan
+++ b/TundraExploration/TundraExploration-1.0.2.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.0.ckan
+++ b/TundraExploration/TundraExploration-1.0.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.1.0.ckan
+++ b/TundraExploration/TundraExploration-1.1.0.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.1.1.3.ckan
+++ b/TundraExploration/TundraExploration-1.1.1.3.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.1.2.1.ckan
+++ b/TundraExploration/TundraExploration-1.1.2.1.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.1.2.ckan
+++ b/TundraExploration/TundraExploration-1.1.2.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.1.3.1.ckan
+++ b/TundraExploration/TundraExploration-1.1.3.1.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.1.3.ckan
+++ b/TundraExploration/TundraExploration-1.1.3.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.1.4.0.ckan
+++ b/TundraExploration/TundraExploration-1.1.4.0.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.1.4.ckan
+++ b/TundraExploration/TundraExploration-1.1.4.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.2.0.0.ckan
+++ b/TundraExploration/TundraExploration-1.2.0.0.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.2.0.1.ckan
+++ b/TundraExploration/TundraExploration-1.2.0.1.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.2.1.ckan
+++ b/TundraExploration/TundraExploration-1.2.1.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.2.2.ckan
+++ b/TundraExploration/TundraExploration-1.2.2.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.3.0.2.ckan
+++ b/TundraExploration/TundraExploration-1.3.0.2.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.3.0.3.ckan
+++ b/TundraExploration/TundraExploration-1.3.0.3.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.3.0.5.ckan
+++ b/TundraExploration/TundraExploration-1.3.0.5.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.3.0.ckan
+++ b/TundraExploration/TundraExploration-1.3.0.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraExploration/TundraExploration-1.4.0.ckan
+++ b/TundraExploration/TundraExploration-1.4.0.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.1.3.1.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.1.3.1.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.1.4.0.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.1.4.0.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.1.4.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.1.4.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.2.0.0.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.2.0.0.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.2.0.1.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.2.0.1.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.2.1.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.2.1.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.2.2.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.2.2.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.3.0.2.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.3.0.2.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.3.0.3.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.3.0.3.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.3.0.5.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.3.0.5.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.3.0.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.3.0.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",

--- a/TundraTechnologies/TundraTechnologies-1.4.0.ckan
+++ b/TundraTechnologies/TundraTechnologies-1.4.0.ckan
@@ -7,7 +7,7 @@
         "tygoo7",
         "damon"
     ],
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166915-131-tundra-exploration-v093-stockalike-falcon-9-and-dragon-v2/",
         "spacedock": "https://spacedock.info/mod/223/Tundra%20Exploration%20-%20Stockalike%20Dragon%20V2%20and%20Falcon%209",


### PR DESCRIPTION
This mod uses CC-BY-NC-ND-4.0, but we had it as CC-BY-NC-SA-4.0.
KSP-CKAN/NetKAN#7127 fixed the netkan.
This pull request updates the old versions. 1.4.0.1 is left unchanged to allow the bot to handle it without conflicts.

Fixes KSP-CKAN/NetKAN#7125.