### PR TITLE
Remove KJR provides from old versions of KJRNext

### DIFF
--- a/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.0.ckan
+++ b/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.0.ckan
@@ -15,9 +15,6 @@
     },
     "version": "v4.0.0",
     "ksp_version_min": "1.4.0",
-    "provides": [
-        "KerbalJointReinforcement"
-    ],
     "conflicts": [
         {
             "name": "KerbalJointReinforcement"

--- a/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.10.ckan
+++ b/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.10.ckan
@@ -15,9 +15,6 @@
     },
     "version": "v4.0.10",
     "ksp_version_min": "1.4.0",
-    "provides": [
-        "KerbalJointReinforcement"
-    ],
     "conflicts": [
         {
             "name": "KerbalJointReinforcement"

--- a/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.3.ckan
+++ b/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.3.ckan
@@ -15,9 +15,6 @@
     },
     "version": "v4.0.3",
     "ksp_version_min": "1.4.0",
-    "provides": [
-        "KerbalJointReinforcement"
-    ],
     "conflicts": [
         {
             "name": "KerbalJointReinforcement"

--- a/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.4.ckan
+++ b/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.4.ckan
@@ -15,9 +15,6 @@
     },
     "version": "v4.0.4",
     "ksp_version_min": "1.4.0",
-    "provides": [
-        "KerbalJointReinforcement"
-    ],
     "conflicts": [
         {
             "name": "KerbalJointReinforcement"

--- a/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.5.ckan
+++ b/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.5.ckan
@@ -15,9 +15,6 @@
     },
     "version": "v4.0.5",
     "ksp_version_min": "1.4.0",
-    "provides": [
-        "KerbalJointReinforcement"
-    ],
     "conflicts": [
         {
             "name": "KerbalJointReinforcement"

--- a/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.6.ckan
+++ b/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.6.ckan
@@ -15,9 +15,6 @@
     },
     "version": "v4.0.6",
     "ksp_version_min": "1.4.0",
-    "provides": [
-        "KerbalJointReinforcement"
-    ],
     "conflicts": [
         {
             "name": "KerbalJointReinforcement"

--- a/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.7.ckan
+++ b/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.7.ckan
@@ -15,9 +15,6 @@
     },
     "version": "v4.0.7",
     "ksp_version_min": "1.4.0",
-    "provides": [
-        "KerbalJointReinforcement"
-    ],
     "conflicts": [
         {
             "name": "KerbalJointReinforcement"

--- a/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.8.ckan
+++ b/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.8.ckan
@@ -15,9 +15,6 @@
     },
     "version": "v4.0.8",
     "ksp_version_min": "1.4.0",
-    "provides": [
-        "KerbalJointReinforcement"
-    ],
     "conflicts": [
         {
             "name": "KerbalJointReinforcement"

--- a/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.9.ckan
+++ b/KerbalJointReinforcementNext/KerbalJointReinforcementNext-v4.0.9.ckan
@@ -15,9 +15,6 @@
     },
     "version": "v4.0.9",
     "ksp_version_min": "1.4.0",
-    "provides": [
-        "KerbalJointReinforcement"
-    ],
     "conflicts": [
         {
             "name": "KerbalJointReinforcement"


### PR DESCRIPTION
See KSP-CKAN/NetKAN#7221; KJRNext providing KJR has caused problems, so we're removing that.
This pull request covers already indexed versions.