### PR TITLE
Update ksp_version_max in 0.3.12.5 to 1.99.99

### DIFF
--- a/SpacetuxSA/SpacetuxSA-0.3.12.5.ckan
+++ b/SpacetuxSA/SpacetuxSA-0.3.12.5.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.3.12.5",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.6.0",
+    "ksp_version_max": "1.99.99",
     "install": [
         {
             "find": "SpaceTuxSA",


### PR DESCRIPTION
The ksp_version_max in SpaceTuxSA 0.3.12.4 is 1.99.99, so it seems 0.3.12.5 should be too.