### PR TITLE
Clean up 1.99.99 versions

### DIFF
--- a/ContractConfigurator-CleverSats/ContractConfigurator-CleverSats-1.3.0.1.ckan
+++ b/ContractConfigurator-CleverSats/ContractConfigurator-CleverSats-1.3.0.1.ckan
@@ -11,7 +11,6 @@
     },
     "version": "1.3.0.1",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-CleverSats/ContractConfigurator-CleverSats-1.4.ckan
+++ b/ContractConfigurator-CleverSats/ContractConfigurator-CleverSats-1.4.ckan
@@ -11,7 +11,6 @@
     },
     "version": "1.4",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.1.ckan
+++ b/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.1.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/123892",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/111573-*",
         "repository": "https://github.com/jrossignol/ContractPack-FieldResearch",
         "bugtracker": "https://github.com/jrossignol/ContractPack-FieldResearch/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-FieldResearch/master/GameData/ContractPacks/FieldResearch/LICENSE.txt"
     },
     "version": "1.1.1",
     "ksp_version_min": "1.0.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.2.ckan
+++ b/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.2.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/123892",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/111573-*",
         "repository": "https://github.com/jrossignol/ContractPack-FieldResearch",
         "bugtracker": "https://github.com/jrossignol/ContractPack-FieldResearch/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-FieldResearch/master/GameData/ContractPacks/FieldResearch/LICENSE.txt"
     },
     "version": "1.1.2",
     "ksp_version_min": "1.0.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.3.ckan
+++ b/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.3.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/123892",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/111573-*",
         "repository": "https://github.com/jrossignol/ContractPack-FieldResearch",
         "bugtracker": "https://github.com/jrossignol/ContractPack-FieldResearch/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-FieldResearch/master/GameData/ContractPacks/FieldResearch/LICENSE.txt"
     },
     "version": "1.1.3",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.4.ckan
+++ b/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.4.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/123892",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/111573-*",
         "repository": "https://github.com/jrossignol/ContractPack-FieldResearch",
         "bugtracker": "https://github.com/jrossignol/ContractPack-FieldResearch/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-FieldResearch/master/GameData/ContractPacks/FieldResearch/LICENSE.txt"
     },
     "version": "1.1.4",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.5.ckan
+++ b/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.5.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/123892",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/111573-*",
         "repository": "https://github.com/jrossignol/ContractPack-FieldResearch",
         "bugtracker": "https://github.com/jrossignol/ContractPack-FieldResearch/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-FieldResearch/master/GameData/ContractPacks/FieldResearch/LICENSE.txt"
     },
     "version": "1.1.5",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.6.ckan
+++ b/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.6.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/123892",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/111573-*",
         "repository": "https://github.com/jrossignol/ContractPack-FieldResearch",
         "bugtracker": "https://github.com/jrossignol/ContractPack-FieldResearch/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-FieldResearch/master/GameData/ContractPacks/FieldResearch/LICENSE.txt"
     },
     "version": "1.1.6",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.7.ckan
+++ b/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.1.7.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/123892",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/111573-*",
         "repository": "https://github.com/jrossignol/ContractPack-FieldResearch",
         "bugtracker": "https://github.com/jrossignol/ContractPack-FieldResearch/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-FieldResearch/master/GameData/ContractPacks/FieldResearch/LICENSE.txt"
     },
     "version": "1.1.7",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.2.0.ckan
+++ b/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.2.0.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/123892",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/111573-*",
         "repository": "https://github.com/jrossignol/ContractPack-FieldResearch",
         "bugtracker": "https://github.com/jrossignol/ContractPack-FieldResearch/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-FieldResearch/master/GameData/ContractPacks/FieldResearch/LICENSE.txt"
     },
     "version": "1.2.0",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.2.1.ckan
+++ b/ContractConfigurator-FieldResearch/ContractConfigurator-FieldResearch-1.2.1.ckan
@@ -15,7 +15,6 @@
     },
     "version": "1.2.1",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.10.ckan
+++ b/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.10.ckan
@@ -16,7 +16,6 @@
     },
     "version": "1.1.10",
     "ksp_version_min": "1.4.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.3.ckan
+++ b/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.3.ckan
@@ -11,7 +11,6 @@
     },
     "version": "1.1.3",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.4.ckan
+++ b/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.4.ckan
@@ -11,7 +11,6 @@
     },
     "version": "1.1.4",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.5.ckan
