### PR TITLE
Fix min version of old LaserDist version

### DIFF
--- a/LaserDist/LaserDist-v1.1.0.ckan
+++ b/LaserDist/LaserDist-v1.1.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/Dunbaratu/LaserDist"
     },
     "version": "v1.1.0",
-    "ksp_version_min": "1.1.2",
+    "ksp_version_min": "1.4.2",
     "ksp_version_max": "1.5.1",
     "suggests": [
         {


### PR DESCRIPTION
See KSP-CKAN/NetKAN#7324, this version of LaserDist has an incorrect min game version.
Now it's set based on the .version file.