### PR TITLE
Fix NewTantares game versions

### DIFF
--- a/NewTantares/NewTantares-v16.0.ckan
+++ b/NewTantares/NewTantares-v16.0.ckan
@@ -10,8 +10,7 @@
         "repository": "https://github.com/Tantares/Tantares"
     },
     "version": "v16.0",
-    "ksp_version_min": "1.4",
-    "ksp_version_max": "1.5",
+    "ksp_version": "1.6",
     "recommends": [
         {
             "name": "NewTantaresLV"

--- a/NewTantares/NewTantares-v17.0.ckan
+++ b/NewTantares/NewTantares-v17.0.ckan
@@ -10,8 +10,7 @@
         "repository": "https://github.com/Tantares/Tantares"
     },
     "version": "v17.0",
-    "ksp_version_min": "1.4",
-    "ksp_version_max": "1.5",
+    "ksp_version": "1.6",
     "recommends": [
         {
             "name": "NewTantaresLV"

--- a/NewTantares/NewTantares-v17.1.ckan
+++ b/NewTantares/NewTantares-v17.1.ckan
@@ -10,8 +10,7 @@
         "repository": "https://github.com/Tantares/Tantares"
     },
     "version": "v17.1",
-    "ksp_version_min": "1.4",
-    "ksp_version_max": "1.5",
+    "ksp_version": "1.7",
     "recommends": [
         {
             "name": "NewTantaresLV"


### PR DESCRIPTION
This mod's game versions are hard coded in the netkan and were 4 versions out of date.
KSP-CKAN/NetKAN#7246 updated the current version and enabled staging.
This pull request fixes the older verisons.