### PR TITLE
More Kopernicus backports

### DIFF
--- a/Kopernicus/Kopernicus-2-release-1.3.1-24.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.3.1-24.ckan
@@ -1,0 +1,53 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Kopernicus",
+    "name": "Kopernicus Planetary System Modifier",
+    "abstract": "Allows users to replace the planetary system used by the game.",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "KillAshley",
+        "Gravitasi",
+        "KCreator",
+        "Sigma88"
+    ],
+    "license": "LGPL-3.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/181547-*",
+        "repository": "https://github.com/Kopernicus/Kopernicus-Backport"
+    },
+    "version": "2:release-1.3.1-24",
+    "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.8.0"
+        },
+        {
+            "name": "ModularFlightIntegrator",
+            "min_version": "1.2.4.0"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/Kopernicus/Kopernicus-Backport/releases/download/backport-1.3.1-24/Kopernicus-1.3.1-24.zip",
+    "download_size": 337505,
+    "download_hash": {
+        "sha1": "2ADBB2D3D06B95371840466C97EB31D4D7ECA557",
+        "sha256": "C622FD8965C05CBB7CFD7890521C8E3AB992A47500814074A35FEB0EE57056FD"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/Kopernicus/Kopernicus-2-release-1.4.5-15.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.4.5-15.ckan
@@ -1,0 +1,53 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Kopernicus",
+    "name": "Kopernicus Planetary System Modifier",
+    "abstract": "Allows users to replace the planetary system used by the game.",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "KillAshley",
+        "Gravitasi",
+        "KCreator",
+        "Sigma88"
+    ],
+    "license": "LGPL-3.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/181547-*",
+        "repository": "https://github.com/Kopernicus/Kopernicus-Backport"
+    },
+    "version": "2:release-1.4.5-15",
+    "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.8.0"
+        },
+        {
+            "name": "ModularFlightIntegrator",
+            "min_version": "1.2.4.0"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/Kopernicus/Kopernicus-Backport/releases/download/backport-1.4.5-15/Kopernicus-1.4.5-15.zip",
+    "download_size": 349841,
+    "download_hash": {
+        "sha1": "E8053D7FB84B3AA7C429B8A1FF5CDBDC7D507A83",
+        "sha256": "6C4FBC10B92F31C72683C620E0AD42C7D5325EB448E2FA9FBF62BDE5618AD536"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/Kopernicus/Kopernicus-2-release-1.5.1-10.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.5.1-10.ckan
@@ -1,0 +1,53 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Kopernicus",
+    "name": "Kopernicus Planetary System Modifier",
+    "abstract": "Allows users to replace the planetary system used by the game.",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "KillAshley",
+        "Gravitasi",
+        "KCreator",
+        "Sigma88"
+    ],
+    "license": "LGPL-3.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/181547-*",
+        "repository": "https://github.com/Kopernicus/Kopernicus-Backport"
+    },
+    "version": "2:release-1.5.1-10",
+    "ksp_version": "1.5.1",
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.8.0"
+        },
+        {
+            "name": "ModularFlightIntegrator",
+            "min_version": "1.2.4.0"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/Kopernicus/Kopernicus-Backport/releases/download/backport-1.5.1-10/Kopernicus-1.5.1-10.zip",
+    "download_size": 349801,
+    "download_hash": {
+        "sha1": "DED2FB8022AE8EA42B5A3D9AD229EDFDF4AD2F3A",
+        "sha256": "36D95267D54A057C585EF0031F987E6B3BA07F7D4E02752C3499AD1557A5767C"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/Kopernicus/Kopernicus-2-release-1.6.1-8.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.6.1-8.ckan
@@ -1,0 +1,53 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Kopernicus",
+    "name": "Kopernicus Planetary System Modifier",
+    "abstract": "Allows users to replace the planetary system used by the game.",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "KillAshley",
+        "Gravitasi",
+        "KCreator",
+        "Sigma88"
+    ],
+    "license": "LGPL-3.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/181547-*",
+        "repository": "https://github.com/Kopernicus/Kopernicus-Backport"
+    },
+    "version": "2:release-1.6.1-8",
+    "ksp_version": "1.6.1",
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.8.0"
+        },
+        {
+            "name": "ModularFlightIntegrator",
+            "min_version": "1.2.4.0"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/Kopernicus/Kopernicus-Backport/releases/download/backport-1.6.1-8/Kopernicus-1.6.1-8.zip",
+    "download_size": 359878,
+    "download_hash": {
+        "sha1": "FE0A01C9AA537BE2D26C58688BB38DED43700DB4",
+        "sha256": "EDD2EE92DE04FF74402F2F4A9C8CD2EB7B1A7C4236DAC8E4C80F05BFC23BF1A8"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
Successor to #1460.
These fix the issue of Kopernicus freezing with .bin files in GameData that weren't intended for it.