### PR TITLE
Tag frozen modules, group 2

### DIFF
--- a/GammaTextures/GammaTextures-2.0.0.0.1.ckan
+++ b/GammaTextures/GammaTextures-2.0.0.0.1.ckan
@@ -12,6 +12,10 @@
     },
     "version": "2.0.0.0.1",
     "ksp_version": "any",
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "provides": [
         "PPTextures"
     ],

--- a/HazardTanksTextures/HazardTanksTextures-1.0.ckan
+++ b/HazardTanksTextures/HazardTanksTextures-1.0.ckan
@@ -10,6 +10,10 @@
         "spacedock": "https://spacedock.info/mod/467/Hazard%20Tanks%20Textures%20for%20Procedural%20Parts",
         "x_screenshot": "https://spacedock.info/content/Enceos_856/Hazard_Tanks_Textures_for_Procedural_Parts/Hazard_Tanks_Textures_for_Procedural_Parts-1459548045.2359412.jpg"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "version": "1.0",
     "ksp_version": "any",
     "provides": [

--- a/MainSailorTextures-Complete/MainSailorTextures-Complete-2.0.0.0.1.ckan
+++ b/MainSailorTextures-Complete/MainSailorTextures-Complete-2.0.0.0.1.ckan
@@ -10,6 +10,10 @@
         "spacedock": "https://spacedock.info/mod/487/MainSailor's%20Textures%20(for%20Procedural%20Parts)",
         "x_screenshot": "https://spacedock.info/content/MainSailor_2201/MainSailors_Textures_for_Procedural_Parts/MainSailors_Textures_for_Procedural_Parts-1460114608.284803.png"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "version": "2.0.0.0.1",
     "ksp_version": "any",
     "provides": [

--- a/MainSailorTextures-Essentials/MainSailorTextures-Essentials-2.0.0.0.1.ckan
+++ b/MainSailorTextures-Essentials/MainSailorTextures-Essentials-2.0.0.0.1.ckan
@@ -10,6 +10,10 @@
         "spacedock": "https://spacedock.info/mod/487/MainSailor's%20Textures%20(for%20Procedural%20Parts)",
         "x_screenshot": "https://spacedock.info/content/MainSailor_2201/MainSailors_Textures_for_Procedural_Parts/MainSailors_Textures_for_Procedural_Parts-1460114608.284803.png"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "version": "2.0.0.0.1",
     "ksp_version": "any",
     "provides": [

--- a/MainSailorTextures-Fairings/MainSailorTextures-Fairings-2.0.0.0.1.ckan
+++ b/MainSailorTextures-Fairings/MainSailorTextures-Fairings-2.0.0.0.1.ckan
@@ -10,8 +10,16 @@
         "spacedock": "https://spacedock.info/mod/487/MainSailor's%20Textures%20(for%20Procedural%20Parts)",
         "x_screenshot": "https://spacedock.info/content/MainSailor_2201/MainSailors_Textures_for_Procedural_Parts/MainSailors_Textures_for_Procedural_Parts-1460114608.284803.png"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "version": "2.0.0.0.1",
     "ksp_version": "any",
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "provides": [
         "PPTextures"
     ],

--- a/MainSailorTextures-Historical/MainSailorTextures-Historical-2.0.0.0.1.ckan
+++ b/MainSailorTextures-Historical/MainSailorTextures-Historical-2.0.0.0.1.ckan
@@ -12,6 +12,10 @@
     },
     "version": "2.0.0.0.1",
     "ksp_version": "any",
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "provides": [
         "PPTextures"
     ],

--- a/MainSailorTextures-Theta/MainSailorTextures-Theta-2.0.0.0.1.ckan
+++ b/MainSailorTextures-Theta/MainSailorTextures-Theta-2.0.0.0.1.ckan
@@ -10,6 +10,10 @@
         "spacedock": "https://spacedock.info/mod/487/MainSailor's%20Textures%20(for%20Procedural%20Parts)",
         "x_screenshot": "https://spacedock.info/content/MainSailor_2201/MainSailors_Textures_for_Procedural_Parts/MainSailors_Textures_for_Procedural_Parts-1460114608.284803.png"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "version": "2.0.0.0.1",
     "ksp_version": "any",
     "provides": [

--- a/OffStage/OffStage-1.5.1.ckan
+++ b/OffStage/OffStage-1.5.1.ckan
@@ -9,6 +9,10 @@
         "spacedock": "https://spacedock.info/mod/933/Off%20Stage",
         "x_screenshot": "https://spacedock.info/content/Xyphos_7084/Off_Stage/Off_Stage-1572345076.8569775.jpg"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "version": "1.5.1",
     "ksp_version": "1.7.2",
     "depends": [

--- a/PhoenixIndustriesFlags/PhoenixIndustriesFlags-2.1.ckan
+++ b/PhoenixIndustriesFlags/PhoenixIndustriesFlags-2.1.ckan
@@ -11,6 +11,10 @@
         "spacedock": "https://spacedock.info/mod/246/Phoenix%20Industries%20-%20Boosters",
         "x_screenshot": "https://spacedock.info/content/MoviesColin_1252/Phoenix_Industries_-_Boosters/Phoenix_Industries_-_Boosters-1484864748.1118786.jpg"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "version": "2.1",
     "ksp_version": "any",
     "install": [

--- a/ProceduralParts-Textures-SaturnNova/ProceduralParts-Textures-SaturnNova-1.2.ckan
+++ b/ProceduralParts-Textures-SaturnNova/ProceduralParts-Textures-SaturnNova-1.2.ckan
@@ -8,6 +8,10 @@
     "license": "CC-BY-SA-3.0",
     "version": "1.2",
     "ksp_version_min": "0.23.5",
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "provides": [
         "PPTextures"
     ],

--- a/SamBelangerFlags/SamBelangerFlags-1-v1.0.ckan
+++ b/SamBelangerFlags/SamBelangerFlags-1-v1.0.ckan
@@ -11,6 +11,9 @@
         "homepage": "https://sambelanger.wixsite.com/sambelanger",
         "repository": "https://github.com/SamBelanger/SamBelangerFlags"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "1:v1.0",
     "ksp_version": "any",
     "install": [

--- a/Sarkomand/Sarkomand-v1.0.ckan
+++ b/Sarkomand/Sarkomand-v1.0.ckan
@@ -10,6 +10,9 @@
     "resources": {
         "repository": "https://github.com/politas/Sarkomand"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "v1.0",
     "ksp_version": "any",
     "download": "https://github.com/politas/Sarkomand/releases/download/v1.0/Sarkomand-1.0.zip",

--- a/StarTrekRebootUniformPack/StarTrekRebootUniformPack-1.00.ckan
+++ b/StarTrekRebootUniformPack/StarTrekRebootUniformPack-1.00.ckan
@@ -10,6 +10,11 @@
         "spacedock": "https://spacedock.info/mod/488/Star%20Trek%20Uniform%20pack%20for%20TextureReplacer",
         "x_screenshot": "https://spacedock.info/content/Arryl_3222/Star_Trek_Uniform_pack_for_TextureReplacer/Star_Trek_Uniform_pack_for_TextureReplacer-1460233273.4930942.png"
     },
+    "tags": [
+        "config",
+        "graphics",
+        "crewed"
+    ],
     "version": "1.00",
     "ksp_version": "any",
     "depends": [

--- a/StructuralDisks/StructuralDisks-1.2.0.1.ckan
+++ b/StructuralDisks/StructuralDisks-1.2.0.1.ckan
@@ -11,6 +11,9 @@
         "repository": "https://github.com/Benji-13/StructuralDisks/tree/master",
         "x_screenshot": "https://spacedock.info/content/Benji13_8656/Structural_Disks/Structural_Disks-1477515677.598861.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "1.2.0.1",
     "depends": [
         {

--- a/TALSphericalToroidalPack/TALSphericalToroidalPack-3.12.ckan
+++ b/TALSphericalToroidalPack/TALSphericalToroidalPack-3.12.ckan
@@ -11,6 +11,9 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/30673"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "3.12",
     "ksp_version": "any",
     "depends": [

--- a/Taerobee/Taerobee-1-3.0.ckan
+++ b/Taerobee/Taerobee-1-3.0.ckan
@@ -9,6 +9,9 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/119858-*",
         "repository": "https://github.com/Tantares/Taerobee"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "1:3.0",
     "ksp_version": "any",
     "install": [

--- a/UpgradesUIextensions/UpgradesUIextensions-1-1.5.0.2.ckan
+++ b/UpgradesUIextensions/UpgradesUIextensions-1-1.5.0.2.ckan
@@ -14,6 +14,11 @@
         "repository": "https://github.com/zer0Kerbal/UpgradesGUIExtended",
         "x_screenshot": "https://spacedock.info/content/zer0Kerbal_21147/Upgrades_GUI_-_Extended/Upgrades_GUI_-_Extended-1565648658.949599.png"
     },
+    "tags": [
+        "plugin",
+        "information",
+        "editor"
+    ],
     "version": "1:1.5.0.2",
     "ksp_version_min": "1.2.2",
     "ksp_version_max": "1.7.9",

--- a/VensStylePPTextures/VensStylePPTextures-1.1.ckan
+++ b/VensStylePPTextures/VensStylePPTextures-1.1.ckan
@@ -11,6 +11,10 @@
         "spacedock": "https://spacedock.info/mod/439/Ven's%20Style%20Procedural%20Part%20Textures",
         "x_screenshot": "https://spacedock.info/content/Enceos_856/Vens_Style_Procedural_Part_Textures/Vens_Style_Procedural_Part_Textures-1458917514.829847.jpg"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "version": "1.1",
     "ksp_version": "any",
     "suggests": [

--- a/World-Airforce-Insignia/World-Airforce-Insignia-v1.1.ckan
+++ b/World-Airforce-Insignia/World-Airforce-Insignia-v1.1.ckan
@@ -9,6 +9,9 @@
     "resources": {
         "repository": "https://github.com/chaseAEd/World-Airforce-Insignia"
     },
+    "tags": [
+        "flags"
+    ],
     "version": "v1.1",
     "ksp_version": "any",
     "download": "https://github.com/chaseAEd/World-Airforce-Insignia/releases/download/v1.1/World-Airforce-Insignia.zip",


### PR DESCRIPTION
Successor to #1749. This should finish tagging frozen modules compatible with 1.7 and 1.8.