### PR TITLE
Fix license and links for old mods

### DIFF
--- a/NavBallTextureExport/NavBallTextureExport-1.5.ckan
+++ b/NavBallTextureExport/NavBallTextureExport-1.5.ckan
@@ -12,20 +12,19 @@
         "repository": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger",
         "x_textures": "http://bit.ly/navballs"
     },
-    "version": "1.3",
-    "ksp_version_min": "0.24",
-    "ksp_version_max": "1.0.99",
+    "version": "1.5",
+    "ksp_version": "1.2",
     "install": [
         {
-            "file": "GameData/NavBallTextureExport",
+            "file": "GameData/NavBallTextureChanger",
             "install_to": "GameData"
         }
     ],
-    "download": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger/downloads/KSP-0.24-NavballChanger-v.1.3.zip",
-    "download_size": 86852,
+    "download": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger/downloads/KSP-1.2-NavBallChanger-1.5-v2.zip",
+    "download_size": 11764,
     "download_hash": {
-        "sha1": "CE83304A0DC1A3B6EB99BF70BFAD70B946CA9843",
-        "sha256": "614631208D0AFDDB605D3775E4941BC67310B1FC2D118B6BA713E8EBD6E11332"
+        "sha1": "87B825D36F966FD1CC8F5FD02E5B63CB79A76F30",
+        "sha256": "692EC3B6EB8ADF1BC1143D7D367985B458DB1E80D5303916AEA3EA478D0E856C"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/TCShipInfo/TCShipInfo-0.3.ckan
+++ b/TCShipInfo/TCShipInfo-0.3.ckan
@@ -8,7 +8,7 @@
     ],
     "license": "public-domain",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/65769"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/59724-*"
     },
     "version": "0.3",
     "ksp_version_min": "0.24.2",

--- a/TCShipInfo/TCShipInfo-0.4.ckan
+++ b/TCShipInfo/TCShipInfo-0.4.ckan
@@ -8,7 +8,7 @@
     ],
     "license": "public-domain",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/65769"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/59724-*"
     },
     "version": "0.4",
     "ksp_version": "1.1",


### PR DESCRIPTION
KSP-CKAN/NetKAN#4131 listed several mods without netkans that it thought should use the Unlicense. This was not correct, but investigating those mods nonetheless turned up a few changes that were needed.

- NavBallTextureExport
  - License changed from public-domain to MIT
  - Homepage fixed
  - 1.5 added
- TCShipInfo homepage fixed

Fixes KSP-CKAN/NetKAN#4131.