+++ b/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.5.ckan
@@ -11,7 +11,6 @@
     },
     "version": "1.1.5",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.6.ckan
+++ b/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.6.ckan
@@ -11,7 +11,6 @@
     },
     "version": "1.1.6",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.7.ckan
+++ b/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.7.ckan
@@ -11,7 +11,6 @@
     },
     "version": "1.1.7",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.8.ckan
+++ b/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.8.ckan
@@ -11,7 +11,6 @@
     },
     "version": "1.1.8",
     "ksp_version_min": "1.4.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.9.ckan
+++ b/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.9.ckan
@@ -16,7 +16,6 @@
     },
     "version": "1.1.9",
     "ksp_version_min": "1.4.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.2.2.1.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.2.2.1.ckan
@@ -6,12 +6,11 @@
     "author": "severedsolo",
     "license": "CC-BY-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102390-*",
         "repository": "https://github.com/severedsolo/KerbinSpaceStation"
     },
     "version": "1:3.2.2.1",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.3.1.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.3.1.ckan
@@ -6,12 +6,11 @@
     "author": "severedsolo",
     "license": "CC-BY-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102390-*",
         "repository": "https://github.com/severedsolo/KerbinSpaceStation"
     },
     "version": "1:3.3.1",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.3.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.3.ckan
@@ -6,12 +6,11 @@
     "author": "severedsolo",
     "license": "CC-BY-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102390-*",
         "repository": "https://github.com/severedsolo/KerbinSpaceStation"
     },
     "version": "1:3.3",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.4.1.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.4.1.ckan
@@ -6,12 +6,11 @@
     "author": "severedsolo",
     "license": "CC-BY-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102390-*",
         "repository": "https://github.com/severedsolo/KerbinSpaceStation"
     },
     "version": "1:3.4.1",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.4.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.4.ckan
@@ -6,12 +6,11 @@
     "author": "severedsolo",
     "license": "CC-BY-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102390-*",
         "repository": "https://github.com/severedsolo/KerbinSpaceStation"
     },
     "version": "1:3.4",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.5.1.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.5.1.ckan
@@ -6,12 +6,11 @@
     "author": "severedsolo",
     "license": "CC-BY-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102390-*",
         "repository": "https://github.com/severedsolo/KerbinSpaceStation"
     },
     "version": "1:3.5.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.5.2.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.5.2.ckan
@@ -6,12 +6,11 @@
     "author": "severedsolo",
     "license": "CC-BY-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102390-*",
         "repository": "https://github.com/severedsolo/KerbinSpaceStation"
     },
     "version": "1:3.5.2",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.5.3.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.5.3.ckan
@@ -6,12 +6,11 @@
     "author": "severedsolo",
     "license": "CC-BY-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102390-*",
         "repository": "https://github.com/severedsolo/KerbinSpaceStation"
     },
     "version": "1:3.5.3",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.5.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.5.ckan
@@ -6,12 +6,11 @@
     "author": "severedsolo",
     "license": "CC-BY-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102390-*",
         "repository": "https://github.com/severedsolo/KerbinSpaceStation"
     },
     "version": "1:3.5",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.6.1.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.6.1.ckan
@@ -6,12 +6,11 @@
     "author": "severedsolo",
     "license": "CC-BY-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102390-*",
         "repository": "https://github.com/severedsolo/KerbinSpaceStation"
     },
     "version": "1:3.6.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.6.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.6.ckan
@@ -6,12 +6,11 @@
     "author": "severedsolo",
     "license": "CC-BY-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102390-*",
         "repository": "https://github.com/severedsolo/KerbinSpaceStation"
     },
     "version": "1:3.6",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.7.0.1.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-3.7.0.1.ckan
@@ -11,7 +11,6 @@
     },
     "version": "1:3.7.0.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-6.7.0.0.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-1-6.7.0.0.ckan
@@ -11,7 +11,6 @@
     },
     "version": "1:6.7.0.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-2-3.7.0.1.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-2-3.7.0.1.ckan
@@ -11,7 +11,6 @@
     },
     "version": "2:3.7.0.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-2-3.7.0.2.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-2-3.7.0.2.ckan
@@ -11,7 +11,6 @@
     },
     "version": "2:3.7.0.2",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-2-3.7.0.4.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-2-3.7.0.4.ckan
@@ -11,7 +11,6 @@
     },
     "version": "2:3.7.0.4",
     "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-2-3.7.1.1.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-2-3.7.1.1.ckan
