### PR TITLE
Backfill missing KSPIE versions, add localizations

### DIFF
--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.21.10.2.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.21.10.2.ckan
@@ -11,8 +11,8 @@
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/KSP_Interstellar_Extended/KSP_Interstellar_Extended-1470128568.7429862.png"
     },
-    "version": "1.21.9.3",
-    "ksp_version": "1.6.1",
+    "version": "1.21.10.2",
+    "ksp_version": "1.5.1",
     "localizations": [
         "en-us",
         "es-es",
@@ -87,11 +87,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.21.9.3",
-    "download_size": 172995794,
+    "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.21.10.2",
+    "download_size": 173583802,
     "download_hash": {
-        "sha1": "3DBC7101120F48F0D7D0686D822B5222D79F8C2A",
-        "sha256": "CD4B898AB8E440EBE52528E3B5E27E7FC31418BF6C6103B4302F6A874B66AD67"
+        "sha1": "D2BB1F1888D0A20989C829286A27B0F41DF507E6",
+        "sha256": "9DEFF7BC1CE6B16ED0E77B646D6D612427DCAD360102208E1B6C17EE4898E7FD"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.21.10.3.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.21.10.3.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/KSP_Interstellar_Extended/KSP_Interstellar_Extended-1470128568.7429862.png"
     },
-    "version": "1.21.9.3",
+    "version": "1.21.10.3",
     "ksp_version": "1.6.1",
     "localizations": [
         "en-us",
@@ -87,11 +87,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.21.9.3",
-    "download_size": 172995794,
+    "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.21.10.3",
+    "download_size": 173004415,
     "download_hash": {
-        "sha1": "3DBC7101120F48F0D7D0686D822B5222D79F8C2A",
-        "sha256": "CD4B898AB8E440EBE52528E3B5E27E7FC31418BF6C6103B4302F6A874B66AD67"
+        "sha1": "20D82237E40B1EA9FB6D98AE9D74550FC73F9980",
+        "sha256": "FA8E997BC7889BED57AA625D0F337F3F308414C2C900E8844FF73D200014209B"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.21.8.1.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.21.8.1.ckan
@@ -11,18 +11,8 @@
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/KSP_Interstellar_Extended/KSP_Interstellar_Extended-1470128568.7429862.png"
     },
-    "version": "1.21.9.3",
-    "ksp_version": "1.6.1",
-    "localizations": [
-        "en-us",
-        "es-es",
-        "pt-br",
-        "ru",
-        "zh-cn",
-        "de-de",
-        "ja",
-        "fr-fr"
-    ],
+    "version": "1.21.8.1",
+    "ksp_version": "1.4.5",
     "depends": [
         {
             "name": "InterstellarFuelSwitch-Core"
@@ -87,11 +77,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.21.9.3",
-    "download_size": 172995794,
+    "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.21.8.1",
+    "download_size": 173740298,
     "download_hash": {
-        "sha1": "3DBC7101120F48F0D7D0686D822B5222D79F8C2A",
-        "sha256": "CD4B898AB8E440EBE52528E3B5E27E7FC31418BF6C6103B4302F6A874B66AD67"
+        "sha1": "9D64AAAC1375C6885433AEBDF628A1EB2BF60E76",
+        "sha256": "815CE3A839F11D31D200B36C7DCF58275D6C165AF3CD10401E7E5475E5465AB6"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.21.8.2.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.21.8.2.ckan
@@ -11,18 +11,8 @@
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/KSP_Interstellar_Extended/KSP_Interstellar_Extended-1470128568.7429862.png"
     },
-    "version": "1.21.9.3",
-    "ksp_version": "1.6.1",
-    "localizations": [
-        "en-us",
-        "es-es",
-        "pt-br",
-        "ru",
-        "zh-cn",
-        "de-de",
-        "ja",
-        "fr-fr"
-    ],
+    "version": "1.21.8.2",
+    "ksp_version": "1.5.1",
     "depends": [
         {
             "name": "InterstellarFuelSwitch-Core"
@@ -87,11 +77,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.21.9.3",
-    "download_size": 172995794,
+    "download": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended/download/1.21.8.2",
+    "download_size": 173574887,
     "download_hash": {
-        "sha1": "3DBC7101120F48F0D7D0686D822B5222D79F8C2A",
-        "sha256": "CD4B898AB8E440EBE52528E3B5E27E7FC31418BF6C6103B4302F6A874B66AD67"
+        "sha1": "61DBD1C665CDED55211D51CEDAB8BA34E3195E8F",
+        "sha256": "C01C3AC5B19311CA07EB13C73D1857D324AE39B814D3DB53984335555BDDF3E6"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.21.8.3.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.21.8.3.ckan
@@ -13,6 +13,16 @@
     },
     "version": "1.21.8.3",
     "ksp_version": "1.6.1",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "pt-br",
+        "ru",
+        "zh-cn",
+        "de-de",
+        "ja",
+        "fr-fr"
+    ],
     "depends": [
         {
             "name": "InterstellarFuelSwitch-Core"

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.21.8.4.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.21.8.4.ckan
@@ -13,6 +13,16 @@
     },
     "version": "1.21.8.4",
     "ksp_version": "1.7.1",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "pt-br",
+        "ru",
+        "zh-cn",
+        "de-de",
+        "ja",
+        "fr-fr"
+    ],
     "depends": [
         {
             "name": "InterstellarFuelSwitch-Core"

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.21.9.0.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.21.9.0.ckan
@@ -14,6 +14,16 @@
     "version": "1.21.9.0",
     "ksp_version_min": "1.3.1",
     "ksp_version_max": "1.4.5",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "pt-br",
+        "ru",
+        "zh-cn",
+        "de-de",
+        "ja",
+        "fr-fr"
+    ],
     "depends": [
         {
             "name": "InterstellarFuelSwitch-Core"

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.21.9.1.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.21.9.1.ckan
@@ -13,6 +13,16 @@
     },
     "version": "1.21.9.1",
     "ksp_version": "1.4.5",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "pt-br",
+        "ru",
+        "zh-cn",
+        "de-de",
+        "ja",
+        "fr-fr"
+    ],
     "depends": [
         {
             "name": "InterstellarFuelSwitch-Core"

--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.21.9.2.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.21.9.2.ckan
@@ -13,6 +13,16 @@
     },
     "version": "1.21.9.2",
     "ksp_version": "1.5.1",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "pt-br",
+        "ru",
+        "zh-cn",
+        "de-de",
+        "ja",
+        "fr-fr"
+    ],
     "depends": [
         {
             "name": "InterstellarFuelSwitch-Core"


### PR DESCRIPTION
The SpaceDock new upload web hooks is working, but it's missing versions, presumably due to timing.

This pull request indexes a few missing releases of KSPInterstellarExtended. Localization data is added to older versions that weren't missed, so we don't have a weird disappearance of localizations as the version numbers increase.


ckan compat add 1.7