### PR TITLE
Update AutomatedScienceSampler-1.3.5-KSP1.8.ckan

### DIFF
--- a/AutomatedScienceSampler/AutomatedScienceSampler-1.3.5-KSP1.8.ckan
+++ b/AutomatedScienceSampler/AutomatedScienceSampler-1.3.5-KSP1.8.ckan
@@ -16,11 +16,11 @@
     },
     "version": "1.3.5-KSP1.8",
     "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.3",
+    "ksp_version_max": "1.8.9",
     "depends": [
         {
             "name": "KerboKatzUtilities",
-            "min_version": "1.5.2"
+            "min_version": "1.5.2-KSP1.8"
         }
     ],
     "install": [


### PR DESCRIPTION
Correct for updated version 1.3.5-KSP1.8 of AutomatedScienceSampler and KerboKatzUtilities 1.5.2-KSP1.8.