@@ -11,7 +11,6 @@
     },
     "version": "2:3.7.1.1",
     "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-2-3.7.1.ckan
+++ b/ContractConfigurator-KerbinSpaceStation/ContractConfigurator-KerbinSpaceStation-2-3.7.1.ckan
@@ -11,7 +11,6 @@
     },
     "version": "2:3.7.1",
     "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator",

--- a/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.0.2.ckan
+++ b/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.0.2.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106580",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/96045-*",
         "repository": "https://github.com/jrossignol/ContractPack-RemoteTech",
         "bugtracker": "https://github.com/jrossignol/ContractPack-RemoteTech/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-RemoteTech/master/GameData/ContractPacks/RemoteTech/LICENSE.txt"
     },
     "version": "2.0.2",
     "ksp_version_min": "1.0.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.1.0.ckan
+++ b/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.1.0.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106580",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/96045-*",
         "repository": "https://github.com/jrossignol/ContractPack-RemoteTech",
         "bugtracker": "https://github.com/jrossignol/ContractPack-RemoteTech/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-RemoteTech/master/GameData/ContractPacks/RemoteTech/LICENSE.txt"
     },
     "version": "2.1.0",
     "ksp_version_min": "1.0.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.1.1.ckan
+++ b/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.1.1.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106580",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/96045-*",
         "repository": "https://github.com/jrossignol/ContractPack-RemoteTech",
         "bugtracker": "https://github.com/jrossignol/ContractPack-RemoteTech/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-RemoteTech/master/GameData/ContractPacks/RemoteTech/LICENSE.txt"
     },
     "version": "2.1.1",
     "ksp_version_min": "1.0.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.1.2.ckan
+++ b/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.1.2.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106580",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/96045-*",
         "repository": "https://github.com/jrossignol/ContractPack-RemoteTech",
         "bugtracker": "https://github.com/jrossignol/ContractPack-RemoteTech/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-RemoteTech/master/GameData/ContractPacks/RemoteTech/LICENSE.txt"
     },
     "version": "2.1.2",
     "ksp_version_min": "1.0.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.1.3.ckan
+++ b/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.1.3.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106580",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/96045-*",
         "repository": "https://github.com/jrossignol/ContractPack-RemoteTech",
         "bugtracker": "https://github.com/jrossignol/ContractPack-RemoteTech/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-RemoteTech/master/GameData/ContractPacks/RemoteTech/LICENSE.txt"
     },
     "version": "2.1.3",
     "ksp_version_min": "1.0.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.1.4.ckan
+++ b/ContractConfigurator-RemoteTech/ContractConfigurator-RemoteTech-2.1.4.ckan
@@ -15,7 +15,6 @@
     },
     "version": "2.1.4",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.2.0.ckan
+++ b/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.2.0.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113621",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102372-*",
         "repository": "https://github.com/jrossignol/ContractPack-Tourism",
         "bugtracker": "https://github.com/jrossignol/ContractPack-Tourism/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-Tourism/master/GameData/ContractPacks/Tourism/LICENSE.txt"
     },
     "version": "1.2.0",
     "ksp_version_min": "1.0.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.3.0.ckan
+++ b/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.3.0.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113621",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102372-*",
         "repository": "https://github.com/jrossignol/ContractPack-Tourism",
         "bugtracker": "https://github.com/jrossignol/ContractPack-Tourism/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-Tourism/master/GameData/ContractPacks/Tourism/LICENSE.txt"
     },
     "version": "1.3.0",
     "ksp_version_min": "1.0.2",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.4.0.ckan
+++ b/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.4.0.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113621",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102372-*",
         "repository": "https://github.com/jrossignol/ContractPack-Tourism",
         "bugtracker": "https://github.com/jrossignol/ContractPack-Tourism/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-Tourism/master/GameData/ContractPacks/Tourism/LICENSE.txt"
     },
     "version": "1.4.0",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.4.2.ckan
+++ b/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.4.2.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113621",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102372-*",
         "repository": "https://github.com/jrossignol/ContractPack-Tourism",
         "bugtracker": "https://github.com/jrossignol/ContractPack-Tourism/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-Tourism/master/GameData/ContractPacks/Tourism/LICENSE.txt"
     },
     "version": "1.4.2",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.5.0.ckan
