### PR TITLE
Update ChattererExtended-0.6.2.ckan

### DIFF
--- a/ChattererExtended/ChattererExtended-0.6.2.ckan
+++ b/ChattererExtended/ChattererExtended-0.6.2.ckan
@@ -12,7 +12,6 @@
     },
     "version": "0.6.2",
     "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.4.99",
     "depends": [
         {
             "name": "Chatterer"


### PR DESCRIPTION
Remove ksp_version_max as compatibility with KSP is controlled by chatterer.