### PR TITLE
Backfill missing versions for IFS, IFSCore, and PhotonSailor

### DIFF
--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.16.0.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.16.0.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.16.0",
+    "ksp_version": "1.3.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.16.0",
+    "download_size": 8771055,
+    "download_hash": {
+        "sha1": "F25C4139A90FF425E4BF2571DB1C7725B9D086D6",
+        "sha256": "DDB228E103415B96721068554559C73ED986C6415FAA8A2EA89DDFF4B9578A5A"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.16.1.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.16.1.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.16.1",
+    "ksp_version": "1.4.5",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.16.1",
+    "download_size": 8913626,
+    "download_hash": {
+        "sha1": "26C15567FD2C0E30904462FB40630955BE3C2245",
+        "sha256": "74FB7748BED8C8F0C33B513807F790D914AF41D650B43D212DF6A194190A9C83"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.17.0.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.17.0.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.17.0",
+    "ksp_version": "1.3.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.17.0",
+    "download_size": 8921773,
+    "download_hash": {
+        "sha1": "99C0EB5AEE3B2C6757ED1839101003563DC3E39A",
+        "sha256": "9CC2B87948D9D4226D88F2D7FC744F5DC13AD0E646FDFA477FF950C6EEEB1D0B"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.17.1.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.17.1.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.17.1",
+    "ksp_version": "1.4.5",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.17.1",
+    "download_size": 8916509,
+    "download_hash": {
+        "sha1": "C16334CA0865F197F1EFAFCA37C3E8BDFEDDAF39",
+        "sha256": "F5CC4B6DECAE5E75394697E99AFCB19714D040D0A387BC089F3153EA1DF435F9"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.18.0.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.18.0.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.18.0",
+    "ksp_version": "1.3.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.18.0",
+    "download_size": 9284777,
+    "download_hash": {
+        "sha1": "BD8CF4825ED33EA8AB8AD9072F1ECE73BB885E9D",
+        "sha256": "EEAD7FDFD069ADE895FF7E7695A405D223398C0A36125931D18D287A913AA1C2"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.18.1.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.18.1.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.18.1",
+    "ksp_version": "1.4.5",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.18.1",
+    "download_size": 9279496,
+    "download_hash": {
+        "sha1": "FD0650CFB2BA9CE4271376FF87B0AC0D15F2284C",
+        "sha256": "5FD9D21B69E8922B2E271D2A2961CEB28D287AAF5591CA943C370B70C2478F01"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.18.2.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.6.18.2.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.18.2",
+    "ksp_version": "1.5.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.18.2",
+    "download_size": 9301885,
+    "download_hash": {
+        "sha1": "ADA267335CAED374C6E9E58E02D3D04D445B1886",
+        "sha256": "478F99AA60381D8E02978A3DB637ADE38EFEA7398BB0D9DFA0BE4E1EA0B00F55"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.0.0.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.0.0.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.0.0",
+    "ksp_version": "1.3.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.0.0",
+    "download_size": 9289879,
+    "download_hash": {
+        "sha1": "BE8438EEE82BBCAD67B2DCD3BB1FE296FCDA7515",
+        "sha256": "E031CE86C57243632F716D452F0C06C5837CF319CCE93BF0F0A7ACCC84F3C514"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.0.1.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.0.1.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.0.1",
+    "ksp_version": "1.4.5",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.0.1",
+    "download_size": 9284601,
+    "download_hash": {
+        "sha1": "4E251EB4183F08F624D039F1178E6E37839B612B",
+        "sha256": "C2AD79AA9622C26908C757E732CE3DB972BB663B42D0B692719EEBDFB6F7DDB6"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.0.2.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.0.2.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.0.2",
+    "ksp_version": "1.5.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.0.2",
+    "download_size": 9306993,
+    "download_hash": {
+        "sha1": "0809BBAE1FB647787E7B9EAE428F29E923E9FCBC",
+        "sha256": "9DC69370F19206B3B4E8DB837F8EDB47EC7DCC745A14E15A1F1E663023BCFAE3"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.1.0.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.1.0.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.1.0",
+    "ksp_version": "1.3.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.1.0",
+    "download_size": 9313677,
+    "download_hash": {
+        "sha1": "BAD1D3BA886F8A0BFFEF7DADD30BD326AC500E2F",
+        "sha256": "6C0E37DD2F85DC57426F64E1ADFB0941A2D730651B844745AD58F78F6DF23C60"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.1.1.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.1.1.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.1.1",
+    "ksp_version": "1.4.5",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.1.1",
+    "download_size": 9308397,
+    "download_hash": {
+        "sha1": "80B07D3F85E5D35F7F3F80B83F7B1D6DEC163F03",
+        "sha256": "3069C11CA13643C2FA58C661D0B558E5A41B2FA1004F82A0F638A8DCD2D4346B"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.1.2.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.7.1.2.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.1.2",
+    "ksp_version": "1.5.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.1.2",
+    "download_size": 9330787,
+    "download_hash": {
+        "sha1": "34E633A0A0BC04DB8473C45EE7F5007711F7B21B",
+        "sha256": "B0A2B5718664BCBD00FE6937FC8739315166E4CD8C0C7C2D4F8D135F9A2F8EB8"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.0.0.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.0.0.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.0.0",
+    "ksp_version": "1.3.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.0.0",
+    "download_size": 9314786,
+    "download_hash": {
+        "sha1": "8F1A4B1E0A1DB44F4A7DE9C8C1C2E0A33108B4D2",
+        "sha256": "FF925ECEBF95DD0E782256CAB90406ACC586D781A6CAB32C35A8EC96B312CFF5"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.0.1.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.0.1.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.0.1",
+    "ksp_version": "1.4.5",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.0.1",
+    "download_size": 9309479,
+    "download_hash": {
+        "sha1": "FAB167423BE593DA8B34FD7F10B7DFA3412DB64C",
+        "sha256": "C60708AB02C6C9AF301BB4AA84B865CFCEBFC7BAA5D6C3ADC3875A8279B2AAD8"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.0.2.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.0.2.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.0.2",
+    "ksp_version": "1.5.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.0.2",
+    "download_size": 9331863,
+    "download_hash": {
+        "sha1": "718F9E4473DA47FBBAF9625214162C2219D0B0B1",
+        "sha256": "116CBFBA7D8E80DCCA9918DE8829C17672E6990DE61FF7FA48333DF71ABDD82B"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.2.0.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.2.0.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.2.0",
+    "ksp_version": "1.3.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.2.0",
+    "download_size": 9332223,
+    "download_hash": {
+        "sha1": "80946B90F7AD18E9815F15853FB67283C2BE026B",
+        "sha256": "D9F766EDD8EF233C97B913F3C38856C74D8F0517A301EEB8D7104E53F7CD4CFA"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.2.1.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.2.1.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.2.1",
+    "ksp_version": "1.4.5",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.2.1",
+    "download_size": 9330924,
+    "download_hash": {
+        "sha1": "8756E19067AA15E4D142A3132EC2E3D2D45597FF",
+        "sha256": "B4AB1143744B867C414A2C380979A78452EEFD9D8A78CEB5D164052631FD0BBD"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.2.2.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.2.2.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.2.2",
+    "ksp_version": "1.5.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.2.2",
+    "download_size": 9351198,
+    "download_hash": {
+        "sha1": "872DC45C34D9823599DE293B192C0CA9428AE00C",
+        "sha256": "E20AD88B1EBC6AB18DD8FFE658C833306F15CC6700B04ABE8960A1B20B95CC26"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.2.3.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.2.3.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.2.3",
+    "ksp_version": "1.6.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.2.3",
+    "download_size": 9357616,
+    "download_hash": {
+        "sha1": "E9D85A96C68140D3F2A91E1BF6B3ABA8107A4077",
+        "sha256": "DBBA7D813D168E366D7924A5C140634BE604320FA8665EBFBD8FD0A85D225A73"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.3.0.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.3.0.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.3.0",
+    "ksp_version": "1.3.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.3.0",
+    "download_size": 9332825,
+    "download_hash": {
+        "sha1": "1470C2E7041041775A67C2B3C09EF62A36E2A169",
+        "sha256": "1BB462326B0567D38760CC8BFE29D9019B297734E7F105439D690E4C61A8E872"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.3.1.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.3.1.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.3.1",
+    "ksp_version": "1.4.5",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.3.1",
+    "download_size": 9331544,
+    "download_hash": {
+        "sha1": "C108F7785A14ACE8DC0A3A3549F67BC4101E12FD",
+        "sha256": "5003558A236839129C16253E77409176B73BEDC39615D2643171AE4372B901B5"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.3.2.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.3.2.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.3.2",
+    "ksp_version": "1.5.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.3.2",
+    "download_size": 9351819,
+    "download_hash": {
+        "sha1": "7F81C8FD329E60AE829380FB705D86A7BAF10C35",
+        "sha256": "1F6976F0C9C62A20131F5BABB4DD45AA2B432F4A73F2A94708D0E4B68628EA02"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.3.3.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.3.3.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.3.3",
+    "ksp_version": "1.6.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.3.3",
+    "download_size": 9358238,
+    "download_hash": {
+        "sha1": "35AFCFC5A14A2F2502EE1DADE10672E425EB3E02",
+        "sha256": "50A9999E939B8554DE198FB623F3EBFB0875E06CCD7A9E61E7CCD818B14949DF"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.4.0.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.4.0.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.4.0",
+    "ksp_version": "1.3.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.4.0",
+    "download_size": 9331864,
+    "download_hash": {
+        "sha1": "BDDEC055BB07008A370E3B6AD5F5DC31ECABE2CF",
+        "sha256": "4ACAFC203FE34AFD0E92B2E2303D9C9DDE9EBFCF0AFCC85426488F9D357AEBDD"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.4.1.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.4.1.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.4.1",
+    "ksp_version": "1.4.5",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.4.1",
+    "download_size": 9330581,
+    "download_hash": {
+        "sha1": "EE442B79D2DA563EB1FF1C6CFD511D2CB8CA04E7",
+        "sha256": "177DC5AFDF5DA9732C8CBF5EC5D0DED29D2BB30FC01E33EA76DBD256DDA0F489"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.4.3.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.4.3.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.4.3",
+    "ksp_version": "1.6.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.4.3",
+    "download_size": 9357278,
+    "download_hash": {
+        "sha1": "208CF1FDC36DF9ADC7C64D8F3888A1CA4A8654AC",
+        "sha256": "F8563993C5771E447D8B52762BA6022D07D0FD70BCEB0CD6D94EF0C6A6123D6C"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.4.ckan
+++ b/InterstellarFuelSwitch-Core/InterstellarFuelSwitch-Core-3.8.4.ckan
@@ -1,0 +1,51 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch-Core",
+    "name": "Interstellar Fuel Switch Core",
+    "abstract": "Core plugin for Interstellar Fuel Switch",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.4",
+    "ksp_version": "1.5.1",
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "recommends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.7.1"
+        },
+        {
+            "name": "TweakScale",
+            "min_version": "2.3.6"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch/Plugins",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Resources",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        },
+        {
+            "find": "InterstellarFuelSwitch/Localization",
+            "install_to": "GameData/InterstellarFuelSwitch"
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.4",
+    "download_size": 9350864,
+    "download_hash": {
+        "sha1": "03133B479A5F843EEAEB2D51E3860DB12F6479DF",
+        "sha256": "288513CF32ACCD00E4B06C55D48C22F1196999CAF7B1D6639A609EE3275C549D"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.16.0.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.16.0.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.16.0",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.16.0",
+    "download_size": 8771055,
+    "download_hash": {
+        "sha1": "F25C4139A90FF425E4BF2571DB1C7725B9D086D6",
+        "sha256": "DDB228E103415B96721068554559C73ED986C6415FAA8A2EA89DDFF4B9578A5A"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.16.1.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.16.1.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.16.1",
+    "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.16.1",
+    "download_size": 8913626,
+    "download_hash": {
+        "sha1": "26C15567FD2C0E30904462FB40630955BE3C2245",
+        "sha256": "74FB7748BED8C8F0C33B513807F790D914AF41D650B43D212DF6A194190A9C83"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.17.0.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.17.0.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.17.0",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.17.0",
+    "download_size": 8921773,
+    "download_hash": {
+        "sha1": "99C0EB5AEE3B2C6757ED1839101003563DC3E39A",
+        "sha256": "9CC2B87948D9D4226D88F2D7FC744F5DC13AD0E646FDFA477FF950C6EEEB1D0B"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.17.1.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.17.1.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.17.1",
+    "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.17.1",
+    "download_size": 8916509,
+    "download_hash": {
+        "sha1": "C16334CA0865F197F1EFAFCA37C3E8BDFEDDAF39",
+        "sha256": "F5CC4B6DECAE5E75394697E99AFCB19714D040D0A387BC089F3153EA1DF435F9"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.18.0.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.18.0.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.18.0",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.18.0",
+    "download_size": 9284777,
+    "download_hash": {
+        "sha1": "BD8CF4825ED33EA8AB8AD9072F1ECE73BB885E9D",
+        "sha256": "EEAD7FDFD069ADE895FF7E7695A405D223398C0A36125931D18D287A913AA1C2"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.18.1.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.18.1.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.18.1",
+    "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.18.1",
+    "download_size": 9279496,
+    "download_hash": {
+        "sha1": "FD0650CFB2BA9CE4271376FF87B0AC0D15F2284C",
+        "sha256": "5FD9D21B69E8922B2E271D2A2961CEB28D287AAF5591CA943C370B70C2478F01"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.18.2.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.6.18.2.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.6.18.2",
+    "ksp_version": "1.5.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.6.18.2",
+    "download_size": 9301885,
+    "download_hash": {
+        "sha1": "ADA267335CAED374C6E9E58E02D3D04D445B1886",
+        "sha256": "478F99AA60381D8E02978A3DB637ADE38EFEA7398BB0D9DFA0BE4E1EA0B00F55"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.0.0.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.0.0.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.0.0",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.0.0",
+    "download_size": 9289879,
+    "download_hash": {
+        "sha1": "BE8438EEE82BBCAD67B2DCD3BB1FE296FCDA7515",
+        "sha256": "E031CE86C57243632F716D452F0C06C5837CF319CCE93BF0F0A7ACCC84F3C514"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.0.1.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.0.1.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.0.1",
+    "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.0.1",
+    "download_size": 9284601,
+    "download_hash": {
+        "sha1": "4E251EB4183F08F624D039F1178E6E37839B612B",
+        "sha256": "C2AD79AA9622C26908C757E732CE3DB972BB663B42D0B692719EEBDFB6F7DDB6"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.0.2.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.0.2.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.0.2",
+    "ksp_version": "1.5.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.0.2",
+    "download_size": 9306993,
+    "download_hash": {
+        "sha1": "0809BBAE1FB647787E7B9EAE428F29E923E9FCBC",
+        "sha256": "9DC69370F19206B3B4E8DB837F8EDB47EC7DCC745A14E15A1F1E663023BCFAE3"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.1.0.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.1.0.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.1.0",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.1.0",
+    "download_size": 9313677,
+    "download_hash": {
+        "sha1": "BAD1D3BA886F8A0BFFEF7DADD30BD326AC500E2F",
+        "sha256": "6C0E37DD2F85DC57426F64E1ADFB0941A2D730651B844745AD58F78F6DF23C60"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.1.1.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.1.1.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.1.1",
+    "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.1.1",
+    "download_size": 9308397,
+    "download_hash": {
+        "sha1": "80B07D3F85E5D35F7F3F80B83F7B1D6DEC163F03",
+        "sha256": "3069C11CA13643C2FA58C661D0B558E5A41B2FA1004F82A0F638A8DCD2D4346B"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.1.2.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.7.1.2.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.7.1.2",
+    "ksp_version": "1.5.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.7.1.2",
+    "download_size": 9330787,
+    "download_hash": {
+        "sha1": "34E633A0A0BC04DB8473C45EE7F5007711F7B21B",
+        "sha256": "B0A2B5718664BCBD00FE6937FC8739315166E4CD8C0C7C2D4F8D135F9A2F8EB8"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.0.0.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.0.0.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.0.0",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.0.0",
+    "download_size": 9314786,
+    "download_hash": {
+        "sha1": "8F1A4B1E0A1DB44F4A7DE9C8C1C2E0A33108B4D2",
+        "sha256": "FF925ECEBF95DD0E782256CAB90406ACC586D781A6CAB32C35A8EC96B312CFF5"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.0.1.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.0.1.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.0.1",
+    "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.0.1",
+    "download_size": 9309479,
+    "download_hash": {
+        "sha1": "FAB167423BE593DA8B34FD7F10B7DFA3412DB64C",
+        "sha256": "C60708AB02C6C9AF301BB4AA84B865CFCEBFC7BAA5D6C3ADC3875A8279B2AAD8"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.0.2.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.0.2.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.0.2",
+    "ksp_version": "1.5.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.0.2",
+    "download_size": 9331863,
+    "download_hash": {
+        "sha1": "718F9E4473DA47FBBAF9625214162C2219D0B0B1",
+        "sha256": "116CBFBA7D8E80DCCA9918DE8829C17672E6990DE61FF7FA48333DF71ABDD82B"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.2.0.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.2.0.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.2.0",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.2.0",
+    "download_size": 9332223,
+    "download_hash": {
+        "sha1": "80946B90F7AD18E9815F15853FB67283C2BE026B",
+        "sha256": "D9F766EDD8EF233C97B913F3C38856C74D8F0517A301EEB8D7104E53F7CD4CFA"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.2.1.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.2.1.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.2.1",
+    "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.2.1",
+    "download_size": 9330924,
+    "download_hash": {
+        "sha1": "8756E19067AA15E4D142A3132EC2E3D2D45597FF",
+        "sha256": "B4AB1143744B867C414A2C380979A78452EEFD9D8A78CEB5D164052631FD0BBD"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.2.2.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.2.2.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.2.2",
+    "ksp_version": "1.5.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.2.2",
+    "download_size": 9351198,
+    "download_hash": {
+        "sha1": "872DC45C34D9823599DE293B192C0CA9428AE00C",
+        "sha256": "E20AD88B1EBC6AB18DD8FFE658C833306F15CC6700B04ABE8960A1B20B95CC26"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.2.3.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.2.3.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.2.3",
+    "ksp_version": "1.6.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.2.3",
+    "download_size": 9357616,
+    "download_hash": {
+        "sha1": "E9D85A96C68140D3F2A91E1BF6B3ABA8107A4077",
+        "sha256": "DBBA7D813D168E366D7924A5C140634BE604320FA8665EBFBD8FD0A85D225A73"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.3.0.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.3.0.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.3.0",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.3.0",
+    "download_size": 9332825,
+    "download_hash": {
+        "sha1": "1470C2E7041041775A67C2B3C09EF62A36E2A169",
+        "sha256": "1BB462326B0567D38760CC8BFE29D9019B297734E7F105439D690E4C61A8E872"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.3.1.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.3.1.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.3.1",
+    "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.3.1",
+    "download_size": 9331544,
+    "download_hash": {
+        "sha1": "C108F7785A14ACE8DC0A3A3549F67BC4101E12FD",
+        "sha256": "5003558A236839129C16253E77409176B73BEDC39615D2643171AE4372B901B5"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.3.2.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.3.2.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.3.2",
+    "ksp_version": "1.5.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.3.2",
+    "download_size": 9351819,
+    "download_hash": {
+        "sha1": "7F81C8FD329E60AE829380FB705D86A7BAF10C35",
+        "sha256": "1F6976F0C9C62A20131F5BABB4DD45AA2B432F4A73F2A94708D0E4B68628EA02"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.3.3.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.3.3.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.3.3",
+    "ksp_version": "1.6.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.3.3",
+    "download_size": 9358238,
+    "download_hash": {
+        "sha1": "35AFCFC5A14A2F2502EE1DADE10672E425EB3E02",
+        "sha256": "50A9999E939B8554DE198FB623F3EBFB0875E06CCD7A9E61E7CCD818B14949DF"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.4.0.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.4.0.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.4.0",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.4.0",
+    "download_size": 9331864,
+    "download_hash": {
+        "sha1": "BDDEC055BB07008A370E3B6AD5F5DC31ECABE2CF",
+        "sha256": "4ACAFC203FE34AFD0E92B2E2303D9C9DDE9EBFCF0AFCC85426488F9D357AEBDD"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.4.1.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.4.1.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.4.1",
+    "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.4.1",
+    "download_size": 9330581,
+    "download_hash": {
+        "sha1": "EE442B79D2DA563EB1FF1C6CFD511D2CB8CA04E7",
+        "sha256": "177DC5AFDF5DA9732C8CBF5EC5D0DED29D2BB30FC01E33EA76DBD256DDA0F489"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.4.3.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.4.3.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.4.3",
+    "ksp_version": "1.6.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.4.3",
+    "download_size": 9357278,
+    "download_hash": {
+        "sha1": "208CF1FDC36DF9ADC7C64D8F3888A1CA4A8654AC",
+        "sha256": "F8563993C5771E447D8B52762BA6022D07D0FD70BCEB0CD6D94EF0C6A6123D6C"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.4.ckan
+++ b/InterstellarFuelSwitch/InterstellarFuelSwitch-3.8.4.ckan
@@ -1,0 +1,56 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "InterstellarFuelSwitch",
+    "name": "Interstellar Fuel Switch",
+    "abstract": "Library that enables switching the contents, meshes, and textures of tanks.",
+    "author": "FreeThinker",
+    "license": "GPL-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106243-105interstellar-fuel-switch-118-updated-10-11-2015/",
+        "spacedock": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch",
+        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues",
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Interstellar_Fuel_Switch/Interstellar_Fuel_Switch-1481278354.0821617.jpg"
+    },
+    "version": "3.8.4",
+    "ksp_version": "1.5.1",
+    "depends": [
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.5.1"
+        },
+        {
+            "name": "InterstellarFuelSwitch-Core",
+            "min_version": "1.28"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KSPInterstellarExtended"
+        },
+        {
+            "name": "PatchManager"
+        }
+    ],
+    "install": [
+        {
+            "find": "InterstellarFuelSwitch",
+            "install_to": "GameData",
+            "filter": [
+                "Plugins",
+                "Resources",
+                "Localization"
+            ]
+        }
+    ],
+    "download": "https://spacedock.info/mod/175/Interstellar%20Fuel%20Switch/download/3.8.4",
+    "download_size": 9350864,
+    "download_hash": {
+        "sha1": "03133B479A5F843EEAEB2D51E3860DB12F6479DF",
+        "sha256": "288513CF32ACCD00E4B06C55D48C22F1196999CAF7B1D6639A609EE3275C549D"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/PhotonSailor/PhotonSailor-1.1.1.ckan
+++ b/PhotonSailor/PhotonSailor-1.1.1.ckan
@@ -9,19 +9,35 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/176144-*",
         "spacedock": "https://spacedock.info/mod/1895/Photon%20Sailor",
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
-        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Photon_Sailor/Photon_Sailor-1530001785.2104235.png"
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Photon_Sailor/Photon_Sailor-1531575477.7373607.png"
     },
     "version": "1.1.1",
     "ksp_version": "1.4.3",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "recommends": [
         {
             "name": "PersistentRotation"
         },
         {
-            "name": "KSPInterstellarExtended"
+            "name": "KSPInterstellarExtended",
+            "min_version": "1.19.3"
         },
         {
             "name": "SolarSailNavigator"
+        },
+        {
+            "name": "TexturesUnlimited"
+        },
+        {
+            "name": "TweakScale"
+        },
+        {
+            "name": "CommunityTechTree",
+            "min_version": "1:3.3.2"
         }
     ],
     "install": [

--- a/PhotonSailor/PhotonSailor-1.2.ckan
+++ b/PhotonSailor/PhotonSailor-1.2.ckan
@@ -9,7 +9,7 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/176144-*",
         "spacedock": "https://spacedock.info/mod/1895/Photon%20Sailor",
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
-        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Photon_Sailor/Photon_Sailor-1530001785.2104235.png"
+        "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Photon_Sailor/Photon_Sailor-1531575477.7373607.png"
     },
     "version": "1.2",
     "ksp_version": "1.4.3",
@@ -34,6 +34,10 @@
         },
         {
             "name": "TweakScale"
+        },
+        {
+            "name": "CommunityTechTree",
+            "min_version": "1:3.3.2"
         }
     ],
     "install": [

--- a/PhotonSailor/PhotonSailor-1.4.7.0.ckan
+++ b/PhotonSailor/PhotonSailor-1.4.7.0.ckan
@@ -11,9 +11,8 @@
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Photon_Sailor/Photon_Sailor-1531575477.7373607.png"
     },
-    "version": "1.3",
-    "ksp_version_min": "1.4.3",
-    "ksp_version_max": "1.4.4",
+    "version": "1.4.7.0",
+    "ksp_version": "1.3.1",
     "depends": [
         {
             "name": "ModuleManager"
@@ -47,11 +46,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.3",
-    "download_size": 2190684,
+    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.4.7.0",
+    "download_size": 6529376,
     "download_hash": {
-        "sha1": "A494DF05A99FE8233077A82707238769FF21DE7D",
-        "sha256": "06ED6FF1C29044DC57796B79455ECB160EBA749EBB6F422569DE07320CA25299"
+        "sha1": "C320C199E1AAD02B95C27E9C1A1CB4B125B80534",
+        "sha256": "2A2BCBD5F2C26CE9F3A9DAB43C02ACDCC035CAA7F49CE252B9613C5B50E2F3B2"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/PhotonSailor/PhotonSailor-1.4.7.1.ckan
+++ b/PhotonSailor/PhotonSailor-1.4.7.1.ckan
@@ -11,9 +11,8 @@
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Photon_Sailor/Photon_Sailor-1531575477.7373607.png"
     },
-    "version": "1.3",
-    "ksp_version_min": "1.4.3",
-    "ksp_version_max": "1.4.4",
+    "version": "1.4.7.1",
+    "ksp_version": "1.4.5",
     "depends": [
         {
             "name": "ModuleManager"
@@ -47,11 +46,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.3",
-    "download_size": 2190684,
+    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.4.7.1",
+    "download_size": 6529371,
     "download_hash": {
-        "sha1": "A494DF05A99FE8233077A82707238769FF21DE7D",
-        "sha256": "06ED6FF1C29044DC57796B79455ECB160EBA749EBB6F422569DE07320CA25299"
+        "sha1": "1DED591899D4C1B676A0D0040FDF9BA466D76A28",
+        "sha256": "9BDA88A900FD0F326518701794468C73F438FFFF82C8EF935D09682A9AC4575C"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/PhotonSailor/PhotonSailor-1.4.7.2.ckan
+++ b/PhotonSailor/PhotonSailor-1.4.7.2.ckan
@@ -11,9 +11,8 @@
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Photon_Sailor/Photon_Sailor-1531575477.7373607.png"
     },
-    "version": "1.3",
-    "ksp_version_min": "1.4.3",
-    "ksp_version_max": "1.4.4",
+    "version": "1.4.7.2",
+    "ksp_version": "1.5.1",
     "depends": [
         {
             "name": "ModuleManager"
@@ -47,11 +46,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.3",
-    "download_size": 2190684,
+    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.4.7.2",
+    "download_size": 6529351,
     "download_hash": {
-        "sha1": "A494DF05A99FE8233077A82707238769FF21DE7D",
-        "sha256": "06ED6FF1C29044DC57796B79455ECB160EBA749EBB6F422569DE07320CA25299"
+        "sha1": "FB54C2AB497566FF294634DB247D12ECC4E958FA",
+        "sha256": "67774538304E3BF44FF8C66F1B4B6D750AC615ED27D8D80C1D6801BEC4FA6365"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/PhotonSailor/PhotonSailor-1.4.8.0.ckan
+++ b/PhotonSailor/PhotonSailor-1.4.8.0.ckan
@@ -11,9 +11,8 @@
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Photon_Sailor/Photon_Sailor-1531575477.7373607.png"
     },
-    "version": "1.3",
-    "ksp_version_min": "1.4.3",
-    "ksp_version_max": "1.4.4",
+    "version": "1.4.8.0",
+    "ksp_version": "1.3.1",
     "depends": [
         {
             "name": "ModuleManager"
@@ -47,11 +46,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.3",
-    "download_size": 2190684,
+    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.4.8.0",
+    "download_size": 8779165,
     "download_hash": {
-        "sha1": "A494DF05A99FE8233077A82707238769FF21DE7D",
-        "sha256": "06ED6FF1C29044DC57796B79455ECB160EBA749EBB6F422569DE07320CA25299"
+        "sha1": "5C4568E5DE6801F2386FD6F79FAACFE930D3908F",
+        "sha256": "EBFD7ABB54D846B6C6FD20B9967B5904E4121432564138366E0F7FF52FAD1283"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/PhotonSailor/PhotonSailor-1.4.8.1.ckan
+++ b/PhotonSailor/PhotonSailor-1.4.8.1.ckan
@@ -11,9 +11,8 @@
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Photon_Sailor/Photon_Sailor-1531575477.7373607.png"
     },
-    "version": "1.3",
-    "ksp_version_min": "1.4.3",
-    "ksp_version_max": "1.4.4",
+    "version": "1.4.8.1",
+    "ksp_version": "1.4.5",
     "depends": [
         {
             "name": "ModuleManager"
@@ -47,11 +46,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.3",
-    "download_size": 2190684,
+    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.4.8.1",
+    "download_size": 8779145,
     "download_hash": {
-        "sha1": "A494DF05A99FE8233077A82707238769FF21DE7D",
-        "sha256": "06ED6FF1C29044DC57796B79455ECB160EBA749EBB6F422569DE07320CA25299"
+        "sha1": "8C2FA964FE24500A569189267DDD49937D4767CB",
+        "sha256": "EF5BB84640C69A260A3DCF59D4A2D774E3F8CD6A8C7AD737B416ADD7143494D1"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/PhotonSailor/PhotonSailor-1.4.8.2.ckan
+++ b/PhotonSailor/PhotonSailor-1.4.8.2.ckan
@@ -11,9 +11,8 @@
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Photon_Sailor/Photon_Sailor-1531575477.7373607.png"
     },
-    "version": "1.3",
-    "ksp_version_min": "1.4.3",
-    "ksp_version_max": "1.4.4",
+    "version": "1.4.8.2",
+    "ksp_version": "1.5.1",
     "depends": [
         {
             "name": "ModuleManager"
@@ -47,11 +46,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.3",
-    "download_size": 2190684,
+    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.4.8.2",
+    "download_size": 8779149,
     "download_hash": {
-        "sha1": "A494DF05A99FE8233077A82707238769FF21DE7D",
-        "sha256": "06ED6FF1C29044DC57796B79455ECB160EBA749EBB6F422569DE07320CA25299"
+        "sha1": "472EC88C6490A32B21415A2AD986910D8AD4761B",
+        "sha256": "E92C0117F987D88C77CA1EFDA10974C799B68EC09F8C42646B6DC39F21E433CD"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/PhotonSailor/PhotonSailor-1.4.8.3.ckan
+++ b/PhotonSailor/PhotonSailor-1.4.8.3.ckan
@@ -11,9 +11,8 @@
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Photon_Sailor/Photon_Sailor-1531575477.7373607.png"
     },
-    "version": "1.3",
-    "ksp_version_min": "1.4.3",
-    "ksp_version_max": "1.4.4",
+    "version": "1.4.8.3",
+    "ksp_version": "1.6.1",
     "depends": [
         {
             "name": "ModuleManager"
@@ -47,11 +46,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.3",
-    "download_size": 2190684,
+    "download": "https://spacedock.info/mod/1895/Photon%20Sailor/download/1.4.8.3",
+    "download_size": 8784957,
     "download_hash": {
-        "sha1": "A494DF05A99FE8233077A82707238769FF21DE7D",
-        "sha256": "06ED6FF1C29044DC57796B79455ECB160EBA749EBB6F422569DE07320CA25299"
+        "sha1": "BD7CA443B11473D1F2F4DBA012036A904E18D9AA",
+        "sha256": "193D4448DB8C3D76666988A681094B6B689C20E09FB43DE55C5CA3F2F993EF3B"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
See https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1260-baikonur/&do=findComment&comment=3608707

These mods release **five** separate versions each time they update, each for different versions of the game, rapidly uploaded at the same time. When KSP-SpaceDock/SpaceDock#192 was unfixed, this meant only the most recently uploaded version got indexed. This pull request fills in the missing versions.

Some later changes to PhotonSailor's netkan (KSP-CKAN/NetKAN#6615, KSP-CKAN/NetKAN#6625, KSP-CKAN/NetKAN#6630) are also applied retroactively to its oldest versions, since they sound like fixes rather than things that were needed to support changes to the mod.