### PR TITLE
Clean up old KAS metadata

### DIFF
--- a/KAS/KAS-0.4.10.ckan
+++ b/KAS/KAS-0.4.10.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -11,15 +11,24 @@
         "a.g."
     ],
     "license": "restricted",
-    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
+    },
     "version": "0.4.10",
     "ksp_version": "0.90",
-    "depends": [
+    "recommends": [
         {
-            "name": "ModuleManager"
+            "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/ksp-mods/223900-kerbal-attachment-system-kas/files/2222185/download",
+    "download": "https://media.forgecdn.net/files/2222/185/KAS_0.4.10.zip",
     "download_size": 6758533,
     "download_hash": {
         "sha1": "CA899565B7F5B2FF9528A420C5DD7F085E39513D",

--- a/KAS/KAS-0.4.7.ckan
+++ b/KAS/KAS-0.4.7.ckan
@@ -4,12 +4,7 @@
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
-        "IgorZ",
-        "KospY",
-        "Winn75",
-        "zzz",
-        "Majiir",
-        "a.g."
+        "IgorZ"
     ],
     "license": "restricted",
     "resources": {
@@ -19,8 +14,8 @@
         "bugtracker": "https://github.com/ihsoft/KAS/issues",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
-    "version": "0.6.3.0",
-    "ksp_version": "1.3",
+    "version": "0.4.7",
+    "ksp_version": "0.23.5",
     "recommends": [
         {
             "name": "KIS"
@@ -29,11 +24,11 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://media.forgecdn.net/files/2425/421/KAS_v0.6.3.zip",
-    "download_size": 2982090,
+    "download": "https://media.forgecdn.net/files/2240/822/KAS_0.4.7.zip",
+    "download_size": 7420744,
     "download_hash": {
-        "sha1": "2AD8F6356D9A4C21F9C50426C9CF793ED8FCA8B0",
-        "sha256": "4A5B9BD957D3049249DD35C42B4D0586B7DC1FF41E27FF744B8F01CED0E49E60"
+        "sha1": "21BEDC26A7D3986262323D9A6B03C51154ECBDCF",
+        "sha256": "3148907900190B91AAEFE7B8670C92D6C83A2077152B69134CF5E9E02B2F28C2"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KAS/KAS-0.4.8.ckan
+++ b/KAS/KAS-0.4.8.ckan
@@ -4,12 +4,7 @@
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
-        "IgorZ",
-        "KospY",
-        "Winn75",
-        "zzz",
-        "Majiir",
-        "a.g."
+        "IgorZ"
     ],
     "license": "restricted",
     "resources": {
@@ -19,8 +14,8 @@
         "bugtracker": "https://github.com/ihsoft/KAS/issues",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
-    "version": "0.6.3.0",
-    "ksp_version": "1.3",
+    "version": "0.4.8",
+    "ksp_version": "0.24.2",
     "recommends": [
         {
             "name": "KIS"
@@ -29,11 +24,11 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://media.forgecdn.net/files/2425/421/KAS_v0.6.3.zip",
-    "download_size": 2982090,
+    "download": "https://media.forgecdn.net/files/2213/185/KAS_0.4.8.zip",
+    "download_size": 6735103,
     "download_hash": {
-        "sha1": "2AD8F6356D9A4C21F9C50426C9CF793ED8FCA8B0",
-        "sha256": "4A5B9BD957D3049249DD35C42B4D0586B7DC1FF41E27FF744B8F01CED0E49E60"
+        "sha1": "B42390AAC7170A04B45884213A60AD4FCDE79EF7",
+        "sha256": "B07E169CF580D9313F336182DD0D89F2E933C8F132CB8B7F0CFDDFE6F855B089"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KAS/KAS-0.4.9.ckan
+++ b/KAS/KAS-0.4.9.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -11,15 +11,24 @@
         "a.g."
     ],
     "license": "restricted",
-    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
+    },
     "version": "0.4.9",
     "ksp_version": "0.25",
-    "depends": [
+    "recommends": [
         {
-            "name": "ModuleManager"
+            "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/ksp-mods/223900-kerbal-attachment-system-kas/files/2216138/download",
+    "download": "https://media.forgecdn.net/files/2216/138/KAS_0.4.9.zip",
     "download_size": 6758559,
     "download_hash": {
         "sha1": "3F07FDB0943B7606A2F9376B178B5C1653741441",

--- a/KAS/KAS-0.4.ckan
+++ b/KAS/KAS-0.4.ckan
@@ -4,12 +4,7 @@
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
-        "IgorZ",
-        "KospY",
-        "Winn75",
-        "zzz",
-        "Majiir",
-        "a.g."
+        "IgorZ"
     ],
     "license": "restricted",
     "resources": {
@@ -19,8 +14,8 @@
         "bugtracker": "https://github.com/ihsoft/KAS/issues",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
-    "version": "0.6.3.0",
-    "ksp_version": "1.3",
+    "version": "0.4",
+    "ksp_version": "1.0.2",
     "recommends": [
         {
             "name": "KIS"
@@ -29,11 +24,11 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://media.forgecdn.net/files/2425/421/KAS_v0.6.3.zip",
-    "download_size": 2982090,
+    "download": "https://media.forgecdn.net/files/2238/230/KAS_v0.4_OldParts.zip",
+    "download_size": 3048866,
     "download_hash": {
-        "sha1": "2AD8F6356D9A4C21F9C50426C9CF793ED8FCA8B0",
-        "sha256": "4A5B9BD957D3049249DD35C42B4D0586B7DC1FF41E27FF744B8F01CED0E49E60"
+        "sha1": "C6AA0EB1C29C66F50472DCD1495AA1FF6A28B354",
+        "sha256": "5A5CECC29D679CF784BEA33603D43C7A242428B203BF2FC236C40B8FE0D0110F"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KAS/KAS-0.5.0.ckan
+++ b/KAS/KAS-0.5.0.ckan
@@ -4,12 +4,7 @@
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
-        "IgorZ",
-        "KospY",
-        "Winn75",
-        "zzz",
-        "Majiir",
-        "a.g."
+        "IgorZ"
     ],
     "license": "restricted",
     "resources": {
@@ -19,8 +14,8 @@
         "bugtracker": "https://github.com/ihsoft/KAS/issues",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
-    "version": "0.6.3.0",
-    "ksp_version": "1.3",
+    "version": "0.5.0",
+    "ksp_version": "1.0.2",
     "recommends": [
         {
             "name": "KIS"
@@ -29,11 +24,11 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://media.forgecdn.net/files/2425/421/KAS_v0.6.3.zip",
-    "download_size": 2982090,
+    "download": "https://media.forgecdn.net/files/2238/224/KAS_v0.5.0.zip",
+    "download_size": 2659912,
     "download_hash": {
-        "sha1": "2AD8F6356D9A4C21F9C50426C9CF793ED8FCA8B0",
-        "sha256": "4A5B9BD957D3049249DD35C42B4D0586B7DC1FF41E27FF744B8F01CED0E49E60"
+        "sha1": "80CAF27893EB9EBB086317DA67312A57E42F9571",
+        "sha256": "1B218FD7472FE13B91C8768C28C889266C57B49E987427CB1A337D8EC30BACD0"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KAS/KAS-0.5.1.ckan
+++ b/KAS/KAS-0.5.1.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -12,20 +12,23 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.1",
     "ksp_version": "1.0.2",
-    "depends": [
+    "recommends": [
         {
-            "name": "ModuleManager"
+            "name": "KIS"
         },
         {
-            "name": "KIS",
-            "min_version": "1.1.4"
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons-origin.cursecdn.com/files/2238/254/KAS_v0.5.1.zip",
+    "download": "https://media.forgecdn.net/files/2238/254/KAS_v0.5.1.zip",
     "download_size": 2660240,
     "download_hash": {
         "sha1": "8FCF867C53E7A40D3C9A7CF14979B7E37EC54204",

--- a/KAS/KAS-0.5.2.ckan
+++ b/KAS/KAS-0.5.2.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -12,21 +12,24 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.2",
     "ksp_version_min": "1.0.2",
     "ksp_version_max": "1.0.4",
-    "depends": [
+    "recommends": [
         {
-            "name": "ModuleManager"
+            "name": "KIS"
         },
         {
-            "name": "KIS",
-            "min_version": "1.1.5"
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons-origin.cursecdn.com/files/2240/844/KAS_v0.5.2.zip",
+    "download": "https://media.forgecdn.net/files/2240/844/KAS_v0.5.2.zip",
     "download_size": 3033561,
     "download_hash": {
         "sha1": "136B826437DF1666A720527D9ACDF835E8B73F54",

--- a/KAS/KAS-0.5.3.ckan
+++ b/KAS/KAS-0.5.3.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -12,21 +12,24 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.3",
     "ksp_version_min": "1.0.3",
     "ksp_version_max": "1.0.4",
-    "depends": [
+    "recommends": [
         {
-            "name": "ModuleManager"
+            "name": "KIS"
         },
         {
-            "name": "KIS",
-            "min_version": "1.2.0"
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons.curse.cursecdn.com/files/2246/546/KAS_v0.5.3.zip",
+    "download": "https://media.forgecdn.net/files/2246/546/KAS_v0.5.3.zip",
     "download_size": 3033563,
     "download_hash": {
         "sha1": "48B1BCCC00DD2B866EA13E904A74C2A9971785BA",

--- a/KAS/KAS-0.5.4.ckan
+++ b/KAS/KAS-0.5.4.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -12,22 +12,24 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.4",
     "ksp_version_min": "1.0.3",
     "ksp_version_max": "1.0.4",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
     "recommends": [
         {
             "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons.curse.cursecdn.com/files/2249/712/KAS_v0.5.4.zip",
+    "download": "https://media.forgecdn.net/files/2249/712/KAS_v0.5.4.zip",
     "download_size": 6063412,
     "download_hash": {
         "sha1": "051002EF1484F49923DE7C98DD77C8E68FFDE5E4",

--- a/KAS/KAS-0.5.5.ckan
+++ b/KAS/KAS-0.5.5.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -12,22 +12,23 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514",
-        "repository": "https://github.com/KospY/KAS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.5",
     "ksp_version": "1.0.5",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
     "recommends": [
         {
             "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons.curse.cursecdn.com/files/2266/204/KAS_v0.5.5.zip",
+    "download": "https://media.forgecdn.net/files/2266/204/KAS_v0.5.5.zip",
     "download_size": 3035893,
     "download_hash": {
         "sha1": "9D036821C2465793852EFF7E0F5E66D61380FD3A",

--- a/KAS/KAS-0.5.6.ckan
+++ b/KAS/KAS-0.5.6.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -13,22 +13,23 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514",
-        "repository": "https://github.com/KospY/KAS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.6",
     "ksp_version": "1.1",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
     "recommends": [
         {
             "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2295395/download",
+    "download": "https://media.forgecdn.net/files/2295/395/KAS_v0.5.6_build7.zip",
     "download_size": 2990132,
     "download_hash": {
         "sha1": "E7B444350BC21AAAB1D2E6C7F2C14380DB5A00A0",

--- a/KAS/KAS-0.5.7.ckan
+++ b/KAS/KAS-0.5.7.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -13,22 +13,23 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514",
-        "repository": "https://github.com/KospY/KAS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.7",
     "ksp_version": "1.1",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
     "recommends": [
         {
             "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2297485/download",
+    "download": "https://media.forgecdn.net/files/2297/485/KAS_v0.5.7.zip",
     "download_size": 2989977,
     "download_hash": {
         "sha1": "EC02BE7DD4F980313220A6EBCAB6CA3ABB1D61E3",

--- a/KAS/KAS-0.5.8.0.ckan
+++ b/KAS/KAS-0.5.8.0.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -13,29 +13,23 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514",
-        "repository": "https://github.com/KospY/KAS",
-        "bugtracker": "https://github.com/KospY/KAS/issues"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.8.0",
-    "ksp_version_min": "1.1.2",
-    "ksp_version_max": "1.1.99",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
+    "ksp_version": "1.1",
     "recommends": [
         {
             "name": "KIS"
-        }
-    ],
-    "suggests": [
+        },
         {
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2307201/download",
+    "download": "https://media.forgecdn.net/files/2307/201/KAS_v0.5.8.zip",
     "download_size": 2990069,
     "download_hash": {
         "sha1": "CFA33E9C9C88C0750026FC3C7A65030FCE4341CA",

--- a/KAS/KAS-0.5.9.0.ckan
+++ b/KAS/KAS-0.5.9.0.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -14,28 +14,22 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
-        "repository": "https://github.com/KospY/KAS",
-        "bugtracker": "https://github.com/KospY/KAS/issues"
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.9.0",
-    "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.1.99",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
+    "ksp_version": "1.1",
     "recommends": [
         {
             "name": "KIS"
-        }
-    ],
-    "suggests": [
+        },
         {
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2310963/download",
+    "download": "https://media.forgecdn.net/files/2310/963/KAS_v0.5.9.zip",
     "download_size": 2990318,
     "download_hash": {
         "sha1": "913EA9F244F2B9C41055B45BE584D8644ABE7F21",

--- a/KAS/KAS-0.6.0.0.ckan
+++ b/KAS/KAS-0.6.0.0.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -14,28 +14,22 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
-        "repository": "https://github.com/KospY/KAS",
-        "bugtracker": "https://github.com/KospY/KAS/issues"
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.6.0.0",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.99",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
+    "ksp_version": "1.2",
     "recommends": [
         {
             "name": "KIS"
-        }
-    ],
-    "suggests": [
+        },
         {
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2336078/download",
+    "download": "https://media.forgecdn.net/files/2336/78/KAS_v0.6.0.zip",
     "download_size": 2982624,
     "download_hash": {
         "sha1": "56178A7602EFD2391134ACC5BCB3C21326999BF5",

--- a/KAS/KAS-0.6.1.0.ckan
+++ b/KAS/KAS-0.6.1.0.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -14,28 +14,22 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
         "repository": "https://github.com/ihsoft/KAS",
-        "bugtracker": "https://github.com/ihsoft/KAS/issues"
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.6.1.0",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.99",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
+    "ksp_version": "1.2",
     "recommends": [
         {
             "name": "KIS"
-        }
-    ],
-    "suggests": [
+        },
         {
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2352830/download",
+    "download": "https://media.forgecdn.net/files/2352/830/KAS_v0.6.1.zip",
     "download_size": 2982680,
     "download_hash": {
         "sha1": "76C6CFE1E5B38C2248DF112716F203E8A520E88F",

--- a/KAS/KAS-0.6.2.0.ckan
+++ b/KAS/KAS-0.6.2.0.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -14,28 +14,22 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
         "repository": "https://github.com/ihsoft/KAS",
-        "bugtracker": "https://github.com/ihsoft/KAS/issues"
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.6.2.0",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.99",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
+    "ksp_version": "1.2",
     "recommends": [
         {
             "name": "KIS"
-        }
-    ],
-    "suggests": [
+        },
         {
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2360802/download",
+    "download": "https://media.forgecdn.net/files/2360/802/KAS_v0.6.2.zip",
     "download_size": 2982841,
     "download_hash": {
         "sha1": "CC092CC10529B8996441E78AA02EC5C47EDA070D",

--- a/KAS/KAS-1.0.ckan
+++ b/KAS/KAS-1.0.ckan
@@ -15,8 +15,12 @@
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "1.0",
-    "ksp_version_min": "1.5.0",
-    "ksp_version_max": "1.5.99",
+    "ksp_version": "1.5",
+    "localizations": [
+        "en-us",
+        "it-it",
+        "ru"
+    ],
     "recommends": [
         {
             "name": "KIS"

--- a/KAS/KAS-1.1.ckan
+++ b/KAS/KAS-1.1.ckan
@@ -17,6 +17,12 @@
     "version": "1.1",
     "ksp_version_min": "1.5",
     "ksp_version_max": "1.5.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "it-it",
+        "ru"
+    ],
     "recommends": [
         {
             "name": "KIS"

--- a/KAS/KAS-1.2.ckan
+++ b/KAS/KAS-1.2.ckan
@@ -17,6 +17,14 @@
     "version": "1.2",
     "ksp_version_min": "1.6.0",
     "ksp_version_max": "1.6.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "fr-fr",
+        "it-it",
+        "pt-br",
+        "ru"
+    ],
     "recommends": [
         {
             "name": "KIS"

--- a/KAS/KAS-1.3.ckan
+++ b/KAS/KAS-1.3.ckan
@@ -17,6 +17,14 @@
     "version": "1.3",
     "ksp_version_min": "1.7",
     "ksp_version_max": "1.7.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "fr-fr",
+        "it-it",
+        "pt-br",
+        "ru"
+    ],
     "recommends": [
         {
             "name": "KIS"


### PR DESCRIPTION
## Problem

See KSP-CKAN/CKAN#2825, Curse changed their download URL format, so KIS and KAS's old download URLs don't work anymore.

## Changes

Now the metadata for KIS and KAS's old versions is refreshed with the latest resources, locales, and download URLs.
A few missing versions are added as well.

Fixes KSP-CKAN/CKAN#2836.