### PR TITLE
Revert " "NetKAN generated mods - Kerbalism-2.1.2""

### DIFF
--- a/Kerbalism/Kerbalism-2.1.2.ckan
+++ b/Kerbalism/Kerbalism-2.1.2.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/172400-*",
         "spacedock": "https://spacedock.info/mod/1774/Kerbalism",
-        "repository": "https://github.com/Kerbalism/Kerbalism",
+        "repository": "https://github.com/Steamp0rt/Kerbalism",
         "x_screenshot": "https://spacedock.info/content/N70_4889/Kerbalism/Kerbalism-1522554849.870197.png"
     },
     "version": "2.1.2",
@@ -85,7 +85,13 @@
     "install": [
         {
             "file": "Kerbalism",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter_regexp": [
+                "Kerbalism/Profiles",
+                "Kerbalism/System",
+                "Kerbalism/ResourceConfigs",
+                "Kerbalism/Settings.cfg"
+            ]
         }
     ],
     "download": "https://spacedock.info/mod/1774/Kerbalism/download/2.1.2",


### PR DESCRIPTION
This reverts commit ccc774db21e76b40df919fe907861c730b54e5e8.

Kerbalism 2.1.2 had KSP-CKAN/NetKAN#7228 applied to it, but those changes were for 3.0. Now they're reverted.