### PR TITLE
Update KerboKatzUtilities-1.5.2-KSP1.8.ckan

### DIFF
--- a/KerboKatzUtilities/KerboKatzUtilities-1.5.2-KSP1.8.ckan
+++ b/KerboKatzUtilities/KerboKatzUtilities-1.5.2-KSP1.8.ckan
@@ -16,7 +16,7 @@
     },
     "version": "1.5.2-KSP1.8",
     "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.3",
+    "ksp_version_max": "1.8.9",
     "install": [
         {
             "find": "KerboKatz",


### PR DESCRIPTION
Correct for new maximum version 1.8.x of KerboKatzUtilities.