### PR TITLE
Limit Chatterer 0.9.96 to KSP 1.4-1.6

### DIFF
--- a/Chatterer/Chatterer-0.9.96.ckan
+++ b/Chatterer/Chatterer-0.9.96.ckan
@@ -12,8 +12,8 @@
         "x_screenshot": "https://spacedock.info/content/Athlonic_476/Chatterer/Chatterer-1466941135.9980326.png"
     },
     "version": "0.9.96",
-    "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.7.99",
+    "ksp_version_min": "1.4",
+    "ksp_version_max": "1.6",
     "download": "https://spacedock.info/mod/208/Chatterer/download/0.9.96",
     "download_size": 6936679,
     "download_hash": {


### PR DESCRIPTION
KSP-CKAN/NetKAN#7620 suggested that Chatterer 0.9.96 "throws a bunch of notifications about it being outdated on startup", but that could be KSP-AVC behaving normally. However, some folks on the forum thread indicated they had problems with it on KSP 1.7.3, and version 0.9.97 was specifically a recompile for KSP 1.7.3.

Confused, I asked the author whether this version should be installed on KSP 1.7.3, and he said no:

https://forum.kerbalspaceprogram.com/index.php?/topic/83290-18x-chatterer-v0998-moar-talking-23-oct-2019/&do=findComment&comment=3726176