### PR TITLE
Add game versions to old MechJebForAll

### DIFF
--- a/MechJebForAll/MechJebForAll-1.2.0.0.ckan
+++ b/MechJebForAll/MechJebForAll-1.2.0.0.ckan
@@ -11,7 +11,8 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/83362"
     },
     "version": "1.2.0.0",
-    "ksp_version": "any",
+    "ksp_version_min": "1.0",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"


### PR DESCRIPTION
This mod has an old version that falsely claims far greater compatibility than later versions:

![image](https://user-images.githubusercontent.com/1559108/62160672-2aab6100-b2da-11e9-97ac-9124f71e986b.png)

People on the forum thread started reporting problems on KSP 1.3, and that's when LGG's fork picks up, so I marked it 1.0 through 1.2.

https://forum.kerbalspaceprogram.com/index.php?/topic/75295-0235-mechjeb-and-engineer-for-all/