### PR TITLE
Remove 1.99.99 from old SETI versions

### DIFF
--- a/PartOverhaulsSETI/PartOverhaulsSETI-0.9.0.0.ckan
+++ b/PartOverhaulsSETI/PartOverhaulsSETI-0.9.0.0.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "PartOverhaulsSETI",
     "name": "Porkjets PartOverhauls - SETIconfig",
     "abstract": "Porkjets PartOverhauls with SETI configs. Uses parts as additions instead of replacements of stock parts, thus compatible with VenStockRevamp. Boattail parts 1.25m diameter. Non-boattail parts 0.625m diameter and full set of 1.875m parts, including adapters, decoupler and nosecone. Removes upgrades until that feature is properly implemented.",
     "author": "Y3mo",
     "license": "CC-BY-NC-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/PartOverhaulsSETI"
     },
     "version": "0.9.0.0",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.3",
     "depends": [
         {
             "name": "ModuleManager"

--- a/PartOverhaulsSETI/PartOverhaulsSETI-0.9.1.0.ckan
+++ b/PartOverhaulsSETI/PartOverhaulsSETI-0.9.1.0.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "PartOverhaulsSETI",
     "name": "Porkjets PartOverhauls - SETIconfig",
     "abstract": "Porkjets PartOverhauls with SETI configs. Uses parts as additions instead of replacements of stock parts, thus compatible with VenStockRevamp. Boattail parts 1.25m diameter. Non-boattail parts 0.625m diameter and full set of 1.875m parts, including adapters, decoupler and nosecone. Removes upgrades until that feature is properly implemented.",
     "author": "Y3mo",
     "license": "CC-BY-NC-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/PartOverhaulsSETI"
     },
     "version": "0.9.1.0",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.3",
     "depends": [
         {
             "name": "ModuleManager"

--- a/RCSBuildAid/RCSBuildAid-v0.7.8.ckan
+++ b/RCSBuildAid/RCSBuildAid-v0.7.8.ckan
@@ -30,10 +30,10 @@
         }
     ],
     "download": "http://addons-origin.cursecdn.com/files/2305/296/RCSBuildAid_v0.7.8.zip",
-    "download_size": 131209,
+    "download_size": 130518,
     "download_hash": {
-        "sha1": "C1210A06FC6DC8EA6F628EA23DF32F0DF94D9A3B",
-        "sha256": "D99F7C7C4DD033DE3ADABF56F3C513C265D07EF955F13FA5ADCE2D14E8F3D707"
+        "sha1": "9479E4DD577DE06D5A9DE8266B60BE558640A6BD",
+        "sha256": "4BD4E0C9C77FDB1B417DBFBDD4032970594CEE3C8CB70465AFE2D70E81ED90C2"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/SETI-BalanceMod/SETI-BalanceMod-0.9.6.4.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-0.9.6.4.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "0.9.6.4",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/SETI-BalanceMod/SETI-BalanceMod-0.9.6.5.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-0.9.6.5.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "0.9.6.5",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/SETI-BalanceMod/SETI-BalanceMod-0.9.6.6.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-0.9.6.6.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "0.9.6.6",
     "ksp_version_min": "1.0.5",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/SETI-BalanceMod/SETI-BalanceMod-0.9.7.0.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-0.9.7.0.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "0.9.7.0",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/SETI-BalanceMod/SETI-BalanceMod-0.9.7.1.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-0.9.7.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "name": "SETI-Rebalance",
     "abstract": "Former SETI-BalanceMod. Introduces (non realism overhaul) balance to KSP. Best installed via CKAN, just select it there and it will recommend all the other mods which are supported by it.",
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "0.9.7.1",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/SETI-BalanceMod/SETI-BalanceMod-0.9.7.2.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-0.9.7.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "name": "SETI-Rebalance",
     "abstract": "Former SETI-BalanceMod. Introduces (non realism overhaul) balance to KSP. Best installed via CKAN, just select it there and it will recommend all the other mods which are supported by it.",
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "0.9.7.2",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/SETI-BalanceMod/SETI-BalanceMod-1.2.0.0.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-1.2.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "name": "SETI-Rebalance",
     "abstract": "Former SETI-BalanceMod. Introduces (non realism overhaul) balance to KSP. Best installed via CKAN, just select it there and it will recommend all the other mods which are supported by it.",
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "1.2.0.0",
     "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/SETI-BalanceMod/SETI-BalanceMod-1.2.1.0.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-1.2.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "name": "SETI-Rebalance",
     "abstract": "Former SETI-BalanceMod. Introduces (non realism overhaul) balance to KSP. Best installed via CKAN, just select it there and it will recommend all the other mods which are supported by it.",
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "1.2.1.0",
     "ksp_version_min": "1.2.1",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-BalanceMod/SETI-BalanceMod-1.2.2.0.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-1.2.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "name": "SETI-Rebalance",
     "abstract": "Former SETI-BalanceMod. Introduces (non realism overhaul) balance to KSP. Best installed via CKAN, just select it there and it will recommend all the other mods which are supported by it.",
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "1.2.2.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-BalanceMod/SETI-BalanceMod-1.2.2.1.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-1.2.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "name": "SETI-Rebalance",
     "abstract": "Former SETI-BalanceMod. Introduces (non realism overhaul) balance to KSP. Best installed via CKAN, just select it there and it will recommend all the other mods which are supported by it.",
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "1.2.2.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-BalanceMod/SETI-BalanceMod-1.2.2.2.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-1.2.2.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "name": "SETI-Rebalance",
     "abstract": "Former SETI-BalanceMod. Introduces (non realism overhaul) balance to KSP. Best installed via CKAN, just select it there and it will recommend all the other mods which are supported by it.",
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "1.2.2.2",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-BalanceMod/SETI-BalanceMod-1.2.2.3.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-1.2.2.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "name": "SETI-Rebalance",
     "abstract": "Former SETI-BalanceMod. Introduces (non realism overhaul) balance to KSP. Best installed via CKAN, just select it there and it will recommend all the other mods which are supported by it.",
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "1.2.2.3",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-BalanceMod/SETI-BalanceMod-1.2.2.4.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-1.2.2.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "name": "SETI-Rebalance",
     "abstract": "Former SETI-BalanceMod. Introduces (non realism overhaul) balance to KSP. Best installed via CKAN, just select it there and it will recommend all the other mods which are supported by it.",
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "1.2.2.4",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-BalanceMod/SETI-BalanceMod-1.3.0.0.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-1.3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "name": "SETI-Rebalance",
     "abstract": "Former SETI-BalanceMod. Introduces (non realism overhaul) balance to KSP. Best installed via CKAN, just select it there and it will recommend all the other mods which are supported by it.",
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "1.3.0.0",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.3",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-BalanceMod/SETI-BalanceMod-1.3.0.1.ckan
+++ b/SETI-BalanceMod/SETI-BalanceMod-1.3.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "name": "SETI-Rebalance",
     "abstract": "Former SETI-BalanceMod. Introduces (non realism overhaul) balance to KSP. Best installed via CKAN, just select it there and it will recommend all the other mods which are supported by it.",
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/14/SETI-Rebalance",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Rebalance/SETI-Rebalance-1455815229.1514788.jpg"
     },
     "version": "1.3.0.1",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.3",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-CareerChallenge/SETI-CareerChallenge-1.3.0.0.ckan
+++ b/SETI-CareerChallenge/SETI-CareerChallenge-1.3.0.0.ckan
@@ -11,7 +11,7 @@
     },
     "version": "1.3.0.0",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-Contracts/SETI-Contracts-0.9.6.1.ckan
