### PR TITLE
Fix historical Toolbar max version

### DIFF
--- a/Toolbar/Toolbar-1.7.17.15.ckan
+++ b/Toolbar/Toolbar-1.7.17.15.ckan
@@ -15,6 +15,7 @@
     },
     "version": "1.7.17.15",
     "ksp_version_min": "1.5.1",
+    "ksp_version_max": "1.5.99",
     "install": [
         {
             "find": "GameData/000_Toolbar",


### PR DESCRIPTION
One old version of Toolbar is marked as way more compatible than it really is:

![image](https://user-images.githubusercontent.com/1559108/67161696-7e01de00-f322-11e9-9976-1d85cb37188b.png)

Now it has a max version of 1.5.99, just like the versions immediately preceding it.

Fixes KSP-CKAN/NetKAN#7439.