### PR TITLE
Set missing compatibility for old KOC version

### DIFF
--- a/KerbalOccupationColors/KerbalOccupationColors-v1.2.0.ckan
+++ b/KerbalOccupationColors/KerbalOccupationColors-v1.2.0.ckan
@@ -4,6 +4,7 @@
     "name": "Kerbal Occupation Colors",
     "abstract": "Automatically assigns the Future Suit's light colors based on occupation",
     "author": "Starwaster",
+    "ksp_version_min": "1.7.3",
     "license": "Unlicense",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/185931-17-kerbal-occupation-colors-version-10/",


### PR DESCRIPTION
See KSP-CKAN/NetKAN#7630, the override for this netkan was deleting its own overridden ksp_version_min property. Now it's added back in.