### PR TITLE
Clean up old KIS & KAS & EasyVesselSwitch metadata

### DIFF
--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.0.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.0.0.ckan
@@ -2,18 +2,20 @@
     "spec_version": 1,
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
-    "abstract": "Stock game doesn't offer consistent model of the camera positioning when active vessel is switched. EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features.",
+    "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",
     "author": [
         "IgorZ"
     ],
     "license": "public-domain",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141180-easy-vessel-switch-evs/",
+        "curse": "https://kerbal.curseforge.com/projects/245805",
         "repository": "https://github.com/ihsoft/EasyVesselSwitch",
-        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues"
+        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/42/203/120/120/636006100400447117.jpeg"
     },
     "version": "1.0.0.0",
-    "ksp_version": "1.1.2",
+    "ksp_version": "1.1",
     "suggests": [
         {
             "name": "KIS"
@@ -22,7 +24,7 @@
             "name": "KAS"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/easy-vessel-switch-evs/files/2305110/download",
+    "download": "https://media.forgecdn.net/files/2305/110/EasyVesselSwitch_v1.0.0.zip",
     "download_size": 40995,
     "download_hash": {
         "sha1": "9F6CEC963978AC5D0E3BD96EEDDB56038D65F794",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.1.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.1.0.ckan
@@ -2,18 +2,20 @@
     "spec_version": 1,
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
-    "abstract": "Stock game doesn't offer consistent model of the camera positioning when active vessel is switched. EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features.",
+    "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",
     "author": [
         "IgorZ"
     ],
     "license": "public-domain",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141180-easy-vessel-switch-evs/",
+        "curse": "https://kerbal.curseforge.com/projects/245805",
         "repository": "https://github.com/ihsoft/EasyVesselSwitch",
-        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues"
+        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/42/203/120/120/636006100400447117.jpeg"
     },
     "version": "1.0.1.0",
-    "ksp_version": "1.1.2",
+    "ksp_version": "1.1",
     "suggests": [
         {
             "name": "KIS"
@@ -22,7 +24,7 @@
             "name": "KAS"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/easy-vessel-switch-evs/files/2307475/download",
+    "download": "https://media.forgecdn.net/files/2307/475/EasyVesselSwitch_v1.0.1.zip",
     "download_size": 41573,
     "download_hash": {
         "sha1": "A41CB443EB9D8311F27569F655B5C15E6EB14DAD",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.2.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.2.0.ckan
@@ -2,19 +2,20 @@
     "spec_version": 1,
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
-    "abstract": "Stock game doesn't offer consistent model of the camera positioning when active vessel is switched. EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features.",
+    "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",
     "author": [
         "IgorZ"
     ],
     "license": "public-domain",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141180-easy-vessel-switch-evs/",
+        "curse": "https://kerbal.curseforge.com/projects/245805",
         "repository": "https://github.com/ihsoft/EasyVesselSwitch",
-        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues"
+        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/42/203/120/120/636006100400447117.jpeg"
     },
     "version": "1.0.2.0",
-    "ksp_version_min": "1.1.2",
-    "ksp_version_max": "1.1.99",
+    "ksp_version": "1.1",
     "suggests": [
         {
             "name": "KIS"
@@ -23,7 +24,7 @@
             "name": "KAS"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/easy-vessel-switch-evs/files/2307491/download",
+    "download": "https://media.forgecdn.net/files/2307/491/EasyVesselSwitch_v1.0.2.zip",
     "download_size": 41574,
     "download_hash": {
         "sha1": "614708E47234217717C3A3DAEFEB825412CC87AC",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.3.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.3.0.ckan
@@ -2,15 +2,17 @@
     "spec_version": 1,
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
-    "abstract": "Stock game doesn't offer consistent model of the camera positioning when active vessel is switched. EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features.",
+    "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",
     "author": [
         "IgorZ"
     ],
     "license": "public-domain",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141180-easy-vessel-switch-evs/",
+        "curse": "https://kerbal.curseforge.com/projects/245805",
         "repository": "https://github.com/ihsoft/EasyVesselSwitch",
-        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues"
+        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/42/203/120/120/636006100400447117.jpeg"
     },
     "version": "1.0.3.0",
     "ksp_version_min": "1.1.2",
@@ -23,7 +25,7 @@
             "name": "KAS"
         }
     ],
-    "download": "https://kerbal.curseforge.com/projects/easy-vessel-switch-evs/files/2331443/download",
+    "download": "https://media.forgecdn.net/files/2331/443/EasyVesselSwitch_v1.0.3.zip",
     "download_size": 41643,
     "download_hash": {
         "sha1": "60B5B358D0266BD94D726E6857130DCDAE49E08E",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.1.1.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.1.1.0.ckan
@@ -2,19 +2,20 @@
     "spec_version": 1,
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
-    "abstract": "Stock game doesn't offer consistent model of the camera positioning when active vessel is switched. EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features.",
+    "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",
     "author": [
         "IgorZ"
     ],
     "license": "public-domain",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141180-easy-vessel-switch-evs/",
+        "curse": "https://kerbal.curseforge.com/projects/245805",
         "repository": "https://github.com/ihsoft/EasyVesselSwitch",
-        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues"
+        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/42/203/120/120/636006100400447117.jpeg"
     },
     "version": "1.1.1.0",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.99",
+    "ksp_version": "1.2",
     "suggests": [
         {
             "name": "KIS"
@@ -23,7 +24,7 @@
             "name": "KAS"
         }
     ],
-    "download": "https://kerbal.curseforge.com/projects/easy-vessel-switch-evs/files/2336077/download",
+    "download": "https://media.forgecdn.net/files/2336/77/EasyVesselSwitch_v1.1.1.zip",
     "download_size": 42152,
     "download_hash": {
         "sha1": "FB02AC7D83CE6CE052D2CD77ED1F11289D2048E4",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.10.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.10.ckan
@@ -17,6 +17,12 @@
     "version": "1.10",
     "ksp_version_min": "1.6.0",
     "ksp_version_max": "1.6.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "it-it",
+        "ru"
+    ],
     "suggests": [
         {
             "name": "KIS"

--- a/EasyVesselSwitch/EasyVesselSwitch-1.2.0.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.2.0.0.ckan
@@ -2,19 +2,20 @@
     "spec_version": 1,
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
-    "abstract": "Stock game doesn't offer consistent model of the camera positioning when active vessel is switched. EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features.",
+    "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",
     "author": [
         "IgorZ"
     ],
     "license": "public-domain",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141180-easy-vessel-switch-evs/",
+        "curse": "https://kerbal.curseforge.com/projects/245805",
         "repository": "https://github.com/ihsoft/EasyVesselSwitch",
-        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues"
+        "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/42/203/120/120/636006100400447117.jpeg"
     },
     "version": "1.2.0.0",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.99",
+    "ksp_version": "1.2",
     "suggests": [
         {
             "name": "KIS"
@@ -23,7 +24,7 @@
             "name": "KAS"
         }
     ],
-    "download": "https://kerbal.curseforge.com/projects/easy-vessel-switch-evs/files/2356016/download",
+    "download": "https://media.forgecdn.net/files/2356/16/EasyVesselSwitch_v1.2.0.zip",
     "download_size": 51233,
     "download_hash": {
         "sha1": "158980C142CD0F591F40A82CCB9ABF35D998C7ED",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.2.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.2.0.ckan
@@ -2,21 +2,20 @@
     "spec_version": 1,
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
-    "abstract": "Stock game doesn't offer consistent model of the camera positioning when active vessel is switched. EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features.",
+    "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",
     "author": [
         "IgorZ"
     ],
     "license": "public-domain",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141180-easy-vessel-switch-evs/",
-        "curse": "http://kerbal.curseforge.com/projects/245805",
+        "curse": "https://kerbal.curseforge.com/projects/245805",
         "repository": "https://github.com/ihsoft/EasyVesselSwitch",
         "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues",
-        "x_screenshot": "https://media-curse.cursecdn.com/attachments/188/167/08dbaa4929d0ec2966ed8c393b7a43b6.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/42/203/120/120/636006100400447117.jpeg"
     },
     "version": "1.2.0",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.99",
+    "ksp_version": "1.2",
     "suggests": [
         {
             "name": "KIS"
@@ -25,7 +24,7 @@
             "name": "KAS"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2356/16/EasyVesselSwitch_v1.2.0.zip",
+    "download": "https://media.forgecdn.net/files/2356/16/EasyVesselSwitch_v1.2.0.zip",
     "download_size": 51233,
     "download_hash": {
         "sha1": "158980C142CD0F591F40A82CCB9ABF35D998C7ED",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.3.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.3.0.ckan
@@ -2,17 +2,17 @@
     "spec_version": 1,
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
-    "abstract": "Stock game doesn't offer consistent model of the camera positioning when active vessel is switched. EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features.",
+    "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",
     "author": [
         "IgorZ"
     ],
     "license": "public-domain",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141180-easy-vessel-switch-evs/",
-        "curse": "http://kerbal.curseforge.com/projects/245805",
+        "curse": "https://kerbal.curseforge.com/projects/245805",
         "repository": "https://github.com/ihsoft/EasyVesselSwitch",
         "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues",
-        "x_screenshot": "https://media-curse.cursecdn.com/attachments/188/167/08dbaa4929d0ec2966ed8c393b7a43b6.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/42/203/120/120/636006100400447117.jpeg"
     },
     "version": "1.3.0",
     "ksp_version_min": "1.3",
@@ -25,7 +25,7 @@
             "name": "KAS"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2424/908/EasyVesselSwitch_v1.3.0.zip",
+    "download": "https://media.forgecdn.net/files/2424/908/EasyVesselSwitch_v1.3.0.zip",
     "download_size": 54853,
     "download_hash": {
         "sha1": "F30BA0167E4224D4C04E436557B88F39A30747B9",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.4.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.4.ckan
@@ -2,21 +2,24 @@
     "spec_version": 1,
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
-    "abstract": "Stock game doesn't offer consistent model of the camera positioning when active vessel is switched. EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features.",
+    "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",
     "author": [
         "IgorZ"
     ],
     "license": "public-domain",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141180-easy-vessel-switch-evs/",
-        "curse": "http://kerbal.curseforge.com/projects/245805",
+        "curse": "https://kerbal.curseforge.com/projects/245805",
         "repository": "https://github.com/ihsoft/EasyVesselSwitch",
         "bugtracker": "https://github.com/ihsoft/EasyVesselSwitch/issues",
-        "x_screenshot": "https://media-curse.cursecdn.com/attachments/188/167/08dbaa4929d0ec2966ed8c393b7a43b6.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/42/203/120/120/636006100400447117.jpeg"
     },
     "version": "1.4",
-    "ksp_version_min": "1.3",
-    "ksp_version_max": "1.3.99",
+    "ksp_version": "1.3",
+    "localizations": [
+        "en-us",
+        "ru"
+    ],
     "suggests": [
         {
             "name": "KIS"
@@ -25,7 +28,7 @@
             "name": "KAS"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2481/174/EasyVesselSwitch_v1.4.zip",
+    "download": "https://media.forgecdn.net/files/2481/174/EasyVesselSwitch_v1.4.zip",
     "download_size": 69347,
     "download_hash": {
         "sha1": "8CCE644ABF33EF72AEEFC28D4616C12578078305",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.5.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.5.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
-    "abstract": "Stock game doesn't offer consistent model of the camera positioning when active vessel is switched. EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features.",
+    "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",
     "author": [
         "IgorZ"
     ],
@@ -17,6 +17,10 @@
     "version": "1.5",
     "ksp_version_min": "1.3",
     "ksp_version_max": "1.3.99",
+    "localizations": [
+        "en-us",
+        "ru"
+    ],
     "suggests": [
         {
             "name": "KIS"

--- a/EasyVesselSwitch/EasyVesselSwitch-1.6.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.6.ckan
@@ -17,6 +17,10 @@
     "version": "1.6",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.99",
+    "localizations": [
+        "en-us",
+        "ru"
+    ],
     "suggests": [
         {
             "name": "KIS"

--- a/EasyVesselSwitch/EasyVesselSwitch-1.7.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.7.ckan
@@ -17,6 +17,12 @@
     "version": "1.7",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "it-it",
+        "ru"
+    ],
     "suggests": [
         {
             "name": "KIS"

--- a/EasyVesselSwitch/EasyVesselSwitch-1.8.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.8.ckan
@@ -17,6 +17,12 @@
     "version": "1.8",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "it-it",
+        "ru"
+    ],
     "suggests": [
         {
             "name": "KIS"

--- a/EasyVesselSwitch/EasyVesselSwitch-1.9.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.9.ckan
@@ -17,6 +17,12 @@
     "version": "1.9",
     "ksp_version_min": "1.5",
     "ksp_version_max": "1.5.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "it-it",
+        "ru"
+    ],
     "suggests": [
         {
             "name": "KIS"

--- a/KAS/KAS-0.4.10.ckan
+++ b/KAS/KAS-0.4.10.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -11,15 +11,24 @@
         "a.g."
     ],
     "license": "restricted",
-    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
+    },
     "version": "0.4.10",
     "ksp_version": "0.90",
-    "depends": [
+    "recommends": [
         {
-            "name": "ModuleManager"
+            "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/ksp-mods/223900-kerbal-attachment-system-kas/files/2222185/download",
+    "download": "https://media.forgecdn.net/files/2222/185/KAS_0.4.10.zip",
     "download_size": 6758533,
     "download_hash": {
         "sha1": "CA899565B7F5B2FF9528A420C5DD7F085E39513D",

--- a/KAS/KAS-0.4.7.ckan
+++ b/KAS/KAS-0.4.7.ckan
@@ -4,12 +4,7 @@
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
-        "IgorZ",
-        "KospY",
-        "Winn75",
-        "zzz",
-        "Majiir",
-        "a.g."
+        "IgorZ"
     ],
     "license": "restricted",
     "resources": {
@@ -19,8 +14,8 @@
         "bugtracker": "https://github.com/ihsoft/KAS/issues",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
-    "version": "0.6.3.0",
-    "ksp_version": "1.3",
+    "version": "0.4.7",
+    "ksp_version": "0.23.5",
     "recommends": [
         {
             "name": "KIS"
@@ -29,11 +24,11 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://media.forgecdn.net/files/2425/421/KAS_v0.6.3.zip",
-    "download_size": 2982090,
+    "download": "https://media.forgecdn.net/files/2240/822/KAS_0.4.7.zip",
+    "download_size": 7420744,
     "download_hash": {
-        "sha1": "2AD8F6356D9A4C21F9C50426C9CF793ED8FCA8B0",
-        "sha256": "4A5B9BD957D3049249DD35C42B4D0586B7DC1FF41E27FF744B8F01CED0E49E60"
+        "sha1": "21BEDC26A7D3986262323D9A6B03C51154ECBDCF",
+        "sha256": "3148907900190B91AAEFE7B8670C92D6C83A2077152B69134CF5E9E02B2F28C2"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KAS/KAS-0.4.8.ckan
+++ b/KAS/KAS-0.4.8.ckan
@@ -4,12 +4,7 @@
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
-        "IgorZ",
-        "KospY",
-        "Winn75",
-        "zzz",
-        "Majiir",
-        "a.g."
+        "IgorZ"
     ],
     "license": "restricted",
     "resources": {
@@ -19,8 +14,8 @@
         "bugtracker": "https://github.com/ihsoft/KAS/issues",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
-    "version": "0.6.3.0",
-    "ksp_version": "1.3",
+    "version": "0.4.8",
+    "ksp_version": "0.24.2",
     "recommends": [
         {
             "name": "KIS"
@@ -29,11 +24,11 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://media.forgecdn.net/files/2425/421/KAS_v0.6.3.zip",
-    "download_size": 2982090,
+    "download": "https://media.forgecdn.net/files/2213/185/KAS_0.4.8.zip",
+    "download_size": 6735103,
     "download_hash": {
-        "sha1": "2AD8F6356D9A4C21F9C50426C9CF793ED8FCA8B0",
-        "sha256": "4A5B9BD957D3049249DD35C42B4D0586B7DC1FF41E27FF744B8F01CED0E49E60"
+        "sha1": "B42390AAC7170A04B45884213A60AD4FCDE79EF7",
+        "sha256": "B07E169CF580D9313F336182DD0D89F2E933C8F132CB8B7F0CFDDFE6F855B089"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KAS/KAS-0.4.9.ckan
+++ b/KAS/KAS-0.4.9.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -11,15 +11,24 @@
         "a.g."
     ],
     "license": "restricted",
-    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
+    },
     "version": "0.4.9",
     "ksp_version": "0.25",
-    "depends": [
+    "recommends": [
         {
-            "name": "ModuleManager"
+            "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/ksp-mods/223900-kerbal-attachment-system-kas/files/2216138/download",
+    "download": "https://media.forgecdn.net/files/2216/138/KAS_0.4.9.zip",
     "download_size": 6758559,
     "download_hash": {
         "sha1": "3F07FDB0943B7606A2F9376B178B5C1653741441",

--- a/KAS/KAS-0.4.ckan
+++ b/KAS/KAS-0.4.ckan
@@ -4,12 +4,7 @@
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
-        "IgorZ",
-        "KospY",
-        "Winn75",
-        "zzz",
-        "Majiir",
-        "a.g."
+        "IgorZ"
     ],
     "license": "restricted",
     "resources": {
@@ -19,8 +14,8 @@
         "bugtracker": "https://github.com/ihsoft/KAS/issues",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
-    "version": "0.6.3.0",
-    "ksp_version": "1.3",
+    "version": "0.4",
+    "ksp_version": "1.0.2",
     "recommends": [
         {
             "name": "KIS"
@@ -29,11 +24,11 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://media.forgecdn.net/files/2425/421/KAS_v0.6.3.zip",
-    "download_size": 2982090,
+    "download": "https://media.forgecdn.net/files/2238/230/KAS_v0.4_OldParts.zip",
+    "download_size": 3048866,
     "download_hash": {
-        "sha1": "2AD8F6356D9A4C21F9C50426C9CF793ED8FCA8B0",
-        "sha256": "4A5B9BD957D3049249DD35C42B4D0586B7DC1FF41E27FF744B8F01CED0E49E60"
+        "sha1": "C6AA0EB1C29C66F50472DCD1495AA1FF6A28B354",
+        "sha256": "5A5CECC29D679CF784BEA33603D43C7A242428B203BF2FC236C40B8FE0D0110F"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KAS/KAS-0.5.0.ckan
+++ b/KAS/KAS-0.5.0.ckan
@@ -4,12 +4,7 @@
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
-        "IgorZ",
-        "KospY",
-        "Winn75",
-        "zzz",
-        "Majiir",
-        "a.g."
+        "IgorZ"
     ],
     "license": "restricted",
     "resources": {
@@ -19,8 +14,8 @@
         "bugtracker": "https://github.com/ihsoft/KAS/issues",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
-    "version": "0.6.3.0",
-    "ksp_version": "1.3",
+    "version": "0.5.0",
+    "ksp_version": "1.0.2",
     "recommends": [
         {
             "name": "KIS"
@@ -29,11 +24,11 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://media.forgecdn.net/files/2425/421/KAS_v0.6.3.zip",
-    "download_size": 2982090,
+    "download": "https://media.forgecdn.net/files/2238/224/KAS_v0.5.0.zip",
+    "download_size": 2659912,
     "download_hash": {
-        "sha1": "2AD8F6356D9A4C21F9C50426C9CF793ED8FCA8B0",
-        "sha256": "4A5B9BD957D3049249DD35C42B4D0586B7DC1FF41E27FF744B8F01CED0E49E60"
+        "sha1": "80CAF27893EB9EBB086317DA67312A57E42F9571",
+        "sha256": "1B218FD7472FE13B91C8768C28C889266C57B49E987427CB1A337D8EC30BACD0"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KAS/KAS-0.5.1.ckan
+++ b/KAS/KAS-0.5.1.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -12,20 +12,23 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.1",
     "ksp_version": "1.0.2",
-    "depends": [
+    "recommends": [
         {
-            "name": "ModuleManager"
+            "name": "KIS"
         },
         {
-            "name": "KIS",
-            "min_version": "1.1.4"
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons-origin.cursecdn.com/files/2238/254/KAS_v0.5.1.zip",
+    "download": "https://media.forgecdn.net/files/2238/254/KAS_v0.5.1.zip",
     "download_size": 2660240,
     "download_hash": {
         "sha1": "8FCF867C53E7A40D3C9A7CF14979B7E37EC54204",

--- a/KAS/KAS-0.5.2.ckan
+++ b/KAS/KAS-0.5.2.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -12,21 +12,24 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.2",
     "ksp_version_min": "1.0.2",
     "ksp_version_max": "1.0.4",
-    "depends": [
+    "recommends": [
         {
-            "name": "ModuleManager"
+            "name": "KIS"
         },
         {
-            "name": "KIS",
-            "min_version": "1.1.5"
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons-origin.cursecdn.com/files/2240/844/KAS_v0.5.2.zip",
+    "download": "https://media.forgecdn.net/files/2240/844/KAS_v0.5.2.zip",
     "download_size": 3033561,
     "download_hash": {
         "sha1": "136B826437DF1666A720527D9ACDF835E8B73F54",

--- a/KAS/KAS-0.5.3.ckan
+++ b/KAS/KAS-0.5.3.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -12,21 +12,24 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.3",
     "ksp_version_min": "1.0.3",
     "ksp_version_max": "1.0.4",
-    "depends": [
+    "recommends": [
         {
-            "name": "ModuleManager"
+            "name": "KIS"
         },
         {
-            "name": "KIS",
-            "min_version": "1.2.0"
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons.curse.cursecdn.com/files/2246/546/KAS_v0.5.3.zip",
+    "download": "https://media.forgecdn.net/files/2246/546/KAS_v0.5.3.zip",
     "download_size": 3033563,
     "download_hash": {
         "sha1": "48B1BCCC00DD2B866EA13E904A74C2A9971785BA",

--- a/KAS/KAS-0.5.4.ckan
+++ b/KAS/KAS-0.5.4.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -12,22 +12,24 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.4",
     "ksp_version_min": "1.0.3",
     "ksp_version_max": "1.0.4",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
     "recommends": [
         {
             "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons.curse.cursecdn.com/files/2249/712/KAS_v0.5.4.zip",
+    "download": "https://media.forgecdn.net/files/2249/712/KAS_v0.5.4.zip",
     "download_size": 6063412,
     "download_hash": {
         "sha1": "051002EF1484F49923DE7C98DD77C8E68FFDE5E4",

--- a/KAS/KAS-0.5.5.ckan
+++ b/KAS/KAS-0.5.5.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -12,22 +12,23 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514",
-        "repository": "https://github.com/KospY/KAS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.5",
     "ksp_version": "1.0.5",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
     "recommends": [
         {
             "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons.curse.cursecdn.com/files/2266/204/KAS_v0.5.5.zip",
+    "download": "https://media.forgecdn.net/files/2266/204/KAS_v0.5.5.zip",
     "download_size": 3035893,
     "download_hash": {
         "sha1": "9D036821C2465793852EFF7E0F5E66D61380FD3A",

--- a/KAS/KAS-0.5.6.ckan
+++ b/KAS/KAS-0.5.6.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -13,22 +13,23 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514",
-        "repository": "https://github.com/KospY/KAS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.6",
     "ksp_version": "1.1",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
     "recommends": [
         {
             "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2295395/download",
+    "download": "https://media.forgecdn.net/files/2295/395/KAS_v0.5.6_build7.zip",
     "download_size": 2990132,
     "download_hash": {
         "sha1": "E7B444350BC21AAAB1D2E6C7F2C14380DB5A00A0",

--- a/KAS/KAS-0.5.7.ckan
+++ b/KAS/KAS-0.5.7.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -13,22 +13,23 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514",
-        "repository": "https://github.com/KospY/KAS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.7",
     "ksp_version": "1.1",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
     "recommends": [
         {
             "name": "KIS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2297485/download",
+    "download": "https://media.forgecdn.net/files/2297/485/KAS_v0.5.7.zip",
     "download_size": 2989977,
     "download_hash": {
         "sha1": "EC02BE7DD4F980313220A6EBCAB6CA3ABB1D61E3",

--- a/KAS/KAS-0.5.8.0.ckan
+++ b/KAS/KAS-0.5.8.0.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -13,29 +13,23 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/92514",
-        "repository": "https://github.com/KospY/KAS",
-        "bugtracker": "https://github.com/KospY/KAS/issues"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.8.0",
-    "ksp_version_min": "1.1.2",
-    "ksp_version_max": "1.1.99",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
+    "ksp_version": "1.1",
     "recommends": [
         {
             "name": "KIS"
-        }
-    ],
-    "suggests": [
+        },
         {
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2307201/download",
+    "download": "https://media.forgecdn.net/files/2307/201/KAS_v0.5.8.zip",
     "download_size": 2990069,
     "download_hash": {
         "sha1": "CFA33E9C9C88C0750026FC3C7A65030FCE4341CA",

--- a/KAS/KAS-0.5.9.0.ckan
+++ b/KAS/KAS-0.5.9.0.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -14,28 +14,22 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
-        "repository": "https://github.com/KospY/KAS",
-        "bugtracker": "https://github.com/KospY/KAS/issues"
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.5.9.0",
-    "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.1.99",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
+    "ksp_version": "1.1",
     "recommends": [
         {
             "name": "KIS"
-        }
-    ],
-    "suggests": [
+        },
         {
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2310963/download",
+    "download": "https://media.forgecdn.net/files/2310/963/KAS_v0.5.9.zip",
     "download_size": 2990318,
     "download_hash": {
         "sha1": "913EA9F244F2B9C41055B45BE584D8644ABE7F21",

--- a/KAS/KAS-0.6.0.0.ckan
+++ b/KAS/KAS-0.6.0.0.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -14,28 +14,22 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
-        "repository": "https://github.com/KospY/KAS",
-        "bugtracker": "https://github.com/KospY/KAS/issues"
+        "curse": "https://kerbal.curseforge.com/projects/223900",
+        "repository": "https://github.com/ihsoft/KAS",
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.6.0.0",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.99",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
+    "ksp_version": "1.2",
     "recommends": [
         {
             "name": "KIS"
-        }
-    ],
-    "suggests": [
+        },
         {
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2336078/download",
+    "download": "https://media.forgecdn.net/files/2336/78/KAS_v0.6.0.zip",
     "download_size": 2982624,
     "download_hash": {
         "sha1": "56178A7602EFD2391134ACC5BCB3C21326999BF5",

--- a/KAS/KAS-0.6.1.0.ckan
+++ b/KAS/KAS-0.6.1.0.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -14,28 +14,22 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
         "repository": "https://github.com/ihsoft/KAS",
-        "bugtracker": "https://github.com/ihsoft/KAS/issues"
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.6.1.0",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.99",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
+    "ksp_version": "1.2",
     "recommends": [
         {
             "name": "KIS"
-        }
-    ],
-    "suggests": [
+        },
         {
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2352830/download",
+    "download": "https://media.forgecdn.net/files/2352/830/KAS_v0.6.1.zip",
     "download_size": 2982680,
     "download_hash": {
         "sha1": "76C6CFE1E5B38C2248DF112716F203E8A520E88F",

--- a/KAS/KAS-0.6.2.0.ckan
+++ b/KAS/KAS-0.6.2.0.ckan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
-    "abstract": "KAS introduces new gameplay mechanics by adding winches, containers, dynamic struts/pipes and grabbable & attachable parts.",
+    "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",
     "author": [
         "KospY",
         "Winn75",
@@ -14,28 +14,22 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142594-kerbal-attachment-system-kas/",
+        "curse": "https://kerbal.curseforge.com/projects/223900",
         "repository": "https://github.com/ihsoft/KAS",
-        "bugtracker": "https://github.com/ihsoft/KAS/issues"
+        "bugtracker": "https://github.com/ihsoft/KAS/issues",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "0.6.2.0",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.99",
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
+    "ksp_version": "1.2",
     "recommends": [
         {
             "name": "KIS"
-        }
-    ],
-    "suggests": [
+        },
         {
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://kerbal.curseforge.com/projects/kerbal-attachment-system-kas/files/2360802/download",
+    "download": "https://media.forgecdn.net/files/2360/802/KAS_v0.6.2.zip",
     "download_size": 2982841,
     "download_hash": {
         "sha1": "CC092CC10529B8996441E78AA02EC5C47EDA070D",

--- a/KAS/KAS-1.0.ckan
+++ b/KAS/KAS-1.0.ckan
@@ -15,8 +15,12 @@
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/17/968/120/120/635672058281519835.png"
     },
     "version": "1.0",
-    "ksp_version_min": "1.5.0",
-    "ksp_version_max": "1.5.99",
+    "ksp_version": "1.5",
+    "localizations": [
+        "en-us",
+        "it-it",
+        "ru"
+    ],
     "recommends": [
         {
             "name": "KIS"

--- a/KAS/KAS-1.1.ckan
+++ b/KAS/KAS-1.1.ckan
@@ -17,6 +17,12 @@
     "version": "1.1",
     "ksp_version_min": "1.5",
     "ksp_version_max": "1.5.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "it-it",
+        "ru"
+    ],
     "recommends": [
         {
             "name": "KIS"

--- a/KAS/KAS-1.2.ckan
+++ b/KAS/KAS-1.2.ckan
@@ -17,6 +17,14 @@
     "version": "1.2",
     "ksp_version_min": "1.6.0",
     "ksp_version_max": "1.6.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "fr-fr",
+        "it-it",
+        "pt-br",
+        "ru"
+    ],
     "recommends": [
         {
             "name": "KIS"

--- a/KAS/KAS-1.3.ckan
+++ b/KAS/KAS-1.3.ckan
@@ -17,6 +17,14 @@
     "version": "1.3",
     "ksp_version_min": "1.7",
     "ksp_version_max": "1.7.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "fr-fr",
+        "it-it",
+        "pt-br",
+        "ru"
+    ],
     "recommends": [
         {
             "name": "KIS"

--- a/KIS/KIS-1.0.0.ckan
+++ b/KIS/KIS-1.0.0.ckan
@@ -2,16 +2,39 @@
     "spec_version": 1,
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
-    "abstract": "KIS introduce new gameplay mechanics by adding a brand new inventory sytem and EVA usables items as tools.",
+    "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",
     "author": [
         "KospY",
         "Winn75"
     ],
     "license": "restricted",
-    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
+    },
     "version": "1.0.0",
     "ksp_version": "0.90",
-    "download": "http://kerbal.curseforge.com/ksp-mods/228561-kerbal-inventory-system-kis/files/2230231/download",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
+        }
+    ],
+    "download": "https://media.forgecdn.net/files/2230/231/KIS_v1.0.0.zip",
     "download_size": 4318060,
     "download_hash": {
         "sha1": "B6D770F34D95021DA00FB84F44C69A7F93BB66A7",

--- a/KIS/KIS-1.0.1.ckan
+++ b/KIS/KIS-1.0.1.ckan
@@ -4,7 +4,6 @@
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",
     "author": [
-        "IgorZ",
         "KospY",
         "Winn75"
     ],
@@ -17,17 +16,8 @@
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
-    "version": "1.20",
-    "ksp_version": "1.7",
-    "localizations": [
-        "en-us",
-        "es-es",
-        "fr-fr",
-        "it-it",
-        "pt-br",
-        "ru",
-        "zh-cn"
-    ],
+    "version": "1.0.1",
+    "ksp_version": "0.90",
     "recommends": [
         {
             "name": "CommunityCategoryKit"
@@ -44,11 +34,11 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://media.forgecdn.net/files/2707/28/KIS_v1.20.zip",
-    "download_size": 24813340,
+    "download": "https://media.forgecdn.net/files/2232/186/KIS_v1.0.1.zip",
+    "download_size": 8636434,
     "download_hash": {
-        "sha1": "E1E2C9B27EC66ED712466A05FEFFF8F965873700",
-        "sha256": "383BB275C0889C673DF1A60BBE7B5EDE73C807B5F896797FAC6794CDCF32E34C"
+        "sha1": "561DBAFBF0D9FD576F36BEC62E43C38C125F0ECE",
+        "sha256": "678AD104457A35C80B62B5E6C2B110C959828ACF4216EC86A5A05F8357A1C592"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KIS/KIS-1.0.2.ckan
+++ b/KIS/KIS-1.0.2.ckan
@@ -2,20 +2,39 @@
     "spec_version": 1,
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
-    "abstract": "KIS introduce new gameplay mechanics by adding a brand new inventory sytem and EVA usables items as tools.",
+    "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",
     "author": [
         "KospY",
         "Winn75"
     ],
     "license": "restricted",
-    "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111-0-90-Kerbal-Inventory-System-%28KIS%29-1-0-0",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.0.2",
     "ksp_version": "0.90",
-    "download": "http://kerbal.curseforge.com/ksp-mods/228561-kerbal-inventory-system-kis/files/2232840/download",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
+        }
+    ],
+    "download": "https://media.forgecdn.net/files/2232/840/KIS_v1.0.2.zip",
     "download_size": 8636416,
     "download_hash": {
         "sha1": "4879FF29E69A8FD007C9845555B5CE61EE75FF1A",

--- a/KIS/KIS-1.1.0.ckan
+++ b/KIS/KIS-1.1.0.ckan
@@ -2,20 +2,39 @@
     "spec_version": 1,
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
-    "abstract": "KIS introduce new gameplay mechanics by adding a brand new inventory sytem and EVA usables items as tools.",
+    "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",
     "author": [
         "KospY",
         "Winn75"
     ],
     "license": "restricted",
-    "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111-0-90-Kerbal-Inventory-System-%28KIS%29-1-0-0",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.1.0",
     "ksp_version": "1.0.0",
-    "download": "http://addons-origin.cursecdn.com/files/2235/938/KIS_v1.1.0.zip",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
+        }
+    ],
+    "download": "https://media.forgecdn.net/files/2235/938/KIS_v1.1.0.zip",
     "download_size": 11618008,
     "download_hash": {
         "sha1": "8CC42FA81179F2DDF5D78CD89251A58E47E6D527",

--- a/KIS/KIS-1.1.1.ckan
+++ b/KIS/KIS-1.1.1.ckan
@@ -2,20 +2,39 @@
     "spec_version": 1,
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
-    "abstract": "KIS introduce new gameplay mechanics by adding a brand new inventory sytem and EVA usables items as tools.",
+    "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",
     "author": [
         "KospY",
         "Winn75"
     ],
     "license": "restricted",
-    "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.1.1",
     "ksp_version": "1.0.0",
-    "download": "http://addons-origin.cursecdn.com/files/2236/307/KIS_v1.1.1.zip",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
+        }
+    ],
+    "download": "https://media.forgecdn.net/files/2236/307/KIS_v1.1.1.zip",
     "download_size": 5959203,
     "download_hash": {
         "sha1": "0F548CF6B1C7DCBAF7C645685A4A91363E3D2B5C",

--- a/KIS/KIS-1.1.2.ckan
+++ b/KIS/KIS-1.1.2.ckan
@@ -2,20 +2,39 @@
     "spec_version": 1,
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
-    "abstract": "KIS introduce new gameplay mechanics by adding a brand new inventory sytem and EVA usables items as tools.",
+    "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",
     "author": [
         "KospY",
         "Winn75"
     ],
     "license": "restricted",
-    "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.1.2",
     "ksp_version": "1.0.2",
-    "download": "http://addons-origin.cursecdn.com/files/2237/311/KIS_v1.1.2.zip",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
+        }
+    ],
+    "download": "https://media.forgecdn.net/files/2237/311/KIS_v1.1.2.zip",
     "download_size": 7128371,
     "download_hash": {
         "sha1": "382B843CA2DA87EB548A24998174307C820D3250",

--- a/KIS/KIS-1.1.3.ckan
+++ b/KIS/KIS-1.1.3.ckan
@@ -4,7 +4,6 @@
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",
     "author": [
-        "IgorZ",
         "KospY",
         "Winn75"
     ],
@@ -17,17 +16,8 @@
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
-    "version": "1.20",
-    "ksp_version": "1.7",
-    "localizations": [
-        "en-us",
-        "es-es",
-        "fr-fr",
-        "it-it",
-        "pt-br",
-        "ru",
-        "zh-cn"
-    ],
+    "version": "1.1.3",
+    "ksp_version": "1.0.0",
     "recommends": [
         {
             "name": "CommunityCategoryKit"
@@ -44,11 +34,11 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://media.forgecdn.net/files/2707/28/KIS_v1.20.zip",
-    "download_size": 24813340,
+    "download": "https://media.forgecdn.net/files/2238/152/KIS_v1.1.3.zip",
+    "download_size": 7129409,
     "download_hash": {
-        "sha1": "E1E2C9B27EC66ED712466A05FEFFF8F965873700",
-        "sha256": "383BB275C0889C673DF1A60BBE7B5EDE73C807B5F896797FAC6794CDCF32E34C"
+        "sha1": "59993A340E8FE2DB00D121C505E08ECB4DDF5CA2",
+        "sha256": "89C8D938E7445FA133F2EDC78166249A7195699715796DE51FEEB9F8FA179CA1"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KIS/KIS-1.1.4.ckan
+++ b/KIS/KIS-1.1.4.ckan
@@ -2,19 +2,39 @@
     "spec_version": 1,
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
-    "abstract": "KIS introduce new gameplay mechanics by adding a brand new inventory sytem and EVA usables items as tools.",
+    "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",
     "author": [
         "KospY",
         "Winn75"
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.1.4",
     "ksp_version": "1.0.2",
-    "download": "http://addons-origin.cursecdn.com/files/2238/213/KIS_v1.1.4.zip",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
+        }
+    ],
+    "download": "https://media.forgecdn.net/files/2238/213/KIS_v1.1.4.zip",
     "download_size": 7129480,
     "download_hash": {
         "sha1": "8AC828361B205C85C7F30B46848B2E720753A5B0",

--- a/KIS/KIS-1.1.5.ckan
+++ b/KIS/KIS-1.1.5.ckan
@@ -2,20 +2,40 @@
     "spec_version": 1,
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
-    "abstract": "KIS introduce new gameplay mechanics by adding a brand new inventory sytem and EVA usables items as tools.",
+    "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",
     "author": [
         "KospY",
         "Winn75"
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.1.5",
     "ksp_version_min": "1.0.2",
     "ksp_version_max": "1.0.4",
-    "download": "http://addons-origin.cursecdn.com/files/2240/842/KIS_v1.1.5.zip",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
+        }
+    ],
+    "download": "https://media.forgecdn.net/files/2240/842/KIS_v1.1.5.zip",
     "download_size": 3388162,
     "download_hash": {
         "sha1": "F96AD97F0A3FB263AB88ED4A5DFAA8E5D28CAA44",

--- a/KIS/KIS-1.10.ckan
+++ b/KIS/KIS-1.10.ckan
@@ -20,6 +20,12 @@
     "version": "1.10",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "ru",
+        "zh-cn"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.11.ckan
+++ b/KIS/KIS-1.11.ckan
@@ -17,14 +17,12 @@
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
-    "version": "1.20",
-    "ksp_version": "1.7",
+    "version": "1.11",
+    "ksp_version_min": "1.4.0",
+    "ksp_version_max": "1.4.99",
     "localizations": [
         "en-us",
         "es-es",
-        "fr-fr",
-        "it-it",
-        "pt-br",
         "ru",
         "zh-cn"
     ],
@@ -44,11 +42,11 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://media.forgecdn.net/files/2707/28/KIS_v1.20.zip",
-    "download_size": 24813340,
+    "download": "https://media.forgecdn.net/files/2545/515/KIS_v1.11.zip",
+    "download_size": 4418885,
     "download_hash": {
-        "sha1": "E1E2C9B27EC66ED712466A05FEFFF8F965873700",
-        "sha256": "383BB275C0889C673DF1A60BBE7B5EDE73C807B5F896797FAC6794CDCF32E34C"
+        "sha1": "63F590F6511B1878F30583AD31CBDA71FFE83532",
+        "sha256": "9D50E69F60F47836DA2F958E0D5B166CD305FDAE5B418EC857A9D7DAF8C69751"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KIS/KIS-1.12.ckan
+++ b/KIS/KIS-1.12.ckan
@@ -20,6 +20,12 @@
     "version": "1.12",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "ru",
+        "zh-cn"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.13.ckan
+++ b/KIS/KIS-1.13.ckan
@@ -20,6 +20,13 @@
     "version": "1.13",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "it-it",
+        "ru",
+        "zh-cn"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.14.ckan
+++ b/KIS/KIS-1.14.ckan
@@ -20,6 +20,13 @@
     "version": "1.14",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "it-it",
+        "ru",
+        "zh-cn"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.15.ckan
+++ b/KIS/KIS-1.15.ckan
@@ -18,8 +18,15 @@
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.15",
-    "ksp_version_min": "1.5.1",
+    "ksp_version_min": "1.5",
     "ksp_version_max": "1.5.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "it-it",
+        "ru",
+        "zh-cn"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.16.ckan
+++ b/KIS/KIS-1.16.ckan
@@ -20,6 +20,13 @@
     "version": "1.16",
     "ksp_version_min": "1.5",
     "ksp_version_max": "1.5.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "it-it",
+        "ru",
+        "zh-cn"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.17.ckan
+++ b/KIS/KIS-1.17.ckan
@@ -20,6 +20,14 @@
     "version": "1.17",
     "ksp_version_min": "1.6.0",
     "ksp_version_max": "1.6.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "it-it",
+        "pt-br",
+        "ru",
+        "zh-cn"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.18.ckan
+++ b/KIS/KIS-1.18.ckan
@@ -20,6 +20,15 @@
     "version": "1.18",
     "ksp_version_min": "1.6.0",
     "ksp_version_max": "1.6.99",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "fr-fr",
+        "it-it",
+        "pt-br",
+        "ru",
+        "zh-cn"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.19.ckan
+++ b/KIS/KIS-1.19.ckan
@@ -18,7 +18,16 @@
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.19",
-    "ksp_version": "1.7.0",
+    "ksp_version": "1.7",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "fr-fr",
+        "it-it",
+        "pt-br",
+        "ru",
+        "zh-cn"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.2.0.ckan
+++ b/KIS/KIS-1.2.0.ckan
@@ -9,13 +9,33 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.0",
     "ksp_version_min": "1.0.3",
     "ksp_version_max": "1.0.4",
-    "download": "http://addons.curse.cursecdn.com/files/2246/556/KIS_v1.2.0.zip",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
+        }
+    ],
+    "download": "https://media.forgecdn.net/files/2246/556/KIS_v1.2.0.zip",
     "download_size": 3974015,
     "download_hash": {
         "sha1": "2003092D1E62A5AD206123C1EF2BBDFAC6963B70",

--- a/KIS/KIS-1.2.1.ckan
+++ b/KIS/KIS-1.2.1.ckan
@@ -9,18 +9,33 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.1",
     "ksp_version_min": "1.0.3",
     "ksp_version_max": "1.0.4",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons.curse.cursecdn.com/files/2249/749/KIS_v1.2.1.zip",
+    "download": "https://media.forgecdn.net/files/2249/749/KIS_v1.2.1.zip",
     "download_size": 4852953,
     "download_hash": {
         "sha1": "E3C92B1F6032915B9B36948F38B40FCC260FDCD2",

--- a/KIS/KIS-1.2.10.0.ckan
+++ b/KIS/KIS-1.2.10.0.ckan
@@ -10,14 +10,19 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS",
-        "bugtracker": "https://github.com/KospY/KIS/issues",
-        "manual": "https://github.com/KospY/KIS/raw/master/User%20Guide.pdf"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.10.0",
-    "ksp_version": "1.1.2",
+    "ksp_version": "1.1",
     "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
         {
             "name": "ModuleManager"
         }
@@ -30,7 +35,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-inventory-system-kis/files/2302509/download",
+    "download": "https://media.forgecdn.net/files/2302/509/KIS_v1.2.10.zip",
     "download_size": 5451594,
     "download_hash": {
         "sha1": "7926582744F7D3258BB3E178664D0BD4E6D0E953",

--- a/KIS/KIS-1.2.11.0.ckan
+++ b/KIS/KIS-1.2.11.0.ckan
@@ -10,14 +10,19 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS",
-        "bugtracker": "https://github.com/KospY/KIS/issues",
-        "manual": "https://github.com/KospY/KIS/raw/master/User%20Guide.pdf"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.11.0",
-    "ksp_version": "1.1.2",
+    "ksp_version": "1.1",
     "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
         {
             "name": "ModuleManager"
         }
@@ -30,7 +35,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-inventory-system-kis/files/2306745/download",
+    "download": "https://media.forgecdn.net/files/2306/745/KIS_v1.2.11.zip",
     "download_size": 5453608,
     "download_hash": {
         "sha1": "2747FF156E282EBF422796590D510C967673DC92",

--- a/KIS/KIS-1.2.12.0.ckan
+++ b/KIS/KIS-1.2.12.0.ckan
@@ -10,15 +10,19 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS",
-        "bugtracker": "https://github.com/KospY/KIS/issues",
-        "manual": "https://github.com/KospY/KIS/raw/master/User%20Guide.pdf"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.12.0",
-    "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.1.99",
+    "ksp_version": "1.1",
     "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
         {
             "name": "ModuleManager"
         }
@@ -31,7 +35,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-inventory-system-kis/files/2309383/download",
+    "download": "https://media.forgecdn.net/files/2309/383/KIS_v1.2.12.zip",
     "download_size": 5453642,
     "download_hash": {
         "sha1": "F7DCC2B52004C7499D244D64ECBA6A7E9D5D466F",

--- a/KIS/KIS-1.2.2.ckan
+++ b/KIS/KIS-1.2.2.ckan
@@ -9,18 +9,33 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.2",
     "ksp_version_min": "1.0.3",
     "ksp_version_max": "1.0.4",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons-origin.cursecdn.com/files/2252/142/KIS_v1.2.2.zip",
+    "download": "https://media.forgecdn.net/files/2252/142/KIS_v1.2.2.zip",
     "download_size": 4176340,
     "download_hash": {
         "sha1": "39FEAE400E320DEE9F8C951F4C046616DA372A83",

--- a/KIS/KIS-1.2.3.ckan
+++ b/KIS/KIS-1.2.3.ckan
@@ -9,17 +9,32 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.3",
     "ksp_version": "1.0.5",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons-origin.cursecdn.com/files/2266/203/KIS_v1.2.3.zip",
+    "download": "https://media.forgecdn.net/files/2266/203/KIS_v1.2.3.zip",
     "download_size": 4176355,
     "download_hash": {
         "sha1": "18084AC8C786918052745F9DFCC58F7AF6BE97A0",

--- a/KIS/KIS-1.2.4.ckan
+++ b/KIS/KIS-1.2.4.ckan
@@ -9,17 +9,32 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.4",
     "ksp_version": "1.0.5",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://addons-origin.cursecdn.com/files/2283/12/KIS_v1.2.4_PROPER.zip",
+    "download": "https://media.forgecdn.net/files/2283/12/KIS_v1.2.4_PROPER.zip",
     "download_size": 5513587,
     "download_hash": {
         "sha1": "0DDA3A896FE0E9F2895ADC4544986499F128A3C8",

--- a/KIS/KIS-1.2.5.ckan
+++ b/KIS/KIS-1.2.5.ckan
@@ -10,17 +10,32 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.5",
     "ksp_version": "1.0.5",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://github.com/KospY/KIS/releases/download/1.2.5/KIS_v1.2.5.zip",
+    "download": "https://media.forgecdn.net/files/2283/248/KIS_v1.2.5.zip",
     "download_size": 5440031,
     "download_hash": {
         "sha1": "70B47FCBEB452BC017A30EF1F1F367B1D9A28F10",

--- a/KIS/KIS-1.2.6.ckan
+++ b/KIS/KIS-1.2.6.ckan
@@ -10,17 +10,32 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.6",
     "ksp_version": "1.0.5",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-inventory-system-kis/files/2292986/download",
+    "download": "https://media.forgecdn.net/files/2292/986/KIS_v1.2.6.zip",
     "download_size": 5448753,
     "download_hash": {
         "sha1": "FD9F1B039698ED195E4B45419601CB555251BAB3",

--- a/KIS/KIS-1.2.7.ckan
+++ b/KIS/KIS-1.2.7.ckan
@@ -10,17 +10,32 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.7",
     "ksp_version": "1.1",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-inventory-system-kis/files/2295394/download",
+    "download": "https://media.forgecdn.net/files/2295/394/KIS_v1.2.7_build6.zip",
     "download_size": 5449525,
     "download_hash": {
         "sha1": "BE1E8A745A70EA08F92053076EF49869CD973CAB",

--- a/KIS/KIS-1.2.8.ckan
+++ b/KIS/KIS-1.2.8.ckan
@@ -10,17 +10,32 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.8",
     "ksp_version": "1.1",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-inventory-system-kis/files/2297486/download",
+    "download": "https://media.forgecdn.net/files/2297/486/KIS_v1.2.8.zip",
     "download_size": 5450101,
     "download_hash": {
         "sha1": "5F7B9A53A3BD015646C940422BE65D75C190CBF7",

--- a/KIS/KIS-1.2.9.ckan
+++ b/KIS/KIS-1.2.9.ckan
@@ -10,17 +10,32 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.2.9",
     "ksp_version": "1.1",
+    "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "suggests": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "EasyVesselSwitch"
         }
     ],
-    "download": "http://kerbal.curseforge.com/projects/kerbal-inventory-system-kis/files/2297755/download",
+    "download": "https://media.forgecdn.net/files/2297/755/KIS_v1.2.9.zip",
     "download_size": 5450107,
     "download_hash": {
         "sha1": "462BBC7DD4A5C9A5685788538929085A5289197B",

--- a/KIS/KIS-1.21.ckan
+++ b/KIS/KIS-1.21.ckan
@@ -18,7 +18,16 @@
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.21",
-    "ksp_version": "1.7.0",
+    "ksp_version": "1.7",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "fr-fr",
+        "it-it",
+        "pt-br",
+        "ru",
+        "zh-cn"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"

--- a/KIS/KIS-1.3.0.0.ckan
+++ b/KIS/KIS-1.3.0.0.ckan
@@ -10,15 +10,19 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS",
-        "bugtracker": "https://github.com/KospY/KIS/issues",
-        "manual": "https://github.com/KospY/KIS/raw/master/User%20Guide.pdf"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.3.0.0",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.99",
+    "ksp_version": "1.2",
     "recommends": [
+        {
+            "name": "CommunityCategoryKit"
+        },
         {
             "name": "ModuleManager"
         }
@@ -31,7 +35,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://kerbal.curseforge.com/projects/kerbal-inventory-system-kis/files/2336079/download",
+    "download": "https://media.forgecdn.net/files/2336/79/KIS_v1.3.0.zip",
     "download_size": 5453984,
     "download_hash": {
         "sha1": "55AB52616F12D55E69E80BC660BC82C41D7D1B52",

--- a/KIS/KIS-1.3.1.0.ckan
+++ b/KIS/KIS-1.3.1.0.ckan
@@ -10,15 +10,16 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113111",
-        "repository": "https://github.com/KospY/KIS",
-        "bugtracker": "https://github.com/KospY/KIS/issues",
-        "manual": "https://github.com/KospY/KIS/raw/master/User%20Guide.pdf"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
+        "repository": "https://github.com/ihsoft/KIS",
+        "bugtracker": "https://github.com/ihsoft/KIS/issues",
+        "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.3.1.0",
-    "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.2.99",
-    "depends": [
+    "ksp_version": "1.2",
+    "recommends": [
         {
             "name": "CommunityCategoryKit"
         },
@@ -34,7 +35,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://kerbal.curseforge.com/projects/kerbal-inventory-system-kis/files/2348560/download",
+    "download": "https://media.forgecdn.net/files/2348/560/KIS_v1.3.1.zip",
     "download_size": 4111274,
     "download_hash": {
         "sha1": "0BB8FCF7B1C1DBD09670B08ED71FF7CE21CCD68B",

--- a/KIS/KIS-1.4.0.ckan
+++ b/KIS/KIS-1.4.0.ckan
@@ -11,11 +11,11 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
-        "curse": "http://kerbal.curseforge.com/projects/228561",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
         "repository": "https://github.com/ihsoft/KIS",
         "bugtracker": "https://github.com/ihsoft/KIS/issues",
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
-        "x_screenshot": "https://media-curse.cursecdn.com/attachments/142/84/a42f57265668ef0aa4b8eac6d9af6688.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.4.0",
     "ksp_version_min": "1.2",
@@ -36,7 +36,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2352/228/KIS_v1.4.0.zip",
+    "download": "https://media.forgecdn.net/files/2352/228/KIS_v1.4.0.zip",
     "download_size": 4170055,
     "download_hash": {
         "sha1": "6F335B101F438AA7E9E4852A622848A2DE4EED93",

--- a/KIS/KIS-1.4.1.ckan
+++ b/KIS/KIS-1.4.1.ckan
@@ -11,11 +11,11 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
-        "curse": "http://kerbal.curseforge.com/projects/228561",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
         "repository": "https://github.com/ihsoft/KIS",
         "bugtracker": "https://github.com/ihsoft/KIS/issues",
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
-        "x_screenshot": "https://media-curse.cursecdn.com/attachments/142/84/a42f57265668ef0aa4b8eac6d9af6688.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.4.1",
     "ksp_version_min": "1.2.0",
@@ -36,7 +36,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2369/398/KIS_v1.4.1.zip",
+    "download": "https://media.forgecdn.net/files/2369/398/KIS_v1.4.1.zip",
     "download_size": 4174126,
     "download_hash": {
         "sha1": "AA586559E81E2D732E04C696299896BCF686FB71",

--- a/KIS/KIS-1.4.2.ckan
+++ b/KIS/KIS-1.4.2.ckan
@@ -11,11 +11,11 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
-        "curse": "http://kerbal.curseforge.com/projects/228561",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
         "repository": "https://github.com/ihsoft/KIS",
         "bugtracker": "https://github.com/ihsoft/KIS/issues",
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
-        "x_screenshot": "https://media-curse.cursecdn.com/attachments/142/84/a42f57265668ef0aa4b8eac6d9af6688.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.4.2",
     "ksp_version_min": "1.2.0",
@@ -36,7 +36,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2374/4/KIS_v1.4.2.zip",
+    "download": "https://media.forgecdn.net/files/2374/4/KIS_v1.4.2.zip",
     "download_size": 4173676,
     "download_hash": {
         "sha1": "B0182676709D9465F97570569EF4EB43F3041B9F",

--- a/KIS/KIS-1.4.3.ckan
+++ b/KIS/KIS-1.4.3.ckan
@@ -11,11 +11,11 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
-        "curse": "http://kerbal.curseforge.com/projects/228561",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
         "repository": "https://github.com/ihsoft/KIS",
         "bugtracker": "https://github.com/ihsoft/KIS/issues",
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
-        "x_screenshot": "https://media-curse.cursecdn.com/attachments/142/84/a42f57265668ef0aa4b8eac6d9af6688.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.4.3",
     "ksp_version_min": "1.2.0",
@@ -36,7 +36,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2385/5/KIS_v1.4.3.zip",
+    "download": "https://media.forgecdn.net/files/2385/5/KIS_v1.4.3.zip",
     "download_size": 4250328,
     "download_hash": {
         "sha1": "4570A402D4F4D7B4234996B88E7EE7A57F889D78",

--- a/KIS/KIS-1.4.4.ckan
+++ b/KIS/KIS-1.4.4.ckan
@@ -11,11 +11,11 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
-        "curse": "http://kerbal.curseforge.com/projects/228561",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
         "repository": "https://github.com/ihsoft/KIS",
         "bugtracker": "https://github.com/ihsoft/KIS/issues",
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
-        "x_screenshot": "https://media-curse.cursecdn.com/attachments/142/84/a42f57265668ef0aa4b8eac6d9af6688.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.4.4",
     "ksp_version_min": "1.2.0",
@@ -36,7 +36,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2414/859/KIS_v1.4.4.zip",
+    "download": "https://media.forgecdn.net/files/2414/859/KIS_v1.4.4.zip",
     "download_size": 4255383,
     "download_hash": {
         "sha1": "E630F26D58C8C4F380D7445078B6064CFEE0562F",

--- a/KIS/KIS-1.5.0.ckan
+++ b/KIS/KIS-1.5.0.ckan
@@ -11,11 +11,11 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
-        "curse": "http://kerbal.curseforge.com/projects/228561",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
         "repository": "https://github.com/ihsoft/KIS",
         "bugtracker": "https://github.com/ihsoft/KIS/issues",
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
-        "x_screenshot": "https://media-curse.cursecdn.com/attachments/142/84/a42f57265668ef0aa4b8eac6d9af6688.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.5.0",
     "ksp_version_min": "1.3.0",
@@ -36,7 +36,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2425/200/KIS_v1.5.0.zip",
+    "download": "https://media.forgecdn.net/files/2425/200/KIS_v1.5.0.zip",
     "download_size": 4266949,
     "download_hash": {
         "sha1": "EB327D86A5ACC34F11671B2F0AEF2829C8BCF07A",

--- a/KIS/KIS-1.6.ckan
+++ b/KIS/KIS-1.6.ckan
@@ -11,15 +11,19 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",
-        "curse": "http://kerbal.curseforge.com/projects/228561",
+        "curse": "https://kerbal.curseforge.com/projects/228561",
         "repository": "https://github.com/ihsoft/KIS",
         "bugtracker": "https://github.com/ihsoft/KIS/issues",
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
-        "x_screenshot": "https://media-curse.cursecdn.com/attachments/142/84/a42f57265668ef0aa4b8eac6d9af6688.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.6",
     "ksp_version_min": "1.3",
     "ksp_version_max": "1.3.99",
+    "localizations": [
+        "en-us",
+        "ru"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"
@@ -36,7 +40,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2480/25/KIS_v1.6.zip",
+    "download": "https://media.forgecdn.net/files/2480/25/KIS_v1.6.zip",
     "download_size": 4308256,
     "download_hash": {
         "sha1": "6851BBA554D9816C78665BAEC8DC3F718DED7B53",

--- a/KIS/KIS-1.7.ckan
+++ b/KIS/KIS-1.7.ckan
@@ -15,11 +15,15 @@
         "repository": "https://github.com/ihsoft/KIS",
         "bugtracker": "https://github.com/ihsoft/KIS/issues",
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
-        "x_screenshot": "https://media-elerium.cursecdn.com/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.7",
     "ksp_version_min": "1.3",
     "ksp_version_max": "1.3.99",
+    "localizations": [
+        "en-us",
+        "ru"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"
@@ -36,7 +40,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2480/736/KIS_v1.7.zip",
+    "download": "https://media.forgecdn.net/files/2480/736/KIS_v1.7.zip",
     "download_size": 4308249,
     "download_hash": {
         "sha1": "AA66D1B9983319FC7F138909AFA812F7C666AE93",

--- a/KIS/KIS-1.8.ckan
+++ b/KIS/KIS-1.8.ckan
@@ -15,11 +15,15 @@
         "repository": "https://github.com/ihsoft/KIS",
         "bugtracker": "https://github.com/ihsoft/KIS/issues",
         "manual": "https://github.com/ihsoft/KIS/raw/master/User%20Guide.pdf",
-        "x_screenshot": "https://media-elerium.cursecdn.com/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
+        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.8",
-    "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.3.99",
+    "ksp_version": "1.3",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "ru"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"
@@ -36,7 +40,7 @@
             "name": "EasyVesselSwitch"
         }
     ],
-    "download": "https://addons-origin.cursecdn.com/files/2509/876/KIS_v1.8.zip",
+    "download": "https://media.forgecdn.net/files/2509/876/KIS_v1.8.zip",
     "download_size": 4317905,
     "download_hash": {
         "sha1": "F380B26BFE1534191DA6D309F56993EB6B52084F",

--- a/KIS/KIS-1.9.ckan
+++ b/KIS/KIS-1.9.ckan
@@ -18,8 +18,13 @@
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/15/210/120/120/635619081870286480.jpeg"
     },
     "version": "1.9",
-    "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.3.99",
+    "ksp_version": "1.3",
+    "localizations": [
+        "en-us",
+        "es-es",
+        "ru",
+        "zh-cn"
+    ],
     "recommends": [
         {
             "name": "CommunityCategoryKit"


### PR DESCRIPTION
## Problem

See KSP-CKAN/CKAN#2825, Curse changed their download URL format, so EasyVesselSwitch and KIS and KAS's old download URLs don't work anymore.

## Changes

Now the metadata for EasyVesselSwitch and KIS and KAS's old versions is refreshed with the latest resources, locales, and download URLs.
A few missing versions are added as well.

Fixes KSP-CKAN/CKAN#2836.
Replaces #1503.