### PR TITLE
Update RPM depends for historical modules

### DIFF
--- a/ASETProps/ASETProps-1.4.ckan
+++ b/ASETProps/ASETProps-1.4.ckan
@@ -11,7 +11,8 @@
         "x_screenshot": "https://spacedock.info/content/alexustas_3789/ASET_Props/ASET_Props-1486510832.1924078.png"
     },
     "version": "1.4",
-    "ksp_version": "1.3.1",
+    "ksp_version_min": "1.2",
+    "ksp_version_max": "1.3",
     "depends": [
         {
             "name": "ASETAgency"

--- a/ASETProps/ASETProps-1.5.ckan
+++ b/ASETProps/ASETProps-1.5.ckan
@@ -5,7 +5,8 @@
     "abstract": "ASET Props pack",
     "author": "alexustas",
     "version": "1.5",
-    "ksp_version": "1.7.3",
+    "ksp_version_min": "1.4",
+    "ksp_version_max": "1.7",
     "license": "CC-BY-NC-SA-3.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/116430-ivaprops-aset-props-pack-v13-for-the-modders-who-create-iva/",

--- a/CessnaStyleIVAcokpit/CessnaStyleIVAcokpit-2.0.ckan
+++ b/CessnaStyleIVAcokpit/CessnaStyleIVAcokpit-2.0.ckan
@@ -22,7 +22,7 @@
             "name": "ASETProps"
         },
         {
-            "name": "RasterPropMonitor-Core"
+            "name": "RasterPropMonitor"
         }
     ],
     "install": [

--- a/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-1-1.3_Collectors_Edition.ckan
+++ b/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-1-1.3_Collectors_Edition.ckan
@@ -29,7 +29,7 @@
             "name": "MK12PodIVAReplacementbyASET"
         },
         {
-            "name": "RasterPropMonitor-Core",
+            "name": "RasterPropMonitor",
             "min_version": "0.21.2"
         }
     ],

--- a/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-1-1.3_X.ckan
+++ b/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-1-1.3_X.ckan
@@ -29,7 +29,7 @@
             "name": "MK12PodIVAReplacementbyASET"
         },
         {
-            "name": "RasterPropMonitor-Core",
+            "name": "RasterPropMonitor",
             "min_version": "0.21.2"
         }
     ],

--- a/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-1-Chaka_Monkey_Evolution_1.3.1_X.ckan
+++ b/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-1-Chaka_Monkey_Evolution_1.3.1_X.ckan
@@ -29,7 +29,7 @@
             "name": "MK12PodIVAReplacementbyASET"
         },
         {
-            "name": "RasterPropMonitor-Core",
+            "name": "RasterPropMonitor",
             "min_version": "0.21.2"
         }
     ],

--- a/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-1.1_BETA.ckan
+++ b/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-1.1_BETA.ckan
@@ -29,7 +29,7 @@
             "name": "MK12PodIVAReplacementbyASET"
         },
         {
-            "name": "RasterPropMonitor-Core",
+            "name": "RasterPropMonitor",
             "min_version": "0.21.2"
         }
     ],

--- a/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-2-Chaka_143.ckan
+++ b/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-2-Chaka_143.ckan
@@ -29,7 +29,7 @@
             "name": "MK12PodIVAReplacementbyASET"
         },
         {
-            "name": "RasterPropMonitor-Core",
+            "name": "RasterPropMonitor",
             "min_version": "0.21.2"
         }
     ],

--- a/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-3-1.4.3a.ckan
+++ b/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-3-1.4.3a.ckan
@@ -29,7 +29,7 @@
             "name": "MK12PodIVAReplacementbyASET"
         },
         {
-            "name": "RasterPropMonitor-Core",
+            "name": "RasterPropMonitor",
             "min_version": "0.21.2"
         }
     ],

--- a/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-Chaka_Monkey_Exploration_Systems_1.1.3.ckan
+++ b/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-Chaka_Monkey_Exploration_Systems_1.1.3.ckan
@@ -29,7 +29,7 @@
             "name": "MK12PodIVAReplacementbyASET"
         },
         {
-            "name": "RasterPropMonitor-Core",
+            "name": "RasterPropMonitor",
             "min_version": "0.21.2"
         }
     ],

--- a/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-Chaka_Monkey_Exploration_Systems_1.2.2.A.ckan
+++ b/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-Chaka_Monkey_Exploration_Systems_1.2.2.A.ckan
@@ -29,7 +29,7 @@
             "name": "MK12PodIVAReplacementbyASET"
         },
         {
-            "name": "RasterPropMonitor-Core",
+            "name": "RasterPropMonitor",
             "min_version": "0.21.2"
         }
     ],

--- a/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-Chaka_Monkey_Exploration_Systems_1.2.2.X.ckan
+++ b/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-Chaka_Monkey_Exploration_Systems_1.2.2.X.ckan
@@ -29,7 +29,7 @@
             "name": "MK12PodIVAReplacementbyASET"
         },
         {
-            "name": "RasterPropMonitor-Core",
+            "name": "RasterPropMonitor",
             "min_version": "0.21.2"
         }
     ],

