### PR TITLE
Tags for historical ProgressiveColonizationSystem versions

### DIFF
--- a/ProgressiveColonizationSystem/ProgressiveColonizationSystem-0.0.4.ckan
+++ b/ProgressiveColonizationSystem/ProgressiveColonizationSystem-0.0.4.ckan
@@ -37,8 +37,9 @@
     },
     "download_content_type": "application/zip",
     "tags": [
-        "colonization",
-        "production"
+        "plugin",
+        "parts",
+        "manned"
     ],
     "x_generated_by": "netkan"
 }

--- a/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v0.0.5.ckan
+++ b/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v0.0.5.ckan
@@ -37,8 +37,9 @@
     },
     "download_content_type": "application/zip",
     "tags": [
-        "colonization",
-        "production"
+        "plugin",
+        "parts",
+        "manned"
     ],
     "x_generated_by": "netkan"
 }

--- a/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v0.0.6.ckan
+++ b/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v0.0.6.ckan
@@ -37,8 +37,9 @@
     },
     "download_content_type": "application/zip",
     "tags": [
-        "colonization",
-        "production"
+        "plugin",
+        "parts",
+        "manned"
     ],
     "x_generated_by": "netkan"
 }

--- a/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v0.1.1.ckan
+++ b/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v0.1.1.ckan
@@ -37,8 +37,9 @@
     },
     "download_content_type": "application/zip",
     "tags": [
-        "colonization",
-        "production"
+        "plugin",
+        "parts",
+        "manned"
     ],
     "x_generated_by": "netkan"
 }

--- a/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.0.ckan
+++ b/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.0.ckan
@@ -37,8 +37,9 @@
     },
     "download_content_type": "application/zip",
     "tags": [
-        "colonization",
-        "production"
+        "plugin",
+        "parts",
+        "manned"
     ],
     "x_generated_by": "netkan"
 }

--- a/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.1.ckan
+++ b/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.1.ckan
@@ -37,8 +37,9 @@
     },
     "download_content_type": "application/zip",
     "tags": [
-        "colonization",
-        "production"
+        "plugin",
+        "parts",
+        "manned"
     ],
     "x_generated_by": "netkan"
 }

--- a/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.2.ckan
+++ b/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.2.ckan
@@ -37,8 +37,9 @@
     },
     "download_content_type": "application/zip",
     "tags": [
-        "colonization",
-        "production"
+        "plugin",
+        "parts",
+        "manned"
     ],
     "x_generated_by": "netkan"
 }

--- a/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.3.ckan
+++ b/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.3.ckan
@@ -37,8 +37,9 @@
     },
     "download_content_type": "application/zip",
     "tags": [
-        "colonization",
-        "production"
+        "plugin",
+        "parts",
+        "manned"
     ],
     "x_generated_by": "netkan"
 }

--- a/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.4.ckan
+++ b/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.4.ckan
@@ -40,8 +40,9 @@
     },
     "download_content_type": "application/zip",
     "tags": [
-        "colonization",
-        "production"
+        "plugin",
+        "parts",
+        "manned"
     ],
     "x_generated_by": "netkan"
 }

--- a/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.5.ckan
+++ b/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.5.ckan
@@ -40,8 +40,9 @@
     },
     "download_content_type": "application/zip",
     "tags": [
-        "colonization",
-        "production"
+        "plugin",
+        "parts",
+        "manned"
     ],
     "x_generated_by": "netkan"
 }

--- a/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.6.ckan
+++ b/ProgressiveColonizationSystem/ProgressiveColonizationSystem-v1.0.6.ckan
@@ -40,8 +40,9 @@
     },
     "download_content_type": "application/zip",
     "tags": [
-        "colonization",
-        "production"
+        "plugin",
+        "parts",
+        "manned"
     ],
     "x_generated_by": "netkan"
 }


### PR DESCRIPTION
In KSP-CKAN/NetKAN#7547 we updated this mod's netkan's tags to fit the recommendations of the wiki:

https://github.com/KSP-CKAN/CKAN/wiki/Suggested-Tags

Now the historical versions are updated as well.