### PR TITLE
Add new batch of Kopernicus backports

### DIFF
--- a/Kopernicus/Kopernicus-2-release-1.3.1-23.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.3.1-23.ckan
@@ -1,0 +1,53 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Kopernicus",
+    "name": "Kopernicus Planetary System Modifier",
+    "abstract": "Allows users to replace the planetary system used by the game.",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "KillAshley",
+        "Gravitasi",
+        "KCreator",
+        "Sigma88"
+    ],
+    "license": "LGPL-3.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/181547-*",
+        "repository": "https://github.com/Kopernicus/Kopernicus-Backport"
+    },
+    "version": "2:release-1.3.1-23",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.8.0"
+        },
+        {
+            "name": "ModularFlightIntegrator",
+            "min_version": "1.2.4.0"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/Kopernicus/Kopernicus-Backport/releases/download/backport-1.3.1-23/Kopernicus-1.3.1-23.zip",
+    "download_size": 337337,
+    "download_hash": {
+        "sha1": "BAB4276B57C52EA991B8CEACEDE3B70E961343A1",
+        "sha256": "665F0A1CFDA68D382993C0A878CA8DE7D854CE65A47928D2BB1C1869693E829C"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/Kopernicus/Kopernicus-2-release-1.4.5-14.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.4.5-14.ckan
@@ -1,0 +1,53 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Kopernicus",
+    "name": "Kopernicus Planetary System Modifier",
+    "abstract": "Allows users to replace the planetary system used by the game.",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "KillAshley",
+        "Gravitasi",
+        "KCreator",
+        "Sigma88"
+    ],
+    "license": "LGPL-3.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/181547-*",
+        "repository": "https://github.com/Kopernicus/Kopernicus-Backport"
+    },
+    "version": "2:release-1.4.5-14",
+    "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.8.0"
+        },
+        {
+            "name": "ModularFlightIntegrator",
+            "min_version": "1.2.4.0"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/Kopernicus/Kopernicus-Backport/releases/download/backport-1.4.5-14/Kopernicus-1.4.5-14.zip",
+    "download_size": 349668,
+    "download_hash": {
+        "sha1": "7E66D86C8316934FAA96815F14E164F191225CC4",
+        "sha256": "53F275CD8B79E82ADEE9A8361089638687865B421366998A8544B06240883AD6"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/Kopernicus/Kopernicus-2-release-1.5.1-9.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.5.1-9.ckan
@@ -1,0 +1,53 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Kopernicus",
+    "name": "Kopernicus Planetary System Modifier",
+    "abstract": "Allows users to replace the planetary system used by the game.",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "KillAshley",
+        "Gravitasi",
+        "KCreator",
+        "Sigma88"
+    ],
+    "license": "LGPL-3.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/181547-*",
+        "repository": "https://github.com/Kopernicus/Kopernicus-Backport"
+    },
+    "version": "2:release-1.5.1-9",
+    "ksp_version": "1.5.1",
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.8.0"
+        },
+        {
+            "name": "ModularFlightIntegrator",
+            "min_version": "1.2.4.0"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/Kopernicus/Kopernicus-Backport/releases/download/backport-1.5.1-9/Kopernicus-1.5.1-9.zip",
+    "download_size": 349625,
+    "download_hash": {
+        "sha1": "282C77CB7502F742B4BE54CFF6259F43E9325D6C",
+        "sha256": "2694595D9357F9D3BAE848FA02B9CC9DA65453E4A4FBE57B1F5F9504381182AE"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/Kopernicus/Kopernicus-2-release-1.6.1-7.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.6.1-7.ckan
@@ -1,0 +1,53 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Kopernicus",
+    "name": "Kopernicus Planetary System Modifier",
+    "abstract": "Allows users to replace the planetary system used by the game.",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "KillAshley",
+        "Gravitasi",
+        "KCreator",
+        "Sigma88"
+    ],
+    "license": "LGPL-3.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/181547-*",
+        "repository": "https://github.com/Kopernicus/Kopernicus-Backport"
+    },
+    "version": "2:release-1.6.1-7",
+    "ksp_version": "1.6.1",
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.8.0"
+        },
+        {
+            "name": "ModularFlightIntegrator",
+            "min_version": "1.2.4.0"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/Kopernicus/Kopernicus-Backport/releases/download/backport-1.6.1-7/Kopernicus-1.6.1-7.zip",
+    "download_size": 359710,
+    "download_hash": {
+        "sha1": "05F4773C3B57555B83F956AE1785561FE0A7AAF2",
+        "sha256": "B0FFBE51238BD2275152D9BCEC22FC2E7D61DCD9206F4C07ED8B9B614C2837C2"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/Kopernicus/Kopernicus-2-release-1.7.1-4.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.7.1-4.ckan
@@ -1,0 +1,53 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Kopernicus",
+    "name": "Kopernicus Planetary System Modifier",
+    "abstract": "Allows users to replace the planetary system used by the game.",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "KillAshley",
+        "Gravitasi",
+        "KCreator",
+        "Sigma88"
+    ],
+    "license": "LGPL-3.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/181547-*",
+        "repository": "https://github.com/Kopernicus/Kopernicus"
+    },
+    "version": "2:release-1.7.1-4",
+    "ksp_version": "1.7.1",
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.8.0"
+        },
+        {
+            "name": "ModularFlightIntegrator",
+            "min_version": "1.2.4.0"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/Kopernicus/Kopernicus/releases/download/release-1.7.1-4/Kopernicus-1.7.1-4.zip",
+    "download_size": 360968,
+    "download_hash": {
+        "sha1": "C29472ED022713EB586E99897CC5C2C1D92DC0EA",
+        "sha256": "22174BC985ED8F53442B7A0A6ABAB2E314E01F6D935CF668F3567109E48E6C18"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
Successor to #1456. New Kopernicus release today.

https://forum.kerbalspaceprogram.com/index.php?/topic/181547-171-1-backports-kopernicus-kittopiatech/&do=findComment&comment=3613945

The main one for 1.7.1 will be handled by the bot, but the others won't be without KSP-CKAN/NetKAN-bot#91. So for now we do it manually via

```sh
netkan.exe NetKAN/NetKAN/Backports/Kopernicus.netkan --releases 8
```

Several intermediate versions are skipped because they had bugs that were immediately reported on the forum. This is also true of 1.7.1-2, which the bot just indexed, so 1.7.1-4 is added as well to reduce the number of people using a broken version.

ckan compat add 1.6