### PR TITLE
Make old TRR provide TR

### DIFF
--- a/TextureReplacerReplaced/TextureReplacerReplaced-V0.5.3.ckan
+++ b/TextureReplacerReplaced/TextureReplacerReplaced-V0.5.3.ckan
@@ -18,6 +18,9 @@
     "version": "V0.5.3",
     "ksp_version_min": "1.3.1",
     "ksp_version_max": "1.3.9",
+    "provides": [
+        "TextureReplacer"
+    ],
     "depends": [
         {
             "name": "ModuleManager"


### PR DESCRIPTION
See KSP-CKAN/NetKAN#7149 for details; TextureReplacerReplaced should provide TextureReplacer, and one version of it (still) doesn't.

Fixes another part of KSP-CKAN/CKAN#2738.