### PR TITLE
Fix old AVP epochs

### DIFF
--- a/AstronomersVisualPack/AstronomersVisualPack-2-3.7.0.0.ckan
+++ b/AstronomersVisualPack/AstronomersVisualPack-2-3.7.0.0.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*",
         "repository": "https://github.com/themaster402/AstronomersVisualPack"
     },
-    "version": "1:3.7.0.0",
+    "version": "2:3.7.0.0",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.2",
     "provides": [

--- a/AstronomersVisualPack/AstronomersVisualPack-2-3.7.1.0.ckan
+++ b/AstronomersVisualPack/AstronomersVisualPack-2-3.7.1.0.ckan
@@ -9,9 +9,9 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*",
         "repository": "https://github.com/themaster402/AstronomersVisualPack"
     },
-    "version": "1:3.7.3.0",
-    "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.4.5",
+    "version": "2:3.7.1.0",
+    "ksp_version_min": "1.4.0",
+    "ksp_version_max": "1.4.3",
     "provides": [
         "EnvironmentalVisualEnhancements-Config"
     ],
@@ -49,11 +49,11 @@
             "name": "TextureReplacer"
         }
     ],
-    "download": "https://github.com/themaster402/AstronomersVisualPack/releases/download/v3.73/AVP.v.3.73.zip",
-    "download_size": 98738419,
+    "download": "https://github.com/themaster402/AstronomersVisualPack/releases/download/v3.71/AVP.v.3.71.zip",
+    "download_size": 97550940,
     "download_hash": {
-        "sha1": "C5E564BF36F2111AA43AFDEE7D172278F9AAA936",
-        "sha256": "5EF2C4829AE0A16D784147B86486BABEDC2BF769F04717082869C0EFAD241F75"
+        "sha1": "6C916F351AB5F24E94F7B881883559291B5BE029",
+        "sha256": "2191107E5CD4DBB62A0FB3BE7363DB49F93CE011A9BBB8DE19D9E8C454AD62A6"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/AstronomersVisualPack/AstronomersVisualPack-2-3.7.2.0.ckan
+++ b/AstronomersVisualPack/AstronomersVisualPack-2-3.7.2.0.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*",
         "repository": "https://github.com/themaster402/AstronomersVisualPack"
     },
-    "version": "1:3.7.2.0",
+    "version": "2:3.7.2.0",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.4",
     "provides": [

--- a/AstronomersVisualPack/AstronomersVisualPack-2-3.7.3.0.ckan
+++ b/AstronomersVisualPack/AstronomersVisualPack-2-3.7.3.0.ckan
@@ -9,9 +9,9 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*",
         "repository": "https://github.com/themaster402/AstronomersVisualPack"
     },
-    "version": "1:3.7.1.0",
-    "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.3",
+    "version": "2:3.7.3.0",
+    "ksp_version_min": "1.3.0",
+    "ksp_version_max": "1.4.5",
     "provides": [
         "EnvironmentalVisualEnhancements-Config"
     ],
@@ -49,11 +49,11 @@
             "name": "TextureReplacer"
         }
     ],
-    "download": "https://github.com/themaster402/AstronomersVisualPack/releases/download/v3.71/AVP.v.3.71.zip",
-    "download_size": 97550940,
+    "download": "https://github.com/themaster402/AstronomersVisualPack/releases/download/v3.73/AVP.v.3.73.zip",
+    "download_size": 98738419,
     "download_hash": {
-        "sha1": "6C916F351AB5F24E94F7B881883559291B5BE029",
-        "sha256": "2191107E5CD4DBB62A0FB3BE7363DB49F93CE011A9BBB8DE19D9E8C454AD62A6"
+        "sha1": "C5E564BF36F2111AA43AFDEE7D172278F9AAA936",
+        "sha256": "5EF2C4829AE0A16D784147B86486BABEDC2BF769F04717082869C0EFAD241F75"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/AstronomersVisualPack/AstronomersVisualPack-2-3.7.4.0.ckan
+++ b/AstronomersVisualPack/AstronomersVisualPack-2-3.7.4.0.ckan
@@ -9,9 +9,9 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*",
         "repository": "https://github.com/themaster402/AstronomersVisualPack"
     },
