### PR TITLE
RN fix some things for RO

### DIFF
--- a/RealismOverhaul/RealismOverhaul-v12.6.0.ckan
+++ b/RealismOverhaul/RealismOverhaul-v12.6.0.ckan
@@ -88,9 +88,6 @@
             "name": "KSCSwitcher"
         },
         {
-            "name": "RealismOverhaulCraftFiles"
-        },
-        {
             "name": "RemoteTech"
         },
         {
@@ -109,13 +106,16 @@
             "name": "Toolbar"
         },
         {
-            "name": "ROEngines"
-        },
-        {
             "name": "VenStockRevamp"
         }
     ],
     "suggests": [
+		{
+            "name": "RealismOverhaulCraftFiles"
+        },
+		{
+            "name": "ROEngines"
+        },
         {
             "name": "DMagicOrbitalScience"
         },

--- a/RealismOverhaulCraftFiles/RealismOverhaulCraftFiles-v12.6.0.ckan
+++ b/RealismOverhaulCraftFiles/RealismOverhaulCraftFiles-v12.6.0.ckan
@@ -45,6 +45,11 @@
             "name": "NewTantares"
         }
     ],
+	"conflicts": [
+        {
+            "name": "ROEngines"
+        }
+    ],
     "install": [
         {
             "file": "Ships/VAB",


### PR DESCRIPTION
-move roengines and craft files to suggested, this was a mistake and
should've been fixed before release.
-Add roengines as a conflict to rocraftfiles as the roengines mod
changes part names and breaks the craft files if you have both
installed. This was also supposed to be fixed before release.