### PR TITLE
Unprovide configs for historical JNSQs

### DIFF
--- a/JNSQ/JNSQ-0.8.1.ckan
+++ b/JNSQ/JNSQ-0.8.1.ckan
@@ -24,8 +24,6 @@
     "provides": [
         "EnvironmentalVisualEnhancements-Config",
         "Scatterer-sunflare",
-        "DistantObject-config",
-        "PlanetShine-Config",
         "Kronometer"
     ],
     "depends": [

--- a/JNSQ/JNSQ-0.8.5.ckan
+++ b/JNSQ/JNSQ-0.8.5.ckan
@@ -25,8 +25,6 @@
     "provides": [
         "EnvironmentalVisualEnhancements-Config",
         "Scatterer-sunflare",
-        "DistantObject-config",
-        "PlanetShine-Config",
         "Kronometer"
     ],
     "depends": [


### PR DESCRIPTION
## Problem

@linuxgurugamer and @yalov noted on the JNSQ forum thread that if you install the latest JNSQ, an *older* version of JNSQ is offered as an option for satisfying certain dependencies.

![screenshot](https://i.imgur.com/AOVA8kX.png)

https://forum.kerbalspaceprogram.com/index.php?/topic/184880-17x-jnsq-086-13-nov-2019/&do=findComment&comment=3704814

https://forum.kerbalspaceprogram.com/index.php?/topic/184880-17x-jnsq-086-13-nov-2019/&do=findComment&comment=3714954

## Cause

Older versions of JNSQ provide DistantObject-config and PlanetShine-Config, and the latest version doesn't. @Galileo88 indicated that the provides was a mistake for PlanetShine because the default configs are needed:

https://forum.kerbalspaceprogram.com/index.php?/topic/184880-17x-jnsq-086-13-nov-2019/&do=findComment&comment=3704816

Here he states that DistantObject "can technically be installed any way without issue", suggesting the same is true for that mod:

https://forum.kerbalspaceprogram.com/index.php?/topic/184880-17x-jnsq-086-13-nov-2019/&do=findComment&comment=3617257

## Changes

Now the older versions have both of these provides removed.