### PR TITLE
Backports for VensRevamp new fork

### DIFF
--- a/VenStockRevamp-Core/VenStockRevamp-Core-v1.12.0.ckan
+++ b/VenStockRevamp-Core/VenStockRevamp-Core-v1.12.0.ckan
@@ -1,0 +1,52 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "VenStockRevamp-Core",
+    "name": "Ven's Stock Part Revamp Core",
+    "abstract": "Shared resources for Ven's Stock Revamp and Ven's New Parts",
+    "author": [
+        "VenVen",
+        "Kerbas-ad-astra"
+    ],
+    "license": "CC-BY-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189732-*",
+        "repository": "https://github.com/Kerbas-ad-astra/Stock-Revamp"
+    },
+    "version": "v1.12.0",
+    "ksp_version": "1.6.1",
+    "localizations": [
+        "en-us"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "VenStockRevamp"
+        },
+        {
+            "name": "VenStockRevamp-NewParts"
+        }
+    ],
+    "install": [
+        {
+            "find": "VenStockRevamp",
+            "install_to": "GameData",
+            "filter": [
+                "PathPatches",
+                "Squad",
+                "Part Bin"
+            ]
+        }
+    ],
+    "download": "https://github.com/Kerbas-ad-astra/Stock-Revamp/releases/download/v1.12.0/VenStockRevamp-v1.12.0.zip",
+    "download_size": 116554305,
+    "download_hash": {
+        "sha1": "6D3780A4C631024CC2005FAC0DB324B26DCB7E18",
+        "sha256": "A577ED35841CAC31172E12A56D38A189BA647C12EF603CE0D6A1285487564255"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/VenStockRevamp-Core/VenStockRevamp-Core-v1.13.0.ckan
+++ b/VenStockRevamp-Core/VenStockRevamp-Core-v1.13.0.ckan
@@ -1,0 +1,53 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "VenStockRevamp-Core",
+    "name": "Ven's Stock Part Revamp Core",
+    "abstract": "Shared resources for Ven's Stock Revamp and Ven's New Parts",
+    "author": [
+        "VenVen",
+        "Kerbas-ad-astra"
+    ],
+    "license": "CC-BY-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189732-*",
+        "repository": "https://github.com/Kerbas-ad-astra/Stock-Revamp"
+    },
+    "version": "v1.13.0",
+    "ksp_version_min": "1.7.0",
+    "ksp_version_max": "1.7.3",
+    "localizations": [
+        "en-us"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "VenStockRevamp"
+        },
+        {
+            "name": "VenStockRevamp-NewParts"
+        }
+    ],
+    "install": [
+        {
+            "find": "VenStockRevamp",
+            "install_to": "GameData",
+            "filter": [
+                "PathPatches",
+                "Squad",
+                "Part Bin"
+            ]
+        }
+    ],
+    "download": "https://github.com/Kerbas-ad-astra/Stock-Revamp/releases/download/v1.13.0/VenStockRevamp-v1.13.0.zip",
+    "download_size": 142083086,
+    "download_hash": {
+        "sha1": "D87734F271FF0EFE4A7D4D6E346F1D962BF133BD",
+        "sha256": "204040598DD29074D01F471B1A46B6ADDD872F77EFABE9B56BD11F0C4837A1FC"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/VenStockRevamp-NewParts/VenStockRevamp-NewParts-v1.12.0.ckan
+++ b/VenStockRevamp-NewParts/VenStockRevamp-NewParts-v1.12.0.ckan
@@ -1,0 +1,49 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "VenStockRevamp-NewParts",
+    "name": "Ven's New Parts",
+    "abstract": "New parts from Ven's Stock Part Revamp",
+    "author": [
+        "VenVen",
+        "Kerbas-ad-astra"
+    ],
+    "license": "CC-BY-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189732-*",
+        "repository": "https://github.com/Kerbas-ad-astra/Stock-Revamp"
+    },
+    "version": "v1.12.0",
+    "ksp_version": "1.6.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "VenStockRevamp-Core"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "VensStockPartRevamp-CTTPatch"
+        }
+    ],
+    "install": [
+        {
+            "find": "VenStockRevamp/Part Bin",
+            "install_to": "GameData/VenStockRevamp"
+        }
+    ],
+    "download": "https://github.com/Kerbas-ad-astra/Stock-Revamp/releases/download/v1.12.0/VenStockRevamp-v1.12.0.zip",
+    "download_size": 116554305,
+    "download_hash": {
+        "sha1": "6D3780A4C631024CC2005FAC0DB324B26DCB7E18",
+        "sha256": "A577ED35841CAC31172E12A56D38A189BA647C12EF603CE0D6A1285487564255"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/VenStockRevamp-NewParts/VenStockRevamp-NewParts-v1.13.0.ckan
+++ b/VenStockRevamp-NewParts/VenStockRevamp-NewParts-v1.13.0.ckan
@@ -1,0 +1,50 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "VenStockRevamp-NewParts",
+    "name": "Ven's New Parts",
+    "abstract": "New parts from Ven's Stock Part Revamp",
+    "author": [
+        "VenVen",
+        "Kerbas-ad-astra"
+    ],
+    "license": "CC-BY-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189732-*",
+        "repository": "https://github.com/Kerbas-ad-astra/Stock-Revamp"
+    },
+    "version": "v1.13.0",
+    "ksp_version_min": "1.7.0",
+    "ksp_version_max": "1.7.3",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "VenStockRevamp-Core"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "VensStockPartRevamp-CTTPatch"
+        }
+    ],
+    "install": [
+        {
+            "find": "VenStockRevamp/Part Bin",
+            "install_to": "GameData/VenStockRevamp"
+        }
+    ],
+    "download": "https://github.com/Kerbas-ad-astra/Stock-Revamp/releases/download/v1.13.0/VenStockRevamp-v1.13.0.zip",
+    "download_size": 142083086,
+    "download_hash": {
+        "sha1": "D87734F271FF0EFE4A7D4D6E346F1D962BF133BD",
+        "sha256": "204040598DD29074D01F471B1A46B6ADDD872F77EFABE9B56BD11F0C4837A1FC"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/VenStockRevamp/VenStockRevamp-v1.12.0.ckan
+++ b/VenStockRevamp/VenStockRevamp-v1.12.0.ckan
@@ -1,0 +1,53 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "VenStockRevamp",
+    "name": "Ven's Stock Part Revamp",
+    "abstract": "With this part pack, your rockets/planes/racecars will look at least 20% cooler as they tumble into the ground!",
+    "author": [
+        "VenVen",
+        "Kerbas-ad-astra"
+    ],
+    "license": "CC-BY-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189732-*",
+        "repository": "https://github.com/Kerbas-ad-astra/Stock-Revamp"
+    },
+    "version": "v1.12.0",
+    "ksp_version": "1.6.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "VenStockRevamp-Core"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "VenStockRevamp-NewParts"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        }
+    ],
+    "install": [
+        {
+            "find": "VenStockRevamp/PathPatches",
+            "install_to": "GameData/VenStockRevamp"
+        },
+        {
+            "find": "VenStockRevamp/Squad",
+            "install_to": "GameData/VenStockRevamp"
+        }
+    ],
+    "download": "https://github.com/Kerbas-ad-astra/Stock-Revamp/releases/download/v1.12.0/VenStockRevamp-v1.12.0.zip",
+    "download_size": 116554305,
+    "download_hash": {
+        "sha1": "6D3780A4C631024CC2005FAC0DB324B26DCB7E18",
+        "sha256": "A577ED35841CAC31172E12A56D38A189BA647C12EF603CE0D6A1285487564255"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/VenStockRevamp/VenStockRevamp-v1.13.0.ckan
+++ b/VenStockRevamp/VenStockRevamp-v1.13.0.ckan
@@ -1,0 +1,54 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "VenStockRevamp",
+    "name": "Ven's Stock Part Revamp",
+    "abstract": "With this part pack, your rockets/planes/racecars will look at least 20% cooler as they tumble into the ground!",
+    "author": [
+        "VenVen",
+        "Kerbas-ad-astra"
+    ],
+    "license": "CC-BY-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189732-*",
+        "repository": "https://github.com/Kerbas-ad-astra/Stock-Revamp"
+    },
+    "version": "v1.13.0",
+    "ksp_version_min": "1.7.0",
+    "ksp_version_max": "1.7.3",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "VenStockRevamp-Core"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "VenStockRevamp-NewParts"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        }
+    ],
+    "install": [
+        {
+            "find": "VenStockRevamp/PathPatches",
+            "install_to": "GameData/VenStockRevamp"
+        },
+        {
+            "find": "VenStockRevamp/Squad",
+            "install_to": "GameData/VenStockRevamp"
+        }
+    ],
+    "download": "https://github.com/Kerbas-ad-astra/Stock-Revamp/releases/download/v1.13.0/VenStockRevamp-v1.13.0.zip",
+    "download_size": 142083086,
+    "download_hash": {
+        "sha1": "D87734F271FF0EFE4A7D4D6E346F1D962BF133BD",
+        "sha256": "204040598DD29074D01F471B1A46B6ADDD872F77EFABE9B56BD11F0C4837A1FC"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
In KSP-CKAN/NetKAN#7500, VensRevamp is switched to a new fork and split into pieces that conflict with ReStock and those that don't.

There are two backports with earlier versions. This pull request indexes them.