### PR TITLE
Add depends to old KerbalKonstructs version

### DIFF
--- a/KerbalKonstructs/KerbalKonstructs-1.7.3.0.ckan
+++ b/KerbalKonstructs/KerbalKonstructs-1.7.3.0.ckan
@@ -21,6 +21,9 @@
     "depends": [
         {
             "name": "ModuleManager"
+        },
+        {
+            "name": "CustomPreLaunchChecks"
         }
     ],
     "suggests": [


### PR DESCRIPTION
This is the historical update for KSP-CKAN/NetKAN#7423.