### PR TITLE
Set old AJE versions to depend on virtual FAR

### DIFF
--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
@@ -15,7 +15,7 @@
     "ksp_version": "0.25",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "ModuleManager",

--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
@@ -15,7 +15,7 @@
     "ksp_version": "0.25",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "ModuleManager",

--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
@@ -16,7 +16,7 @@
     "ksp_version": "0.25",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "ModuleManager",

--- a/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
@@ -15,7 +15,7 @@
     "ksp_version": "0.90",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "ModuleManager",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.0.2.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.0.2.ckan
@@ -13,7 +13,7 @@
     "ksp_version": "0.90",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "ModuleManager"

--- a/AdvancedJetEngine/AdvancedJetEngine-2.0.2.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.0.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.2",
     "identifier": "AdvancedJetEngine",
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers and rotors in KSP.",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.0.2.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.0.2.ckan
@@ -33,7 +33,7 @@
             "install_to": "GameData/AJE"
         }
     ],
-    "download": "https://archive.org/download/AdvancedJetEngine-2.0.2/059A6DA8-AdvancedJetEngine-2.0.2.zip",
+    "download": "https://archive.org/download/AdvancedJetEngine-2.0.2/3DB5697F-AdvancedJetEngine-2.0.2.zip",
     "download_size": 929713,
     "download_hash": {
         "sha1": "059A6DA8A547A67A36D007602E5CB00A3168453F",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.0.3.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.0.3.ckan
@@ -14,7 +14,7 @@
     "ksp_version": "0.90",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "ModuleManager"

--- a/AdvancedJetEngine/AdvancedJetEngine-2.0.3.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.0.3.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://archive.org/download/AdvancedJetEngine-2.0.3/56D27043-AdvancedJetEngine-2.0.3.zip",
+    "download": "https://archive.org/download/AdvancedJetEngine-2.0.3/AAEC6B41-AdvancedJetEngine-2.0.3.zip",
     "download_size": 929478,
     "download_hash": {
         "sha1": "56D270436ED58CAC0BE746010069881777933BC3",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.0.3.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.0.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "comment": "The full path in the mod archive can change. I.e. it was AJE-2.0.3/GameData/AJE at some point. The CKAN needs to deal with this. Hence using 'find'",
     "identifier": "AdvancedJetEngine",
     "name": "Advanced Jet Engine",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.0.4.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.0.4.ckan
@@ -14,7 +14,7 @@
     "ksp_version": "0.90",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "ModuleManager"

--- a/AdvancedJetEngine/AdvancedJetEngine-2.0.4.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.0.4.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://archive.org/download/AdvancedJetEngine-2.0.4/2077B02B-AdvancedJetEngine-2.0.4.zip",
+    "download": "https://archive.org/download/AdvancedJetEngine-2.0.4/AD74167A-AdvancedJetEngine-2.0.4.zip",
     "download_size": 932039,
     "download_hash": {
         "sha1": "2077B02B63B9F4CA952C4E0B8DA2AAC51EBE4684",

--- a/AdvancedJetEngine/AdvancedJetEngine-2.2.0.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.2.0.ckan
@@ -16,7 +16,7 @@
     "ksp_version": "1.0.2",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-2.2.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.2.1.ckan
@@ -16,7 +16,7 @@
     "ksp_version": "1.0.4",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-2.3.0.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.3.0.ckan
@@ -16,7 +16,7 @@
     "ksp_version": "1.0.4",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-2.4.0.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.4.0.ckan
@@ -16,7 +16,7 @@
     "ksp_version": "1.0.4",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-2.4.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.4.1.ckan
@@ -16,7 +16,7 @@
     "ksp_version": "1.0.4",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-2.5.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.5.1.ckan
@@ -16,7 +16,7 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-2.5.2.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.5.2.ckan
@@ -15,7 +15,7 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-2.5.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-2.5.ckan
@@ -16,7 +16,7 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.10.0.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.10.0.ckan
@@ -17,7 +17,7 @@
     "ksp_version": "1.3.1",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.11.0.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.11.0.ckan
@@ -17,7 +17,7 @@
     "ksp_version": "1.4.1",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.11.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.11.1.ckan
@@ -17,7 +17,7 @@
     "ksp_version": "1.4.1",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.11.3.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.11.3.ckan
@@ -17,7 +17,7 @@
     "ksp_version": "1.4.2",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.11.4.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.11.4.ckan
@@ -17,7 +17,7 @@
     "ksp_version": "1.4.3",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.12.0.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.12.0.ckan
@@ -17,7 +17,7 @@
     "ksp_version": "1.5.1",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.5.4.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.5.4.ckan
@@ -15,7 +15,7 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.6.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.6.1.ckan
@@ -15,7 +15,7 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.6.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.6.ckan
@@ -15,7 +15,7 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.7.1.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.7.1.ckan
@@ -17,7 +17,7 @@
     "ksp_version": "1.1.2",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.7.2.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.7.2.ckan
@@ -17,7 +17,7 @@
     "ksp_version": "1.1.3",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.7.3.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.7.3.ckan
@@ -17,7 +17,7 @@
     "ksp_version": "1.2.2",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.7.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.7.ckan
@@ -15,7 +15,7 @@
     "ksp_version": "1.1.0",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.8.0.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.8.0.ckan
@@ -17,7 +17,7 @@
     "ksp_version": "1.2.2",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/AdvancedJetEngine/AdvancedJetEngine-v2.9.0.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-v2.9.0.ckan
@@ -17,7 +17,7 @@
     "ksp_version": "1.3.0",
     "depends": [
         {
-            "name": "FerramAerospaceResearch"
+            "name": "FAR"
         },
         {
             "name": "SolverEngines"

--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.0.ckan
@@ -12,7 +12,8 @@
         "x_ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
     },
     "version": "1.0",
-    "ksp_version": "1.0.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.2",
     "download": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/6/artifact/ModularFlightIntegrator-1.0.0.0.zip",
     "download_size": 7091,
     "download_hash": {

--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.0.repackaged0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.0.repackaged0.ckan
@@ -12,7 +12,8 @@
         "x_ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
     },
     "version": "1.0.repackaged0",
-    "ksp_version": "1.0.0",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.0.2",
     "download": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/6/artifact/ModularFlightIntegrator-1.0.0.0.zip",
     "download_size": 7091,
     "download_hash": {

--- a/SmokeScreen/SmokeScreen-2.5.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.5.0.ckan
@@ -3,7 +3,7 @@
     "name"         : "SmokeScreen 2.5.0 - Extended FX Plugin",
     "abstract"     : "SmokeScreen is a plugin that build on the engine FX added in .23 and adds new features to them. Most of the features ideas comes from Nothke",
     "identifier"   : "SmokeScreen",
-    "download"     : "https://ksp.sarbian.com/jenkins/job/SmokeScreen/lastSuccessfulBuild/artifact/SmokeScreen-2.5.0.0.zip",
+    "download"     : "https://ksp.sarbian.com/jenkins/job/SmokeScreen/37/artifact/SmokeScreen-2.5.0.0.zip",
     "license"      : "BSD-2-clause",
     "author"       : [ "sarbian" ],
     "version"      : "2.5.0",


### PR DESCRIPTION
This module's netkan made this change in KSP-RO/AJE@95181e3bdcf0f394c3ce0c529d1bfab0a4f2f53a, but the old versions have the old metadata. This can be a problem if you want to install them:

![image](https://user-images.githubusercontent.com/1559108/60400933-24568780-9b6a-11e9-82fd-9c547ba627cb.png)

Now they're updated.

Also SmokeScreen 2.5.0 had "lastSuccessfulBuild" in its URL, which is wrong. This is replaced with 37 because that build has the file:
https://ksp.sarbian.com/jenkins/job/SmokeScreen/37/

Some of the modules had invalid URLs, which are fixed.
Some had wrong spec versions, which are fixed.

MFI 1.0 now supports KSP 1.0.2, justification:
https://forum.kerbalspaceprogram.com/index.php?/topic/106369-125-15x-modularflightintegrator-125-march-23th/&do=findComment&comment=1967721