### PR TITLE
Tag frozen modules, group 1

### DIFF
--- a/AlternisKerbolRekerjiggered-flags/AlternisKerbolRekerjiggered-flags-1.5.ckan
+++ b/AlternisKerbolRekerjiggered-flags/AlternisKerbolRekerjiggered-flags-1.5.ckan
@@ -10,6 +10,9 @@
         "kerbalstuff": "https://kerbalstuff.com/mod/1143/Alternis%20Kerbol%20Rekerjiggered",
         "x_screenshot": "https://kerbalstuff.com/content/GregroxMun_8555/Alternis_Kerbol_Rekerjiggered/Alternis_Kerbol_Rekerjiggered-1443398937.4146845.png"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "1.5",
     "ksp_version": "any",
     "install": [

--- a/AnimatedStationScreens/AnimatedStationScreens-1.0.ckan
+++ b/AnimatedStationScreens/AnimatedStationScreens-1.0.ckan
@@ -10,6 +10,9 @@
         "spacedock": "https://spacedock.info/mod/1057/Animated%20Station%20Screens",
         "x_screenshot": "https://spacedock.info/content/Enceos_856/Animated_Station_Screens/Animated_Station_Screens-1478897443.842688.jpg"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "1.0",
     "ksp_version": "any",
     "install": [

--- a/AsphaltTiles/AsphaltTiles-1.2.ckan
+++ b/AsphaltTiles/AsphaltTiles-1.2.ckan
@@ -10,6 +10,9 @@
         "spacedock": "https://spacedock.info/mod/445/Asphalt%20Tiles",
         "x_screenshot": "https://spacedock.info/content/Enceos_856/Asphalt_Tiles/Asphalt_Tiles-1459095332.8268569.jpg"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "1.2",
     "ksp_version": "any",
     "suggests": [

--- a/AsphaltTilesWelded/AsphaltTilesWelded-1.2.ckan
+++ b/AsphaltTilesWelded/AsphaltTilesWelded-1.2.ckan
@@ -10,6 +10,9 @@
         "spacedock": "https://spacedock.info/mod/445/Asphalt%20Tiles",
         "x_screenshot": "https://spacedock.info/content/Enceos_856/Asphalt_Tiles/Asphalt_Tiles-1459095332.8268569.jpg"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "1.2",
     "ksp_version": "any",
     "depends": [

--- a/Astro-Cosmonauts/Astro-Cosmonauts-0.2.ckan
+++ b/Astro-Cosmonauts/Astro-Cosmonauts-0.2.ckan
@@ -10,6 +10,11 @@
         "spacedock": "https://spacedock.info/mod/759/Astro/Cosmonauts%20for%20Texture%20Replacer",
         "x_screenshot": "https://spacedock.info/content/christronomy_5613/Astro_Cosmonauts_for_Texture_Replacer/Astro_Cosmonauts_for_Texture_Replacer-1465670489.8181043.png"
     },
+    "tags": [
+        "config",
+        "graphics",
+        "crewed"
+    ],
     "version": "0.2",
     "ksp_version": "1.7.2",
     "depends": [

--- a/AustrianSpaceAgency/AustrianSpaceAgency-1.1.1.ckan
+++ b/AustrianSpaceAgency/AustrianSpaceAgency-1.1.1.ckan
@@ -12,6 +12,9 @@
         "homepage": "https://github.com/brama0309/AustrianSpaceAgency",
         "repository": "https://github.com/brama0309/AustrianSpaceAgency"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "1.1.1",
     "ksp_version": "any",
     "depends": [

--- a/BeyondKerbinPlanetPack/BeyondKerbinPlanetPack-1.2.ckan
+++ b/BeyondKerbinPlanetPack/BeyondKerbinPlanetPack-1.2.ckan
@@ -11,6 +11,10 @@
         "spacedock": "https://spacedock.info/mod/1965/Beyond%20Kerbin%20Planet%20Pack",
         "x_screenshot": "https://spacedock.info/content/Ub3rshadow_21488/Beyond_Kerbin_Planet_Pack/Beyond_Kerbin_Planet_Pack-1537904304.599972.png"
     },
+    "tags": [
+        "config",
+        "planet-pack"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/BrazilianFlagBandeiradoBrasil/BrazilianFlagBandeiradoBrasil-2.0.ckan
+++ b/BrazilianFlagBandeiradoBrasil/BrazilianFlagBandeiradoBrasil-2.0.ckan
@@ -11,6 +11,9 @@
         "spacedock": "https://spacedock.info/mod/808/Brazilian%20Flag%20-%20Bandeira%20do%20Brasil",
         "x_screenshot": "https://spacedock.info/content/ricardoguedes21_996/Brazilian_Flag_-_Bandeira_do_Brasil/Brazilian_Flag_-_Bandeira_do_Brasil-1467293806.1396558.jpg"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "2.0",
     "ksp_version": "any",
     "install": [

--- a/BritishRockets/BritishRockets-1.1.3.ckan
+++ b/BritishRockets/BritishRockets-1.1.3.ckan
@@ -11,6 +11,9 @@
     "resources": {
         "spacedock": "https://spacedock.info/mod/921/British%20Rockets"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "1.1.3",
     "ksp_version": "1.7.3",
     "install": [

--- a/CommunityDeltaVMaps/CommunityDeltaVMaps-v2.6.0.ckan
+++ b/CommunityDeltaVMaps/CommunityDeltaVMaps-v2.6.0.ckan
@@ -9,6 +9,10 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/87463-*",
         "repository": "https://github.com/Kowgan/ksp_cheat_sheets"
     },
+    "tags": [
+        "config",
+        "information"
+    ],
     "version": "v2.6.0",
     "ksp_version_min": "1.3",
     "install": [

--- a/ConstellationEssentials/ConstellationEssentials-v1.4.1.0.ckan
+++ b/ConstellationEssentials/ConstellationEssentials-v1.4.1.0.ckan
@@ -12,6 +12,9 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/69581-*",
         "repository": "https://github.com/PhineasFreak/ConstellationEssentials"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.4.1.0",
     "ksp_version": "any",
     "install": [

--- a/ContractConfigurator-CleverSats/ContractConfigurator-CleverSats-1.4.ckan
+++ b/ContractConfigurator-CleverSats/ContractConfigurator-CleverSats-1.4.ckan
@@ -9,6 +9,11 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/132844-105-contract-pack-clever-sats-10-240216",
         "repository": "https://github.com/severedsolo/CleverSat"
     },
+    "tags": [
+        "config",
+        "career",
+        "uncrewed"
+    ],
     "version": "1.4",
     "ksp_version_min": "1.2.2",
     "depends": [

--- a/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.10.ckan
+++ b/ContractConfigurator-KerbalAcademy/ContractConfigurator-KerbalAcademy-1.1.10.ckan
@@ -14,6 +14,11 @@
         "repository": "https://github.com/Mark-Kerbin/Kerbal-Academy-Contract-Pack/releases",
         "x_screenshot": "https://spacedock.info/content/Mark_Kerbin_19882/Kerbal_Academy_Contract_Pack/Kerbal_Academy_Contract_Pack-1526129166.4534357.png"
     },
+    "tags": [
+        "config",
+        "career",
+        "crewed"
+    ],
     "version": "1.1.10",
     "ksp_version_min": "1.4.2",
     "depends": [

--- a/CrowdSourcedFlags/CrowdSourcedFlags-1.55.5.ckan
+++ b/CrowdSourcedFlags/CrowdSourcedFlags-1.55.5.ckan
@@ -10,6 +10,9 @@
         "homepage": "https://www.reddit.com/r/KSP_CrowdSourcedFlags/",
         "repository": "https://github.com/dmxz/CrowdSourcedFlags/"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "1.55.5",
     "ksp_version": "any",
     "suggests": [

--- a/DockingPortSoundFX/DockingPortSoundFX-v2.1.12.ckan
+++ b/DockingPortSoundFX/DockingPortSoundFX-v2.1.12.ckan
@@ -9,6 +9,10 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/113390-*",
         "repository": "https://github.com/TedThompson/Docking-Sounds"
     },
+    "tags": [
+        "plugin",
+        "sound"
+    ],
     "version": "v2.1.12",
     "depends": [
         {

--- a/DogeCoinFlag/DogeCoinFlag-v1.02.ckan
+++ b/DogeCoinFlag/DogeCoinFlag-v1.02.ckan
@@ -11,6 +11,9 @@
         "homepage": "https://www.reddit.com/r/dogecoin/comments/1tdlgg/i_made_a_more_accurate_dogecoin_and_a_ksp_flag/",
         "repository": "https://github.com/pjf/DogeCoinFlag"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "v1.02",
     "ksp_version": "any",
     "download": "https://github.com/pjf/DogeCoinFlag/releases/download/v1.02/DogeCoinFlag-1.02.zip",

--- a/EnduranceSpaceExplorationSystem/EnduranceSpaceExplorationSystem-V1.10.ckan
+++ b/EnduranceSpaceExplorationSystem/EnduranceSpaceExplorationSystem-V1.10.ckan
@@ -11,6 +11,10 @@
         "repository": "https://github.com/JPLRepo/Endurance",
         "x_screenshot": "https://spacedock.info/content/Jplrepo_405/Endurance_from_Interstellar_Continued/Endurance_from_Interstellar_Continued-1457248000.231013.png"
     },
+    "tags": [
+        "plugin",
+        "parts"
+    ],
     "version": "V1.10",
     "ksp_version_min": "1.8.0",
     "ksp_version_max": "1.8.99",

--- a/EskandareHeavyIndustries/EskandareHeavyIndustries-1.0.12.ckan
+++ b/EskandareHeavyIndustries/EskandareHeavyIndustries-1.0.12.ckan
@@ -11,6 +11,9 @@
         "spacedock": "https://spacedock.info/mod/521/Thermonuclear%20Turbines",
         "x_screenshot": "https://spacedock.info/content/Eskandare_547/Thermonuclear_Turbines/Thermonuclear_Turbines-1460492751.5492454.png"
     },
+    "tags": [
+        "agency"
+    ],
     "version": "1.0.12",
     "ksp_version": "any",
     "install": [

--- a/FederalProductions-Flags/FederalProductions-Flags-0.2.ckan
+++ b/FederalProductions-Flags/FederalProductions-Flags-0.2.ckan
@@ -10,6 +10,9 @@
         "kerbalstuff": "https://kerbalstuff.com/mod/1044/Docking%20Target",
         "x_screenshot": "https://kerbalstuff.com/content/TG626_462/Docking_Target/Docking_Target-1438305002.9143665.png"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "0.2",
     "ksp_version": "any",
     "install": [

--- a/FreedomTex/FreedomTex-1-v1.5.1.0.ckan
+++ b/FreedomTex/FreedomTex-1-v1.5.1.0.ckan
@@ -12,6 +12,10 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/85342-jebediahkerman42s-procedural-part-textures",
         "repository": "https://github.com/PhineasFreak/FreedomTextures"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "version": "1:v1.5.1.0",
     "ksp_version_min": "1.2",
     "depends": [

--- a/FusTek-SharedAssets/FusTek-SharedAssets-1.0.ckan
+++ b/FusTek-SharedAssets/FusTek-SharedAssets-1.0.ckan
@@ -10,6 +10,9 @@
     "resources": {
         "repository": "https://github.com/sumghai/FusTek_SharedAssets"
     },
+    "tags": [
+        "agency"
+    ],
     "version": "1.0",
     "ksp_version": "any",
     "install": [

--- a/GrindyScience/GrindyScience-1-1.0.1.1.ckan
+++ b/GrindyScience/GrindyScience-1-1.0.1.1.ckan
@@ -11,6 +11,10 @@
         "spacedock": "https://spacedock.info/mod/1141/Grindy%20Science",
         "repository": "https://github.com/ValynEritai/GrindyScience"
     },
+    "tags": [
+        "config",
+        "science"
+    ],
     "version": "1:1.0.1.1",
     "ksp_version": "any",
     "depends": [

--- a/HumanColoredFaces/HumanColoredFaces-17.ckan
+++ b/HumanColoredFaces/HumanColoredFaces-17.ckan
@@ -11,6 +11,11 @@
         "curse": "https://kerbal.curseforge.com/projects/241870",
         "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/34/538/120/120/635911341287168266.png"
     },
+    "tags": [
+        "config",
+        "graphics",
+        "crewed"
+    ],
     "version": "17",
     "ksp_version": "any",
     "depends": [

--- a/KHWearableKISProps/KHWearableKISProps-1.1.ckan
+++ b/KHWearableKISProps/KHWearableKISProps-1.1.ckan
@@ -10,6 +10,10 @@
         "spacedock": "https://spacedock.info/mod/1120/Kerbal%20Hack:%20Wearable%20KIS%20Props",
         "x_screenshot": "https://spacedock.info/content/Enceos_856/Kerbal_Hack_Wearable_KIS_Props/Kerbal_Hack_Wearable_KIS_Props-1482023206.6846926.jpg"
     },
+    "tags": [
+        "parts",
+        "crewed"
+    ],
     "version": "1.1",
     "ksp_version": "any",
     "depends": [

--- a/KSP-Slovakia-flags/KSP-Slovakia-flags-0.0.1.ckan
+++ b/KSP-Slovakia-flags/KSP-Slovakia-flags-0.0.1.ckan
@@ -12,6 +12,9 @@
         "homepage": "https://github.com/miki-g/KSP-Slovakia-Flags",
         "repository": "https://github.com/miki-g/KSP-Slovakia-Flags"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "0.0.1",
     "ksp_version": "any",
     "install": [

--- a/KerbalHacksDroptankWrapper/KerbalHacksDroptankWrapper-1.0.ckan
+++ b/KerbalHacksDroptankWrapper/KerbalHacksDroptankWrapper-1.0.ckan
@@ -10,6 +10,9 @@
         "spacedock": "https://spacedock.info/mod/1127/Kerbal%20Hacks:%20Droptank%20\"Wrapper\"",
         "x_screenshot": "https://spacedock.info/content/Enceos_856/Kerbal_Hacks_Droptank_Wrapper/Kerbal_Hacks_Droptank_Wrapper-1482782780.704257.jpg"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "1.0",
     "ksp_version": "any",
     "suggests": [

--- a/KerbalOccupationColors/KerbalOccupationColors-v1.2.0.ckan
+++ b/KerbalOccupationColors/KerbalOccupationColors-v1.2.0.ckan
@@ -9,6 +9,11 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/185931-17-kerbal-occupation-colors-version-10/",
         "repository": "https://github.com/Starwaster/Kerbal-Occupation-Colors"
     },
+    "tags": [
+        "plugin",
+        "crewed",
+        "information"
+    ],
     "version": "v1.2.0",
     "depends": [
         {

--- a/LSPFlags/LSPFlags-v2.1.ckan
+++ b/LSPFlags/LSPFlags-v2.1.ckan
@@ -10,6 +10,9 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/78476-12-ual002s-lorefriendy-serious-parody-flags-v21-fall-of-the-ape-edition/",
         "repository": "https://github.com/ual002/Lorefriendly-Serious-Parody-Flags"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "v2.1",
     "ksp_version": "any",
     "install": [

--- a/LessGrindyScience/LessGrindyScience-1-1.0.0.1.ckan
+++ b/LessGrindyScience/LessGrindyScience-1-1.0.0.1.ckan
@@ -11,6 +11,10 @@
         "spacedock": "https://spacedock.info/mod/1143/Less%20Grindy%20Science",
         "repository": "https://github.com/ValynEritai/LessGrindyScience"
     },
+    "tags": [
+        "config",
+        "science"
+    ],
     "version": "1:1.0.0.1",
     "ksp_version": "any",
     "depends": [

--- a/MiniAirbrakes/MiniAirbrakes-1.1.ckan
+++ b/MiniAirbrakes/MiniAirbrakes-1.1.ckan
@@ -10,6 +10,9 @@
         "kerbalstuff": "https://kerbalstuff.com/mod/758/Mini%20Airbrakes",
         "x_screenshot": "https://kerbalstuff.com/content/FishInferno_9757/Mini_Airbrakes/Mini_Airbrakes-1431035827.0628638.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "1.1",
     "ksp_version": "any",
     "depends": [

--- a/ModernChineseFlagPack/ModernChineseFlagPack-1.4.ckan
+++ b/ModernChineseFlagPack/ModernChineseFlagPack-1.4.ckan
@@ -9,6 +9,9 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/100363-Modern-Chinese-Flag-Pack"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "1.4",
     "ksp_version": "any",
     "install": [

--- a/NetherdyneMassDriver/NetherdyneMassDriver-1-1.3.1.ckan
+++ b/NetherdyneMassDriver/NetherdyneMassDriver-1-1.3.1.ckan
@@ -16,6 +16,10 @@
         "repository": "https://github.com/sswelm/InterstellarAccelerator",
         "x_screenshot": "https://spacedock.info/content/FreeThinker_517/Netherdyne_Mass_Driver_Mod/Netherdyne_Mass_Driver_Mod-1470845836.5767908.png"
     },
+    "tags": [
+        "plugin",
+        "parts"
+    ],
     "install": [
         {
             "find": "InterstellarMassAccelerator",

--- a/PartMapper/PartMapper-0.4.2.ckan
+++ b/PartMapper/PartMapper-0.4.2.ckan
@@ -11,6 +11,10 @@
         "repository": "https://github.com/Sujimichi/KerbalX",
         "bugtracker": "https://github.com/Sujimichi/KerbalX/issues"
     },
+    "tags": [
+        "plugin",
+        "app"
+    ],
     "version": "0.4.2",
     "ksp_version": "any",
     "install": [

--- a/ProceduralParts-Textures-SCCKSCS/ProceduralParts-Textures-SCCKSCS-1.ckan
+++ b/ProceduralParts-Textures-SCCKSCS/ProceduralParts-Textures-SCCKSCS-1.ckan
@@ -9,6 +9,10 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/68892"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "version": "1",
     "ksp_version_min": "1.0",
     "provides": [

--- a/SerialIO/SerialIO-v0.19.1.ckan
+++ b/SerialIO/SerialIO-v0.19.1.ckan
@@ -11,6 +11,10 @@
         "repository": "https://github.com/zitron-git/KSPSerialIO",
         "x_screenshot": "https://spacedock.info/content/zitron_3831/KSP_Serial_IO/KSP_Serial_IO-1461368239.7648733.jpg"
     },
+    "tags": [
+        "plugin",
+        "app"
+    ],
     "version": "v0.19.1",
     "ksp_version": "1.7.3",
     "conflicts": [


### PR DESCRIPTION
Successor to KSP-CKAN/NetKAN#7599, these modules are frozen or have indexing errors so we can't tag them via their netkans. Now they're tagged in CKAN-meta.