### PR TITLE
Fix OpenResourceSystem compatibility

### DIFF
--- a/OpenResourceSystem/OpenResourceSystem-1.4.2.ckan
+++ b/OpenResourceSystem/OpenResourceSystem-1.4.2.ckan
@@ -9,7 +9,8 @@
         "homepage": "https://bitbucket.org/FractalUK/kspinstellar/downloads/"
     },
     "version": "1.4.2",
-    "ksp_version": "0.25",
+    "ksp_version_min": "0.24",
+    "ksp_version_max": "0.25",
     "download": "https://bitbucket.org/FractalUK/kspinstellar/downloads/OpenResourceSystem-v1.4.2.zip",
     "download_size": 35710,
     "download_hash": {


### PR DESCRIPTION
There's an old .ckan with no .netkan claiming compatibility only with KSP 0.25. It's a dependency for a mod that failed installation in KSP-CKAN/NetKAN#7544.

It was released on Sept 24, 2014:

- https://forum.kerbalspaceprogram.com/index.php?/topic/58673-open-resource-system-ors-mod-resource-api-version-142/&do=findComment&comment=1420958

But KSP 0.25 was released on Oct 7, 2014:

- https://wiki.kerbalspaceprogram.com/wiki/0.25

So the current version when this mod was released was actually 0.24.