### PR TITLE
Fix StationScienceContinued compatibility

### DIFF
--- a/StationScienceContinued/StationScienceContinued-v2.5.2.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.5.2.ckan
@@ -13,8 +13,7 @@
         "x_preview": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.5.2",
-    "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.98",
+    "ksp_version": "1.6",
     "conflicts": [
         {
             "name": "StationScience"


### PR DESCRIPTION
This module released with incorrect data in its .version file. It was built for KSP 1.6, but the version file says 1.4.
Now it's fixed.
Fixes KSP-CKAN/NetKAN#7262.