### PR TITLE
Update KSP version numbers for KS3P, PlanetShine, Scatterer

### DIFF
--- a/KS3P/KS3P-V6.1.ckan
+++ b/KS3P/KS3P-V6.1.ckan
@@ -12,7 +12,8 @@
         "x_screenshot": "https://spacedock.info/content/The_White_Guardian_1757/KS3P/KS3P-1519836818.9902804.png"
     },
     "version": "V6.1",
-    "ksp_version": "1.7.2",
+    "ksp_version_min": "1.7.2",
+    "ksp_version_max": "1.7.99",
     "download": "https://spacedock.info/mod/1618/KS3P/download/V6.1",
     "download_size": 42878562,
     "download_hash": {

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.6.1.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.6.1.ckan
@@ -14,7 +14,7 @@
     },
     "version": "0.2.6.1",
     "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.999",
+    "ksp_version_max": "1.7.99",
     "provides": [
         "PlanetShine-Config"
     ],

--- a/PlanetShine/PlanetShine-0.2.6.1.ckan
+++ b/PlanetShine/PlanetShine-0.2.6.1.ckan
@@ -14,7 +14,7 @@
     },
     "version": "0.2.6.1",
     "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.999",
+    "ksp_version_max": "1.7.99",
     "depends": [
         {
             "name": "PlanetShine-Config"

--- a/Scatterer/Scatterer-2-v0.0540.ckan
+++ b/Scatterer/Scatterer-2-v0.0540.ckan
@@ -13,7 +13,8 @@
         "x_screenshot": "https://spacedock.info/content/blackrack_378/scatterer/scatterer-1456285817.4561393.jpg"
     },
     "version": "2:v0.0540",
-    "ksp_version": "1.6.1",
+    "ksp_version_min": "1.6.1",
+    "ksp_version_max": "1.7.99",
     "depends": [
         {
             "name": "Scatterer-sunflare"


### PR DESCRIPTION
I've tested all three mods by setting the compat mode in CKAN, they work all fine. They're all dependencies of Astronomer's Visual Pack.

Please merge so everyone can benefit from this! :)