--- a/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-Chaka_Monkey_Exploration_Systems_1.2.2.ckan
+++ b/ChakaMonkeyExplorationSystems/ChakaMonkeyExplorationSystems-Chaka_Monkey_Exploration_Systems_1.2.2.ckan
@@ -29,7 +29,7 @@
             "name": "MK12PodIVAReplacementbyASET"
         },
         {
-            "name": "RasterPropMonitor-Core",
+            "name": "RasterPropMonitor",
             "min_version": "0.21.2"
         }
     ],

--- a/FirespitterCore/FirespitterCore-v7.1.4.ckan
+++ b/FirespitterCore/FirespitterCore-v7.1.4.ckan
@@ -7,9 +7,7 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://snjo.github.io/",
-        "kerbalstuff": "https://kerbalstuff.com/mod/777/Firespitter%20-%20Plugin%20Only",
-        "repository": "https://github.com/snjo/Firespitter",
-        "x_screenshot": "https://kerbalstuff.com/content/Roverdude_9553/Firespitter_-_Plugin_Only/Firespitter_-_Plugin_Only-1431346890.8021555.jpg"
+        "repository": "https://github.com/snjo/Firespitter"
     },
     "version": "v7.1.4",
     "ksp_version": "1.0.4",
@@ -23,7 +21,7 @@
             "install_to": "GameData/Firespitter"
         }
     ],
-    "download": "https://kerbalstuff.com/mod/777/Firespitter%20-%20Plugin%20Only/download/7.1.4",
+    "download": "https://github.com/snjo/Firespitter/releases/download/v7.1.4/Firespitter_7.1.4.zip",
     "download_size": 100224,
     "x_generated_by": "netkan"
 }

--- a/FirespitterCore/FirespitterCore-v7.1.4.ckan
+++ b/FirespitterCore/FirespitterCore-v7.1.4.ckan
@@ -22,6 +22,11 @@
         }
     ],
     "download": "https://github.com/snjo/Firespitter/releases/download/v7.1.4/Firespitter_7.1.4.zip",
-    "download_size": 100224,
+    "download_size": 37438180,
+    "download_hash": {
+        "sha1": "1F6F0BCD2DE4334CC21CDEBF1852ABEA1D5C6D58",
+        "sha256": "D63E2859937EA48C19CB92B6D5E773F2D3E1AE6EE56C0AD8D7539F331D2BBD79"
+    },
+    "download_content_type": "application/zip",
     "x_generated_by": "netkan"
 }

--- a/MK12PodIVAReplacementbyASET/MK12PodIVAReplacementbyASET-1-0.2.ckan
+++ b/MK12PodIVAReplacementbyASET/MK12PodIVAReplacementbyASET-1-0.2.ckan
@@ -11,7 +11,8 @@
         "x_screenshot": "https://spacedock.info/content/alexustas_3789/MK1-2_IVA_Replacement_by_ASET/MK1-2_IVA_Replacement_by_ASET-1486516144.682995.png"
     },
     "version": "1:0.2",
-    "ksp_version": "1.3.1",
+    "ksp_version_min": "1.2",
+    "ksp_version_max": "1.3",
     "depends": [
         {
             "name": "ASETAgency"

--- a/MK12PodIVAReplacementbyASET/MK12PodIVAReplacementbyASET-1-0.3.ckan
+++ b/MK12PodIVAReplacementbyASET/MK12PodIVAReplacementbyASET-1-0.3.ckan
@@ -5,7 +5,8 @@
     "abstract": "Whole brand new interior for the Mk1-2 Pod",
     "author": "alexustas",
     "version": "1:0.3",
-    "ksp_version": "1.7.3",
+    "ksp_version_min": "1.4",
+    "ksp_version_max": "1.7",
     "license": "CC-BY-NC-SA-3.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/116440-mk1-2-pod-iva-replacement-by-aset/",

--- a/MK12PodIVAReplacementbyASET/MK12PodIVAReplacementbyASET-1.1.3.ckan
+++ b/MK12PodIVAReplacementbyASET/MK12PodIVAReplacementbyASET-1.1.3.ckan
@@ -12,7 +12,7 @@
         "x_screenshot": "https://spacedock.info/content/YANFRET_4098/Chaka_Monkey_Exploration_Systems/Chaka_Monkey_Exploration_Systems-1461723387.8193252.jpg"
     },
     "version": "1.1.3",
-    "ksp_version": "1.1.3",
+    "ksp_version": "1.1",
     "depends": [
         {
             "name": "ASETProps"

--- a/Super100ShootingStarCommandPod/Super100ShootingStarCommandPod-1.02.ckan
+++ b/Super100ShootingStarCommandPod/Super100ShootingStarCommandPod-1.02.ckan
@@ -14,7 +14,7 @@
     "ksp_version": "1.0.4",
     "depends": [
         {
-            "name": "RasterPropMonitor-Core"
+            "name": "RasterPropMonitor"
         }
     ],
     "recommends": [


### PR DESCRIPTION
See KSP-CKAN/NetKAN#7610; these modules use RasterPropMonitorBasicMFD, which is provided by RasterPropMonitor, but they only depend on RasterPropMonitor-Core. Now they depend on RasterPropMonitor.