### PR TITLE
Limit three versions of KIS to KSP 1.7.0

### DIFF
--- a/KIS/KIS-1.19.ckan
+++ b/KIS/KIS-1.19.ckan
@@ -18,8 +18,7 @@
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.19",
-    "ksp_version_min": "1.7",
-    "ksp_version_max": "1.7.99",
+    "ksp_version": "1.7.0",
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.20.ckan
+++ b/KIS/KIS-1.20.ckan
@@ -18,8 +18,7 @@
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.20",
-    "ksp_version_min": "1.7",
-    "ksp_version_max": "1.7.99",
+    "ksp_version": "1.7.0",
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.21.ckan
+++ b/KIS/KIS-1.21.ckan
@@ -18,8 +18,7 @@
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.21",
-    "ksp_version_min": "1.7",
-    "ksp_version_max": "1.7.99",
+    "ksp_version": "1.7.0",
     "recommends": [
         {
             "name": "CommunityCategoryKit"


### PR DESCRIPTION
## Problem

See https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1260-baikonur/&do=findComment&comment=3613097

Some recent versions of KIS are the victims of unexpected stock API changes. They don't work on KSP 1.7.1, but their version files and CKAN metadata announce compatibility with 1.7.0 through 1.7.99.

## Changes

Now they're marked as 1.7.0 only.