+++ b/SETI-Contracts/SETI-Contracts-0.9.6.1.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/17/SETI-Contracts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Contracts/SETI-Contracts-1455815273.1833096.png"
     },
     "version": "0.9.6.1",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/SETI-Contracts/SETI-Contracts-0.9.7.0.ckan
+++ b/SETI-Contracts/SETI-Contracts-0.9.7.0.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/17/SETI-Contracts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Contracts/SETI-Contracts-1455815273.1833096.png"
     },
     "version": "0.9.7.0",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/SETI-Contracts/SETI-Contracts-0.9.7.1.ckan
+++ b/SETI-Contracts/SETI-Contracts-0.9.7.1.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/17/SETI-Contracts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Contracts/SETI-Contracts-1455815273.1833096.png"
     },
     "version": "0.9.7.1",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/SETI-Contracts/SETI-Contracts-1.2.0.0.ckan
+++ b/SETI-Contracts/SETI-Contracts-1.2.0.0.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/17/SETI-Contracts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Contracts/SETI-Contracts-1455815273.1833096.png"
     },
     "version": "1.2.0.0",
     "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/SETI-Contracts/SETI-Contracts-1.2.1.0.ckan
+++ b/SETI-Contracts/SETI-Contracts-1.2.1.0.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/17/SETI-Contracts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Contracts/SETI-Contracts-1455815273.1833096.png"
     },
     "version": "1.2.1.0",
     "ksp_version_min": "1.2.1",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/SETI-Contracts/SETI-Contracts-1.2.2.0.ckan