+++ b/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.5.0.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113621",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102372-*",
         "repository": "https://github.com/jrossignol/ContractPack-Tourism",
         "bugtracker": "https://github.com/jrossignol/ContractPack-Tourism/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-Tourism/master/GameData/ContractPacks/Tourism/LICENSE.txt"
     },
     "version": "1.5.0",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.5.1.ckan
+++ b/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.5.1.ckan
@@ -7,14 +7,13 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113621",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/102372-*",
         "repository": "https://github.com/jrossignol/ContractPack-Tourism",
         "bugtracker": "https://github.com/jrossignol/ContractPack-Tourism/issues",
         "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-Tourism/master/GameData/ContractPacks/Tourism/LICENSE.txt"
     },
     "version": "1.5.1",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.5.2.ckan
+++ b/ContractConfigurator-Tourism/ContractConfigurator-Tourism-1.5.2.ckan
@@ -15,7 +15,6 @@
     },
     "version": "1.5.2",
     "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/ContractConfigurator/ContractConfigurator-1.26.0.ckan
+++ b/ContractConfigurator/ContractConfigurator-1.26.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "1.26.0",
     "ksp_version_min": "1.5.1",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.7",
     "ksp_version_strict": true,
     "recommends": [
         {

--- a/ContractConfigurator/ContractConfigurator-1.27.0.ckan
+++ b/ContractConfigurator/ContractConfigurator-1.27.0.ckan
@@ -15,7 +15,7 @@
     },
     "version": "1.27.0",
     "ksp_version_min": "1.6.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.7",
     "ksp_version_strict": true,
     "recommends": [
         {

--- a/GrindyScience/GrindyScience-1-1.0.1.1.ckan
+++ b/GrindyScience/GrindyScience-1-1.0.1.1.ckan
@@ -12,7 +12,7 @@
         "repository": "https://github.com/ValynEritai/GrindyScience"
     },
     "version": "1:1.0.1.1",
-    "ksp_version_min": "any",
+    "ksp_version": "any",
     "depends": [
         {
             "name": "ModuleManager"

--- a/GrindyScience/GrindyScience-1-1.0.1.1.ckan
+++ b/GrindyScience/GrindyScience-1-1.0.1.1.ckan
@@ -12,8 +12,7 @@
         "repository": "https://github.com/ValynEritai/GrindyScience"
     },
     "version": "1:1.0.1.1",
-    "ksp_version_min": "1.0.0",
-    "ksp_version_max": "9.99.999",
+    "ksp_version_min": "any",
     "depends": [
         {
             "name": "ModuleManager"

--- a/KSPScienceRedone/KSPScienceRedone-1.0.2.ckan
+++ b/KSPScienceRedone/KSPScienceRedone-1.0.2.ckan
@@ -10,7 +10,6 @@
     },
     "version": "1.0.2",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "9.99.999",
     "depends": [
         {
             "name": "ModuleManager"

--- a/LessGrindyScience/LessGrindyScience-1-1.0.0.1.ckan
+++ b/LessGrindyScience/LessGrindyScience-1-1.0.0.1.ckan
@@ -12,8 +12,7 @@
         "repository": "https://github.com/ValynEritai/LessGrindyScience"
     },
     "version": "1:1.0.0.1",
-    "ksp_version_min": "1.0.0",
-    "ksp_version_max": "9.99.999",
+    "ksp_version": "any",
     "depends": [
         {
             "name": "ModuleManager"

--- a/RemoteTechRedevAntennas/RemoteTechRedevAntennas-0.1.1.ckan
+++ b/RemoteTechRedevAntennas/RemoteTechRedevAntennas-0.1.1.ckan
@@ -13,7 +13,6 @@
     },
     "version": "0.1.1",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.99.99",
     "depends": [
         {
             "name": "ModuleManager"

--- a/Strategia/Strategia-1.7.3.ckan
+++ b/Strategia/Strategia-1.7.3.ckan
@@ -14,7 +14,7 @@
     },
     "version": "1.7.3",
     "ksp_version_min": "1.5.1",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.7",
     "depends": [
         {
             "name": "CustomBarnKit"


### PR DESCRIPTION
Historical updates for KSP-CKAN/NetKAN#7516. Various SETI mods show up as compatible on 1.8 even though even the most recent releases aren't. There are historical versions with a bad max game version of 1.99.99. Now they're fixed.

To make this easier, other occurrences of 99.99 are also replaced with better data, in some cases "any", in others specific versions.