### PR TITLE
Index missing Chatterer version

### DIFF
--- a/Chatterer/Chatterer-0.9.97.ckan
+++ b/Chatterer/Chatterer-0.9.97.ckan
@@ -1,0 +1,30 @@
+{
+    "spec_version": 1,
+    "identifier": "Chatterer",
+    "name": "Chatterer",
+    "abstract": "A plugin for Kerbal Space Program which adds some SSTV, beeps, and nonsensical radio chatter between your command pods and Mission Control.",
+    "author": "Athlonic",
+    "version": "0.9.97",
+    "ksp_version_min": "1.5.0",
+    "ksp_version_max": "1.7.99",
+    "license": "GPL-3.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83290-105-chatterer-v097-keep-talking-11-nov-2015/&page=1",
+        "spacedock": "https://spacedock.info/mod/208/Chatterer",
+        "repository": "https://github.com/Athlonic/Chatterer",
+        "x_screenshot": "https://spacedock.info/content/Athlonic_476/Chatterer/Chatterer-1466941135.9980326.png"
+    },
+    "tags": [
+        "plugin",
+        "sound",
+        "crewed"
+    ],
+    "download": "https://spacedock.info/mod/208/Chatterer/download/0.9.97",
+    "download_size": 6938353,
+    "download_hash": {
+        "sha1": "5E3709460FB7617684B28CC70B7F2D142B62510B",
+        "sha256": "BDA1768397E1974A2822E7C001550612B9A522A19C9A6EA3CA2CE90D6F974E02"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
A fix release of Chatterer got missed. It was uploaded to SpaceDock the same day as a subsequent version that *was* indexed, back in October, so it may have been due to close timing or the new bot's migration growing pains. Now it's added.

Fixes KSP-CKAN/NetKAN#7620.