### PR TITLE
Clean up old ModularFuelTank versions

### DIFF
--- a/ModularFuelTanks/ModularFuelTanks-5.11.1.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.11.1.ckan
@@ -17,8 +17,9 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/58235-11-modular-fuel-tanks-v570/",
         "repository": "https://github.com/NathanKell/ModularFuelSystem"
     },
-    "version": "5.12.1",
-    "ksp_version": "1.6",
+    "version": "5.11.1",
+    "ksp_version_min": "1.4",
+    "ksp_version_max": "1.5",
     "depends": [
         {
             "name": "ModuleManager"
@@ -56,11 +57,11 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.12.1.zip",
-    "download_size": 39132,
+    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.11.1.zip",
+    "download_size": 38785,
     "download_hash": {
-        "sha1": "9C1FC883B0B517CC6DD700A70029453623317883",
-        "sha256": "3D40264C6A7AAEAC5549C9F3CD73BB59264BB7DC8A76585C3075DF22525B924F"
+        "sha1": "2FBE36AE123AA0599AFDDBEE1BA0E644528DCFA9",
+        "sha256": "84A8E3B4729974B4C28864B4BED1E1E754C78D0C84D3C5E81E538B3FE7D7DFEB"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/ModularFuelTanks/ModularFuelTanks-5.12.0.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.12.0.ckan
@@ -17,7 +17,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/58235-11-modular-fuel-tanks-v570/",
         "repository": "https://github.com/NathanKell/ModularFuelSystem"
     },
-    "version": "5.12.1",
+    "version": "5.12.0",
     "ksp_version": "1.6",
     "depends": [
         {
@@ -56,11 +56,11 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.12.1.zip",
-    "download_size": 39132,
+    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.12.0.zip",
+    "download_size": 39172,
     "download_hash": {
-        "sha1": "9C1FC883B0B517CC6DD700A70029453623317883",
-        "sha256": "3D40264C6A7AAEAC5549C9F3CD73BB59264BB7DC8A76585C3075DF22525B924F"
+        "sha1": "A5CFB970B1A67B831CB61BB159DB408EB3B08667",
+        "sha256": "218D0C6F8B751A8D841BB4455FCFF59D78F66E7644C4349E517852850A531790"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/ModularFuelTanks/ModularFuelTanks-5.12.2.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.12.2.ckan
@@ -17,8 +17,9 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/58235-11-modular-fuel-tanks-v570/",
         "repository": "https://github.com/NathanKell/ModularFuelSystem"
     },
-    "version": "5.12.1",
-    "ksp_version": "1.6",
+    "version": "5.12.2",
+    "ksp_version_min": "1.6",
+    "ksp_version_max": "1.7",
     "depends": [
         {
             "name": "ModuleManager"
@@ -56,7 +57,7 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.12.1.zip",
+    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.12.2.zip",
     "download_size": 39132,
     "download_hash": {
         "sha1": "9C1FC883B0B517CC6DD700A70029453623317883",

--- a/ModularFuelTanks/ModularFuelTanks-5.12.2.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.12.2.ckan
@@ -58,10 +58,10 @@
         }
     ],
     "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.12.2.zip",
-    "download_size": 39132,
+    "download_size": 40319,
     "download_hash": {
-        "sha1": "9C1FC883B0B517CC6DD700A70029453623317883",
-        "sha256": "3D40264C6A7AAEAC5549C9F3CD73BB59264BB7DC8A76585C3075DF22525B924F"
+        "sha1": "AB3FA4BA8E80E8DB8EE978CA43BE0C5FA005A912",
+        "sha256": "CC7D81735352E6E8E331B997E7AD382E96C55A97BA8BFC6CAF7174D9A171D4E6"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
These are the release announcements for the last eight versions of [ModularFuelTanks](https://forum.kerbalspaceprogram.com/index.php?/topic/58235-*):

> I have released MFT 5.10.0 for KSP 1.3.1. Links in the first post, changes in the second.

> I have released MFT 5.11.0 for KSP 1.4.[0-1]. Links in the first post, changes in the second.

> I've released MT 5.11.1 for KSP 1.5.1. It's really just a version check tweak and recompile: it should be compatible with 1.4 still (I did my initial testing with 1.4's MFT).

> I have released version 5.11.2 of ModularFuelTanks. This fixes the delta-v indicator for ships with edited tanks (especially for LV-N).

> I have released version 5.12.0 of ModularFuelTanks, updating MFT for KSP 1.6's delta-v calculation.

> And 5.12.1 with the fix for the broken loading. I apologize for the mess.

> I have released version 5.12.2 of Modular Fuel Tanks: updated for KSP 1.7.x

> And now 5.12.3, thanks to @VoidSquid

## Problems

- 5.11.1 is missing
- 5.12.0 is missing
- 5.12.2 is missing
- KSP-CKAN/NetKAN#7086 updated the version to 5.12.1 but left the download URL pointing at 5.11.0, so CKAN has been installing the wrong version. It also marked that mislabeled 5.11.0 release as compatible with 1.4 onwards, whereas the 5.12.0 announcement said "updating MFT for KSP 1.6's delta-v calculation".

## Changes

Now the missing versions are indexed, and 5.12.1 is updated to actually be 5.12.1, compatible with KSP 1.6.

(I have asked Taniwha for a public version file so we can automate this module.)