### PR TITLE
Mark Scatterer 0.0540 as compatible with KSP 1.6-1.7

### DIFF
--- a/Scatterer-config/Scatterer-config-2-v0.0540.ckan
+++ b/Scatterer-config/Scatterer-config-2-v0.0540.ckan
@@ -13,7 +13,8 @@
         "x_screenshot": "https://spacedock.info/content/blackrack_378/scatterer/scatterer-1456285817.4561393.jpg"
     },
     "version": "2:v0.0540",
-    "ksp_version": "1.6.1",
+    "ksp_version_min": "1.6",
+    "ksp_version_max": "1.7",
     "conflicts": [
         {
             "name": "Scatterer-config"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0540.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0540.ckan
@@ -13,7 +13,8 @@
         "x_screenshot": "https://spacedock.info/content/blackrack_378/scatterer/scatterer-1456285817.4561393.jpg"
     },
     "version": "2:v0.0540",
-    "ksp_version": "1.6.1",
+    "ksp_version_min": "1.6",
+    "ksp_version_max": "1.7",
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer/Scatterer-2-v0.0540.ckan
+++ b/Scatterer/Scatterer-2-v0.0540.ckan
@@ -13,7 +13,8 @@
         "x_screenshot": "https://spacedock.info/content/blackrack_378/scatterer/scatterer-1456285817.4561393.jpg"
     },
     "version": "2:v0.0540",
-    "ksp_version": "1.6.1",
+    "ksp_version_min": "1.6",
+    "ksp_version_max": "1.7",
     "depends": [
         {
             "name": "Scatterer-sunflare"


### PR DESCRIPTION
There's a Scatterer for 1.6 and one for 1.8, but in between is a gap.
Apparently during the 1.7 period Scatterer folks were expected to use 0.0540. Now the metadata reflects that.