-    "version": "1:3.8.1.0",
+    "version": "2:3.7.4.0",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.7.1",
+    "ksp_version_max": "1.6.1",
     "provides": [
         "EnvironmentalVisualEnhancements-Config"
     ],
@@ -27,17 +27,12 @@
         },
         {
             "name": "AVP-Textures"
-        }
-    ],
-    "recommends": [
-        {
-            "name": "KS3P"
         },
         {
             "name": "TextureReplacer"
         }
     ],
-    "suggests": [
+    "recommends": [
         {
             "name": "DistantObject"
         },
@@ -45,19 +40,25 @@
             "name": "PlanetShine"
         },
         {
+            "name": "LoadingScreenManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KS3P"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
             "name": "Chatterer"
         }
     ],
-    "conflicts": [
-        {
-            "name": "EnvironmentalVisualEnhancements-Config"
-        }
-    ],
-    "download": "https://github.com/themaster402/AstronomersVisualPack/releases/download/v3.81/AVP.v.3.81.zip",
-    "download_size": 46879676,
+    "download": "https://github.com/themaster402/AstronomersVisualPack/releases/download/v3.74/AVP.v.3.74.zip",
+    "download_size": 99654924,
     "download_hash": {
-        "sha1": "5ED385F5BBF67B88482F84D1FC80DCA95ADC85DF",
-        "sha256": "9E116737339BDF64EE883FE91063DA30F42EAC8C82AAADE203357312DD6A4C42"
+        "sha1": "2724E5F5BD1B0FCA6B5A5274DE6B65262FFE37BD",
+        "sha256": "E26F488C62748892B5ECB6978BD685019D58429B140C7CC6B80A93C696537125"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/AstronomersVisualPack/AstronomersVisualPack-2-3.8.0.0.ckan
+++ b/AstronomersVisualPack/AstronomersVisualPack-2-3.8.0.0.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*",
         "repository": "https://github.com/themaster402/AstronomersVisualPack"
     },
-    "version": "1:3.8.0.0",
+    "version": "2:3.8.0.0",
     "ksp_version_min": "1.3.0",
     "ksp_version_max": "1.7.0",
     "provides": [

--- a/AstronomersVisualPack/AstronomersVisualPack-2-3.8.1.0.ckan
+++ b/AstronomersVisualPack/AstronomersVisualPack-2-3.8.1.0.ckan
@@ -9,9 +9,9 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*",
         "repository": "https://github.com/themaster402/AstronomersVisualPack"
     },
-    "version": "1:3.7.4.0",
+    "version": "2:3.8.1.0",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.6.1",
+    "ksp_version_max": "1.7.1",
     "provides": [
         "EnvironmentalVisualEnhancements-Config"
     ],
@@ -27,12 +27,17 @@
         },
         {
             "name": "AVP-Textures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "KS3P"
         },
         {
             "name": "TextureReplacer"
         }
     ],
-    "recommends": [
+    "suggests": [
         {
             "name": "DistantObject"
         },
@@ -40,25 +45,19 @@
             "name": "PlanetShine"
         },
         {
-            "name": "LoadingScreenManager"
-        }
-    ],
-    "suggests": [
-        {
-            "name": "KS3P"
-        },
-        {
-            "name": "Kopernicus"
-        },
-        {
             "name": "Chatterer"
         }
     ],
-    "download": "https://github.com/themaster402/AstronomersVisualPack/releases/download/v3.74/AVP.v.3.74.zip",
-    "download_size": 99654924,
+    "conflicts": [
+        {
+            "name": "EnvironmentalVisualEnhancements-Config"
+        }
+    ],
+    "download": "https://github.com/themaster402/AstronomersVisualPack/releases/download/v3.81/AVP.v.3.81.zip",
+    "download_size": 46879676,
     "download_hash": {
-        "sha1": "2724E5F5BD1B0FCA6B5A5274DE6B65262FFE37BD",
-        "sha256": "E26F488C62748892B5ECB6978BD685019D58429B140C7CC6B80A93C696537125"
+        "sha1": "5ED385F5BBF67B88482F84D1FC80DCA95ADC85DF",
+        "sha256": "9E116737339BDF64EE883FE91063DA30F42EAC8C82AAADE203357312DD6A4C42"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
See KSP-CKAN/NetKAN#7286; this module has an old version listed as its newest due to two separate "epoch events". Now the actually-newer versions have their epochs increased.