### PR TITLE
Set old SXTContinued licenses

### DIFF
--- a/SXTContinued/SXTContinued-0.3.0-beta.ckan
+++ b/SXTContinued/SXTContinued-0.3.0-beta.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.10.ckan
+++ b/SXTContinued/SXTContinued-0.3.10.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.11.1.ckan
+++ b/SXTContinued/SXTContinued-0.3.11.1.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.11.ckan
+++ b/SXTContinued/SXTContinued-0.3.11.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.12.1.ckan
+++ b/SXTContinued/SXTContinued-0.3.12.1.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.12.ckan
+++ b/SXTContinued/SXTContinued-0.3.12.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.14.ckan
+++ b/SXTContinued/SXTContinued-0.3.14.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.2-beta.ckan
+++ b/SXTContinued/SXTContinued-0.3.2-beta.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.2.1-beta.ckan
+++ b/SXTContinued/SXTContinued-0.3.2.1-beta.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.3.ckan
+++ b/SXTContinued/SXTContinued-0.3.3.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.4.ckan
+++ b/SXTContinued/SXTContinued-0.3.4.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.5.ckan
+++ b/SXTContinued/SXTContinued-0.3.5.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.6.ckan
+++ b/SXTContinued/SXTContinued-0.3.6.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.7.1.ckan
+++ b/SXTContinued/SXTContinued-0.3.7.1.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.8.ckan
+++ b/SXTContinued/SXTContinued-0.3.8.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.9.1.ckan
+++ b/SXTContinued/SXTContinued-0.3.9.1.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0.3.9.ckan
+++ b/SXTContinued/SXTContinued-0.3.9.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-0313.ckan
+++ b/SXTContinued/SXTContinued-0313.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.14.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.14.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.16.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.16.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.17.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.17.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.18.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.18.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.19.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.19.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.20.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.20.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.21.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.21.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.22.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.22.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.23.1.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.23.1.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",
@@ -36,7 +36,7 @@
     "download": "https://spacedock.info/mod/1030/SXTContinued/download/0.3.23.1",
     "download_size": 38736683,
     "download_hash": {
-        "sha1": "94A24ADF5175F08754F0DBEAF0B30DAAB3FD45C5",                
+        "sha1": "94A24ADF5175F08754F0DBEAF0B30DAAB3FD45C5",
         "sha256": "0DDA094408B2AFCA6E6AE64C54E8EF93A1A45FCF8463E472B397BAC4E3D7F918"
     },
     "download_content_type": "application/zip",

--- a/SXTContinued/SXTContinued-1-0.3.23.2.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.23.2.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.23.3.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.23.3.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.23.4.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.23.4.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.23.5.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.23.5.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.23.6.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.23.6.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.23.7.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.23.7.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.24.1.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.24.1.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.24.2.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.24.2.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.24.3.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.24.3.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.24.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.24.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.25.1.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.25.1.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.25.2.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.25.2.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.25.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.25.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.26.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.26.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.27.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.27.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.28.1.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.28.1.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.28.2.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.28.2.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-0.3.28.ckan
+++ b/SXTContinued/SXTContinued-1-0.3.28.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-1-03.28.2.ckan
+++ b/SXTContinued/SXTContinued-1-03.28.2.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",

--- a/SXTContinued/SXTContinued-2-0.3.29.ckan
+++ b/SXTContinued/SXTContinued-2-0.3.29.ckan
@@ -4,7 +4,7 @@
     "name": "SXTContinued",
     "abstract": "A memory light 'Stock-a-like' expansion pack that relies solely using the MODEL{} to reference Squad's textures and get a lot of 'bang for buck'",
     "author": "linuxgurugamer",
-    "license": "unknown",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/",
         "spacedock": "https://spacedock.info/mod/1030/SXTContinued",


### PR DESCRIPTION
Historical version of KSP-CKAN/NetKAN#7614. I think this will result in these modules being uploaded to archive.org, but I could be wrong.