### PR TITLE
Add StockalikeRealismOverhaul 1.5.1 and 1.5.2

### DIFF
--- a/StockalikeRealismOverhaul/StockalikeRealismOverhaul-1.5.1.ckan
+++ b/StockalikeRealismOverhaul/StockalikeRealismOverhaul-1.5.1.ckan
@@ -1,0 +1,30 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "StockalikeRealismOverhaul",
+    "name": "Stockalike Realism Overhaul",
+    "abstract": "This mod adds many new surprises, requires Kopernicus as it also is a planet pack. Other than that, it is completely standalone. For KSP 1.7. Is also a planet pack.",
+    "author": "Hyper_Fun",
+    "license": "MIT",
+    "resources": {
+        "spacedock": "https://spacedock.info/mod/2239/Stockalike%20Realism%20Overhaul",
+        "x_screenshot": "https://spacedock.info/content/Hyper_Fun_30907/Stockalike_Realism_Overhaul/Stockalike_Realism_Overhaul-1570800033.021394.png"
+    },
+    "version": "1.5.1",
+    "ksp_version": "1.7.3",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        }
+    ],
+    "download": "https://spacedock.info/mod/2239/Stockalike%20Realism%20Overhaul/download/1.5.1",
+    "download_size": 39111955,
+    "download_hash": {
+        "sha1": "429F7B1CB3AF246ABFF5A638603FF675F491D61C",
+        "sha256": "0E4C266E80EB8437544FCE918576C279EC296BEF3B4142B4785F11B3ECB6048A"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/StockalikeRealismOverhaul/StockalikeRealismOverhaul-1.5.2.ckan
+++ b/StockalikeRealismOverhaul/StockalikeRealismOverhaul-1.5.2.ckan
@@ -1,0 +1,30 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "StockalikeRealismOverhaul",
+    "name": "Stockalike Realism Overhaul",
+    "abstract": "This mod adds many new surprises, requires Kopernicus as it also is a planet pack. Other than that, it is completely standalone. For KSP 1.7. Is also a planet pack.",
+    "author": "Hyper_Fun",
+    "license": "MIT",
+    "resources": {
+        "spacedock": "https://spacedock.info/mod/2239/Stockalike%20Realism%20Overhaul",
+        "x_screenshot": "https://spacedock.info/content/Hyper_Fun_30907/Stockalike_Realism_Overhaul/Stockalike_Realism_Overhaul-1570800033.021394.png"
+    },
+    "version": "1.5.2",
+    "ksp_version": "1.7.3",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        }
+    ],
+    "download": "https://spacedock.info/mod/2239/Stockalike%20Realism%20Overhaul/download/1.5.2",
+    "download_size": 39111989,
+    "download_hash": {
+        "sha1": "9C87F3CA322D2EC8A98D90EE01AF4B3421ED7EC9",
+        "sha256": "8797565F837201A1279DA5754F262F6B377F68F08797086E0B5EF63C66C7AF36"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
Our current webhook for SpaceDock seems to be not working.

Those two versions (among others) were missed .