### PR TITLE
Add ABCORS 0.5.0.2 and update 0.5.0.3

### DIFF
--- a/ABCORS/ABCORS-0.5.0.2.ckan
+++ b/ABCORS/ABCORS-0.5.0.2.ckan
@@ -9,18 +9,19 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/172663-141-abookcase-orbital-reference-system-updated/",
         "repository": "https://github.com/linuxgurugamer/abcors"
     },
-    "version": "0.5.0.3",
+    "version": "0.5.0.2",
     "ksp_version_min": "1.5.1",
+    "ksp_version_max": "1.5.99",
     "suggests": [
         {
             "name": "KSP-AVC"
         }
     ],
-    "download": "https://github.com/linuxgurugamer/abcors/releases/download/0.5.0.3/ABCORS-0.5.0.3.zip",
-    "download_size": 25694,
+    "download": "https://github.com/linuxgurugamer/abcors/releases/download/0.5.0.2/ABCORS-0.5.0.2.zip",
+    "download_size": 24729,
     "download_hash": {
-        "sha1": "BE175232B52B0E2A34812C1142196D80FF867F0D",
-        "sha256": "B158C20A19A09DF8AC3CF0122E7CD3556AF60B2A46F77AC5279249DA454FDCAA"
+        "sha1": "8E15ED277F5EC215549D34B66DC786BD56D6D183",
+        "sha256": "97763B8785626E4177E41162FFCCCEFEBFD68FA9D3D3787AF7F94F24EDF91507"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
ABCORS 0.5.0.3 has invalid hashes and file size.
ABCORS 0.5.0.2 is missing.
Closes https://github.com/KSP-CKAN/NetKAN/issues/7124