+++ b/SETI-Contracts/SETI-Contracts-1.2.2.0.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/17/SETI-Contracts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Contracts/SETI-Contracts-1455815273.1833096.png"
     },
     "version": "1.2.2.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ContractConfigurator"

--- a/SETI-CustomBarnKit/SETI-CustomBarnKit-0.9.0.0.ckan
+++ b/SETI-CustomBarnKit/SETI-CustomBarnKit-0.9.0.0.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-CustomBarnKit",
     "name": "SETI-CustomBarnKit-Config (EXPERIMENTAL)",
     "abstract": "EXPERIMENTAL: Use at your own risk at this time. This is a SETI config for CustomBarnKit, increasing the number of building upgrade levels and tweaking unlocks (eg action groups available from the start). Especially balanced for SETIrebalance mod pack.",
     "author": "Y3mo",
     "license": "MIT",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/SETI-CustomBarnKit"
     },
     "version": "0.9.0.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-CustomBarnKit/SETI-CustomBarnKit-0.9.1.0.ckan
+++ b/SETI-CustomBarnKit/SETI-CustomBarnKit-0.9.1.0.ckan
@@ -11,7 +11,7 @@
     },
     "version": "0.9.1.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-Greenhouse/SETI-Greenhouse-0.9.5.0.ckan
+++ b/SETI-Greenhouse/SETI-Greenhouse-0.9.5.0.ckan
@@ -9,12 +9,12 @@
     ],
     "license": "CC-BY-NC-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/19/SETI-Greenhouse",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Greenhouse/SETI-Greenhouse-1455815310.9182491.png"
     },
     "version": "0.9.5.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version": "any",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-Greenhouse/SETI-Greenhouse-1.2.1.0.ckan
+++ b/SETI-Greenhouse/SETI-Greenhouse-1.2.1.0.ckan
@@ -9,12 +9,12 @@
     ],
     "license": "CC-BY-NC-SA-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/19/SETI-Greenhouse",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Greenhouse/SETI-Greenhouse-1455815310.9182491.png"
     },
     "version": "1.2.1.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version": "any",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-MetaModPack/SETI-MetaModPack-1.3.0.0.ckan
+++ b/SETI-MetaModPack/SETI-MetaModPack-1.3.0.0.ckan
@@ -11,7 +11,7 @@
     },
     "version": "1.3.0.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.0.8.1.ckan
+++ b/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.0.8.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-ProbeControlEnabler",
     "name": "RemoteTech - SETI ProbeControlEnabler",
     "abstract": "This SETI version of the ProbeControlEnabler retains the integrated omni antennas (SETIrebalance) for manned command pods. Probe core integrated omni antennas still do not work (needs changes to RemoteTech, see RemoteTech github issue tracker). It was inspired by the MM config from Felger.",

--- a/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.0.8.2.ckan
+++ b/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.0.8.2.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-ProbeControlEnabler",
     "name": "RemoteTech - SETI ProbeControlEnabler",
     "abstract": "This SETI version of the ProbeControlEnabler retains the integrated omni antennas (SETIrebalance) for manned command pods. Probe core integrated omni antennas still do not work (needs changes to RemoteTech, see RemoteTech github issue tracker). It was inspired by the MM config from Felger.",
     "author": "Y3mo",
     "license": "GPL-2.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/SETI-ProbeControlEnabler"
     },
     "version": "1.0.8.2",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.0.8.ckan
+++ b/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.0.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-ProbeControlEnabler",
     "name": "RemoteTech - SETI ProbeControlEnabler",
     "abstract": "This SETI version of the ProbeControlEnabler retains the integrated omni antennas (SETIrebalance) for manned command pods. Probe core integrated omni antennas still do not work (needs changes to RemoteTech, see RemoteTech github issue tracker). It was inspired by the MM config from Felger.",

--- a/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.2.2.0.ckan
+++ b/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.2.2.0.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-ProbeControlEnabler",
     "name": "RemoteTech - SETI ProbeControlEnabler",
     "abstract": "This SETI version of the ProbeControlEnabler retains the integrated omni antennas (SETIrebalance) for manned command pods. Probe core integrated omni antennas still do not work (needs changes to RemoteTech, see RemoteTech github issue tracker). It was inspired by the MM config from Felger.",
     "author": "Y3mo",
     "license": "GPL-2.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/SETI-ProbeControlEnabler"
     },
     "version": "1.2.2.0",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.2.2.1.ckan
