### PR TITLE
Assorted fixes for Mk1RPMInternal

### DIFF
--- a/Mk1RPMInternal/Mk1RPMInternal-1-2.2.ckan
+++ b/Mk1RPMInternal/Mk1RPMInternal-1-2.2.ckan
@@ -10,14 +10,14 @@
         "spacedock": "https://spacedock.info/mod/377/Mk1%20Cockpit%20RPM%20Internals",
         "x_screenshot": "https://spacedock.info/content/fast_de_la_speed_233/Mk1_Cockpit_RPM_Internals/Mk1_Cockpit_RPM_Internals-1459127088.2661915.png"
     },
-    "version": "2.2",
+    "version": "1:2.2",
     "ksp_version": "1.1.3",
     "depends": [
         {
             "name": "ModuleManager"
         },
         {
-            "name": "RasterPropMonitor-Core"
+            "name": "RasterPropMonitor"
         }
     ],
     "download": "https://spacedock.info/mod/377/Mk1%20Cockpit%20RPM%20Internals/download/2.2",

--- a/Mk1RPMInternal/Mk1RPMInternal-2.11.ckan
+++ b/Mk1RPMInternal/Mk1RPMInternal-2.11.ckan
@@ -15,6 +15,9 @@
     "depends": [
         {
             "name": "ModuleManager"
+        },
+        {
+            "name": "RasterPropMonitor"
         }
     ],
     "download": "https://spacedock.info/mod/377/Mk1%20Cockpit%20RPM%20Internals/download/2.11",

--- a/Mk1RPMInternal/Mk1RPMInternal-2.11b.ckan
+++ b/Mk1RPMInternal/Mk1RPMInternal-2.11b.ckan
@@ -17,7 +17,7 @@
             "name": "ModuleManager"
         },
         {
-            "name": "RasterPropMonitor-Core"
+            "name": "RasterPropMonitor"
         }
     ],
     "download": "https://spacedock.info/mod/377/Mk1%20Cockpit%20RPM%20Internals/download/2.11b",

--- a/Mk1RPMInternal/Mk1RPMInternal-2.11c.ckan
+++ b/Mk1RPMInternal/Mk1RPMInternal-2.11c.ckan
@@ -17,7 +17,7 @@
             "name": "ModuleManager"
         },
         {
-            "name": "RasterPropMonitor-Core"
+            "name": "RasterPropMonitor"
         }
     ],
     "download": "https://spacedock.info/mod/377/Mk1%20Cockpit%20RPM%20Internals/download/2.11c",


### PR DESCRIPTION
I contacted RPM's new maintainer as part of KSP-CKAN/NetKAN#7608, and in the course of that conversation he discovered that Mk1RPMInternal should depend on RasterPropMonitor but only depends on RasterPropMonitor-Core currently, because it uses the RasterPropMonitorBasicMFD prop which is (erroneously) defined in RasterPropMonitor instead of RasterPropMonitor-Core.

While preparing this fix, I found that the 2.11 version doesn't depend on *either*. And the latest version needs to be epoched because 2.2 followed 2.11.

Now this is all fixed.