### PR TITLE
Change download source for OpenTree

### DIFF
--- a/OpenTree/OpenTree-2.3.ckan
+++ b/OpenTree/OpenTree-2.3.ckan
@@ -17,7 +17,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://spacedock.info/mod/1623/OpenTree/download/2.3",
+    "download": "https://archive.org/download/OpenTree-2.3/668A7DAE-OpenTree-2.3.zip",
     "download_size": 17321,
     "download_hash": {
         "sha1": "668A7DAEC4BC37DE7221017BCF5B6F0AA914A450",

--- a/OpenTree/OpenTree-2.4.ckan
+++ b/OpenTree/OpenTree-2.4.ckan
@@ -17,7 +17,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://spacedock.info/mod/1623/OpenTree/download/2.4",
+    "download": "https://archive.org/download/OpenTree-2.4/09682740-OpenTree-2.4.zip",
     "download_size": 18801,
     "download_hash": {
         "sha1": "0968274062ED5BCDE8D6F6603CEAFE9F8EF38A9A",

--- a/OpenTree/OpenTree-2.5.ckan
+++ b/OpenTree/OpenTree-2.5.ckan
@@ -17,7 +17,7 @@
             "name": "ModuleManager"
         }
     ],
-    "download": "https://spacedock.info/mod/1623/OpenTree/download/2.5",
+    "download": "https://archive.org/download/OpenTree-2.5/8BD18970-OpenTree-2.5.zip",
     "download_size": 63839,
     "download_hash": {
         "sha1": "8BD1897005AECCF3F90F4E0FB0BB8C3A394EBA60",


### PR DESCRIPTION
Mod has been deleted from Spacedock: https://spacedock.info/mod/1623

Discontinuation confirmed on the forum: https://forum.kerbalspaceprogram.com/index.php?/topic/110365-131-opentree-v25-2512018/&do=findComment&comment=3456854

----

This PR changes the download URL to the respective ones on Archive.org for versions 2.3+.
The previous versions have already their download source set to Archive.org, since they've been hosted on KerbalStuff.

----

NetKAN freeze: https://github.com/KSP-CKAN/NetKAN/pull/7436