+++ b/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.2.2.1.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-ProbeControlEnabler",
     "name": "RemoteTech - SETI ProbeControlEnabler",
     "abstract": "This SETI version of the ProbeControlEnabler retains the integrated omni antennas (SETIrebalance) for manned command pods. Probe core integrated omni antennas still do not work (needs changes to RemoteTech, see RemoteTech github issue tracker). It was inspired by the MM config from Felger.",
     "author": "Y3mo",
     "license": "GPL-2.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/SETI-ProbeControlEnabler"
     },
     "version": "1.2.2.1",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.3.0.0.ckan
+++ b/SETI-ProbeControlEnabler/SETI-ProbeControlEnabler-1.3.0.0.ckan
@@ -11,7 +11,7 @@
     },
     "version": "1.3.0.0",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-ProbeParts/SETI-ProbeParts-1.2.0.0.ckan
+++ b/SETI-ProbeParts/SETI-ProbeParts-1.2.0.0.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/848/SETI-ProbeParts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-ProbeParts/SETI-ProbeParts-1468682057.3815386.jpg"
     },
     "version": "1.2.0.0",
     "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-ProbeParts/SETI-ProbeParts-1.2.0.1.ckan
+++ b/SETI-ProbeParts/SETI-ProbeParts-1.2.0.1.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/848/SETI-ProbeParts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-ProbeParts/SETI-ProbeParts-1468682057.3815386.jpg"
     },
     "version": "1.2.0.1",
     "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-ProbeParts/SETI-ProbeParts-1.2.2.0.ckan
+++ b/SETI-ProbeParts/SETI-ProbeParts-1.2.2.0.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/848/SETI-ProbeParts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-ProbeParts/SETI-ProbeParts-1468682057.3815386.jpg"
     },
     "version": "1.2.2.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-ProbeParts/SETI-ProbeParts-1.2.2.1.ckan
+++ b/SETI-ProbeParts/SETI-ProbeParts-1.2.2.1.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/848/SETI-ProbeParts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-ProbeParts/SETI-ProbeParts-1468682057.3815386.jpg"
     },
     "version": "1.2.2.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-ProbeParts/SETI-ProbeParts-1.3.0.0.ckan
+++ b/SETI-ProbeParts/SETI-ProbeParts-1.3.0.0.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/848/SETI-ProbeParts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-ProbeParts/SETI-ProbeParts-1468682057.3815386.jpg"
     },
     "version": "1.3.0.0",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.3",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-ProbeParts/SETI-ProbeParts-1.3.0.1.ckan
+++ b/SETI-ProbeParts/SETI-ProbeParts-1.3.0.1.ckan
@@ -9,13 +9,13 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/848/SETI-ProbeParts",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-ProbeParts/SETI-ProbeParts-1468682057.3815386.jpg"
     },
     "version": "1.3.0.1",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.3",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-RebalanceMaterialsGoo/SETI-RebalanceMaterialsGoo-1.0.9.0.ckan
+++ b/SETI-RebalanceMaterialsGoo/SETI-RebalanceMaterialsGoo-1.0.9.0.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RebalanceMaterialsGoo",
     "name": "SETI-Rebalance MaterialsBay & MysteryGoo",
     "abstract": "This is the SETI Rebalance MaterialsBay and MysteryGoo MM patch, so that those 2 experiments can not be collected by scientists anymore, which makes them much more balanced in terms of mass/science payout.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/SETI-RebalanceMaterialsGoo"
     },
     "version": "1.0.9.0",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-RebalanceMaterialsGoo/SETI-RebalanceMaterialsGoo-1.3.0.0.ckan
+++ b/SETI-RebalanceMaterialsGoo/SETI-RebalanceMaterialsGoo-1.3.0.0.ckan
@@ -11,7 +11,7 @@
     },
     "version": "1.3.0.0",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-RemoteTech/SETI-RemoteTech-1.0.0.ckan
+++ b/SETI-RemoteTech/SETI-RemoteTech-1.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RemoteTech",
     "name": "RemoteTech - SETI Config",
     "abstract": "This is a SETI config for RemoteTech, adding ground stations, changing the KSC range to cover the whole kerbol system (when not obstructed), setting signal delay to false and tweaking some colors.",

