### PR TITLE
Update old InnerLock versions

### DIFF
--- a/InnerLock/InnerLock-0.0.4_ksp-1.3.1.ckan
+++ b/InnerLock/InnerLock-0.0.4_ksp-1.3.1.ckan
@@ -11,7 +11,17 @@
         "repository": "https://github.com/whale2/InnerLock"
     },
     "version": "0.0.4_ksp-1.3.1",
-    "ksp_version": "1.3.1",
+    "ksp_version": "1.3",
+    "install": [
+        {
+            "find": "InnerLock",
+            "install_to": "GameData"
+        },
+        {
+            "find": "MagicSmokeIndustries",
+            "install_to": "GameData"
+        }
+    ],
     "download": "https://spacedock.info/mod/2113/InnerLock/download/0.0.4_ksp-1.3.1",
     "download_size": 150468,
     "download_hash": {

--- a/InnerLock/InnerLock-0.0.4_ksp-1.5.1.ckan
+++ b/InnerLock/InnerLock-0.0.4_ksp-1.5.1.ckan
@@ -11,7 +11,17 @@
         "repository": "https://github.com/whale2/InnerLock"
     },
     "version": "0.0.4_ksp-1.5.1",
-    "ksp_version": "1.5.1",
+    "ksp_version": "1.5",
+    "install": [
+        {
+            "find": "InnerLock",
+            "install_to": "GameData"
+        },
+        {
+            "find": "MagicSmokeIndustries",
+            "install_to": "GameData"
+        }
+    ],
     "download": "https://spacedock.info/mod/2113/InnerLock/download/0.0.4_ksp-1.5.1",
     "download_size": 150552,
     "download_hash": {


### PR DESCRIPTION
@DasSkelett pointed out that #1434 added two .ckan files to the root folder of the repo. Now they're moved to the InnerLock folder.

KSP-CKAN/NetKAN#7212 added an install stanza to handle a missing folder and added support for InnerLock's version file. Now these changes are applied to the older versions as well.