--- a/SETI-RemoteTech/SETI-RemoteTech-1.0.5.ckan
+++ b/SETI-RemoteTech/SETI-RemoteTech-1.0.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RemoteTech",
     "name": "RemoteTech - SETI Config",
     "abstract": "This is a SETI config for RemoteTech, adding ground stations, changing the KSC range to cover the whole kerbol system (when not obstructed), setting signal delay to false and tweaking some colors.",

--- a/SETI-RemoteTech/SETI-RemoteTech-1.0.8.1.ckan
+++ b/SETI-RemoteTech/SETI-RemoteTech-1.0.8.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RemoteTech",
     "name": "RemoteTech - SETI Config",
     "abstract": "This is a SETI config for RemoteTech, adding ground stations, changing the KSC range to cover the whole kerbol system (when not obstructed), setting signal delay to false and tweaking some colors.",

--- a/SETI-RemoteTech/SETI-RemoteTech-1.0.8.2.ckan
+++ b/SETI-RemoteTech/SETI-RemoteTech-1.0.8.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RemoteTech",
     "name": "RemoteTech - SETI Config",
     "abstract": "This is a SETI config for RemoteTech, adding ground stations, changing the KSC range to cover the whole kerbol system (when not obstructed), setting signal delay to false and tweaking some colors.",

--- a/SETI-RemoteTech/SETI-RemoteTech-1.0.8.ckan
+++ b/SETI-RemoteTech/SETI-RemoteTech-1.0.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RemoteTech",
     "name": "RemoteTech - SETI Config",
     "abstract": "This is a SETI config for RemoteTech, adding ground stations, changing the KSC range to cover the whole kerbol system (when not obstructed), setting signal delay to false and tweaking some colors.",

--- a/SETI-RemoteTech/SETI-RemoteTech-1.0.9.0.ckan
+++ b/SETI-RemoteTech/SETI-RemoteTech-1.0.9.0.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RemoteTech",
     "name": "RemoteTech - SETI Config",
     "abstract": "This is a SETI config for RemoteTech, adding ground stations, changing the KSC range to cover the whole kerbol system (when not obstructed), setting signal delay to false and tweaking some colors.",
     "author": "Y3mo",
     "license": "GPL-2.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/SETI-RemoteTech"
     },
     "version": "1.0.9.0",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "RemoteTech"

--- a/SETI-RemoteTech/SETI-RemoteTech-1.2.1.0.ckan
+++ b/SETI-RemoteTech/SETI-RemoteTech-1.2.1.0.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RemoteTech",
     "name": "RemoteTech - SETI Config",
     "abstract": "This is a SETI config for RemoteTech, adding ground stations, changing the KSC range to cover the whole kerbol system (when not obstructed), setting signal delay to false and tweaking some colors.",
     "author": "Y3mo",
     "license": "GPL-2.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/SETI-RemoteTech"
     },
     "version": "1.2.1.0",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-RemoteTech/SETI-RemoteTech-1.2.2.0.ckan
+++ b/SETI-RemoteTech/SETI-RemoteTech-1.2.2.0.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RemoteTech",
     "name": "RemoteTech - SETI Config",
     "abstract": "This is a SETI config for RemoteTech, adding ground stations, changing the KSC range to cover the whole kerbol system (when not obstructed), setting signal delay to false and tweaking some colors.",
     "author": "Y3mo",
     "license": "GPL-2.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/SETI-RemoteTech"
     },
     "version": "1.2.2.0",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-RemoteTech/SETI-RemoteTech-1.3.0.0.ckan
+++ b/SETI-RemoteTech/SETI-RemoteTech-1.3.0.0.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RemoteTech",
     "name": "RemoteTech - SETI Config",
     "abstract": "This is a SETI config for RemoteTech, adding ground stations, changing the KSC range to cover the whole kerbol system (when not obstructed), setting signal delay to false and tweaking some colors.",
     "author": "Y3mo",
     "license": "GPL-2.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/SETI-RemoteTech"
     },
     "version": "1.3.0.0",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-RemoteTech/SETI-RemoteTech-1.3.0.1.ckan
+++ b/SETI-RemoteTech/SETI-RemoteTech-1.3.0.1.ckan
@@ -11,7 +11,7 @@
     },
     "version": "1.3.0.1",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SmartActuation/SmartActuation-1.0.1.1.ckan
+++ b/SmartActuation/SmartActuation-1.0.1.1.ckan
@@ -17,10 +17,10 @@
         }
     ],
     "download": "https://github.com/theRagingIrishman/SmartActuation/releases/download/1.0.1.1/SmartActuation_1.0.1.1.zip",
-    "download_size": 13907,
+    "download_size": 13747,
     "download_hash": {
-        "sha1": "46CB334B211B9FBAEF6648EC6632678B680F8D8B",
-        "sha256": "36E7B397B2C0235F0B01231859F2D2FD32ED5C903D02A9787136EB950E5F413F"
+        "sha1": "C2C4DE140A5E46FCCC12D02CFE4DD9752AA5840B",
+        "sha256": "B15AAF0CBCCE227CEEDC91F8E90176F696E08902BA234630878EC0660631433A"
     },
     "download_content_type": "application/zip",
     "x_via": "Automated Linuxgurugamer CKAN script",

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.0.8.3.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.0.8.3.ckan
@@ -6,13 +6,13 @@
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.0.8.3",
     "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.0",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.0.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.0.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned Before Manned",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.0.9.0",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.1.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.1.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned Before Manned",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.0.9.1",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.2.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.2.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned Before Manned",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.0.9.2",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.3.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.3.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned Before Manned",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.0.9.3",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.4.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.4.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned Before Manned",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.0.9.4",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.5.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.5.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned Before Manned",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.0.9.5",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "KSP-AVC"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.6.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.0.9.6.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned before Manned (SETI-UbM)",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.0.9.6",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.1",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.2.0.0.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.2.0.0.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned before Manned (SETI-UbM)",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.2.0.0",
     "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.2.0.1.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.2.0.1.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned before Manned (SETI-UbM)",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.2.0.1",
     "ksp_version_min": "1.2.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.2.1.0.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.2.1.0.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned before Manned (SETI-UbM)",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.2.1.0",
     "ksp_version_min": "1.2.1",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.2.2.0.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.2.2.0.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned before Manned (SETI-UbM)",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.2.2.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.2.2.1.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.2.2.1.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned before Manned (SETI-UbM)",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.2.2.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.3.0.0.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.3.0.0.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned before Manned (SETI-UbM)",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.3.0.0",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.3",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UnmannedBeforeManned/UnmannedBeforeManned-1.3.0.1.ckan
+++ b/UnmannedBeforeManned/UnmannedBeforeManned-1.3.0.1.ckan
@@ -1,18 +1,18 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "name": "Unmanned before Manned (SETI-UbM)",
     "abstract": "Moves stock parts around for an unmanned start and a more challenging early game. Works very well with stock tech tree and Community Tech Tree.",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "spacedock": "https://spacedock.info/mod/20/Unmanned%20Before%20Manned",
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/Unmanned_Before_Manned/Unmanned_Before_Manned-1456574347.1219552.png"
     },
     "version": "1.3.0.1",
     "ksp_version_min": "1.3.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.3",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UnmannedBeforeMannedChallenge/UnmannedBeforeMannedChallenge-1.2.2.1.ckan
+++ b/UnmannedBeforeMannedChallenge/UnmannedBeforeMannedChallenge-1.2.2.1.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeMannedChallenge",
     "name": "Unmanned Before Manned Challenge (SETI-UbMchallenge)",
     "abstract": "Makes UbM a bit more challenging. Reaction wheels not before 90 science, fuel lines to 550 science node, skipper engine one node later",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/UnmannedBeforeMannedChallenge"
     },
     "version": "1.2.2.1",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UnmannedBeforeMannedChallenge/UnmannedBeforeMannedChallenge-1.2.2.2.ckan
+++ b/UnmannedBeforeMannedChallenge/UnmannedBeforeMannedChallenge-1.2.2.2.ckan
@@ -1,17 +1,17 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeMannedChallenge",
     "name": "Unmanned Before Manned Challenge (SETI-UbMchallenge)",
     "abstract": "Makes UbM a bit more challenging. Reaction wheels not before 90 science, fuel lines to 550 science node, skipper engine one node later",
     "author": "Y3mo",
     "license": "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",
         "repository": "https://github.com/Y3mo/UnmannedBeforeMannedChallenge"
     },
     "version": "1.2.2.2",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/UnmannedBeforeMannedChallenge/UnmannedBeforeMannedChallenge-1.3.0.0.ckan
+++ b/UnmannedBeforeMannedChallenge/UnmannedBeforeMannedChallenge-1.3.0.0.ckan
@@ -11,7 +11,7 @@
     },
     "version": "1.3.0.0",
     "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.2",
     "depends": [
         {
             "name": "ModuleManager"


### PR DESCRIPTION
This is part of #1590 with just the SETI mods included.
1.99.99 game versions are replaced with the actual game versions as well as can be determined.