### PR TITLE
Fill in old Spaceplane Corrections versions; Rename SPPCC

### DIFF
--- a/SpaceplaneCorrections/SpaceplaneCorrections-v0.12.ckan
+++ b/SpaceplaneCorrections/SpaceplaneCorrections-v0.12.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
-    "identifier": "SPPCC",
-    "name": "Space Plane Color Corrections",
+    "identifier": "SpaceplaneCorrections",
+    "name": "Spaceplane Corrections",
     "abstract": "Personally I've been pretty annoyed that the spaceplane pieces (and a number of other parts) don't all have matching colors or textures. They have a base white coat which is used for all splaceplane parts, but there are about five different shades that are used for wing trims. SO..... rather then complaining about it, I'm going to try and solve it.",
     "author": "Avera9eJoe",
     "license": "MIT",
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://www.dropbox.com/s/822jueuhkmimwqn/SPPCC%20v0.12.zip?dl=1",
+    "download": "https://archive.org/download/SPPCC-v0.12/F0DCCAD9-SPPCC-v0.12.zip",
     "download_size": 12820482,
     "download_hash": {
         "sha1": "F0DCCAD9A7E5B1C77CD60392E2A7F5517C73CB3D",

--- a/SpaceplaneCorrections/SpaceplaneCorrections-v0.14.1.ckan
+++ b/SpaceplaneCorrections/SpaceplaneCorrections-v0.14.1.ckan
@@ -1,0 +1,40 @@
+{
+    "spec_version": 1,
+    "identifier": "SpaceplaneCorrections",
+    "name": "Spaceplane Corrections",
+    "abstract": "SPC replaces the stock plane parts with revamped textures, and integrates with FStextureSwitch to let the player customize which textures and colors to use.",
+    "author": "Avera9eJoe",
+    "version": "v0.14.1",
+    "ksp_version": "1.3.0",
+    "license": "MIT",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106489-12-spc-v014-spaceplane-corrections-fstextureswitch-integration-19-october-16/",
+        "spacedock": "https://spacedock.info/mod/1194/SpacePlane%20Corrections",
+        "x_screenshot": "https://spacedock.info/content/Avera9eJoe_1835/SpacePlane_Corrections/SpacePlane_Corrections-1486134673.581347.png"
+    },
+    "tags": [
+        "config"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "FirespitterCore"
+        }
+    ],
+    "install": [
+        {
+            "file": "SPC",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://spacedock.info/mod/1194/SpacePlane%20Corrections/download/v0.14.1",
+    "download_size": 6601678,
+    "download_hash": {
+        "sha1": "29D98F2554EB9DE336921602BE6A4BE27BAF5565",
+        "sha256": "EA5EC524285C565CBA792B8AF1DD783A0A5138C3C9E9F344E0332DD2749A1A81"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/SpaceplaneCorrections/SpaceplaneCorrections-v0.14.ckan
+++ b/SpaceplaneCorrections/SpaceplaneCorrections-v0.14.ckan
@@ -1,0 +1,40 @@
+{
+    "spec_version": 1,
+    "identifier": "SpaceplaneCorrections",
+    "name": "Spaceplane Corrections",
+    "abstract": "SPC replaces the stock plane parts with revamped textures, and integrates with FStextureSwitch to let the player customize which textures and colors to use.",
+    "author": "Avera9eJoe",
+    "version": "v0.14",
+    "ksp_version": "1.2.2",
+    "license": "MIT",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106489-12-spc-v014-spaceplane-corrections-fstextureswitch-integration-19-october-16/",
+        "spacedock": "https://spacedock.info/mod/1194/SpacePlane%20Corrections",
+        "x_screenshot": "https://spacedock.info/content/Avera9eJoe_1835/SpacePlane_Corrections/SpacePlane_Corrections-1486134673.581347.png"
+    },
+    "tags": [
+        "config"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "FirespitterCore"
+        }
+    ],
+    "install": [
+        {
+            "file": "SPC",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://spacedock.info/mod/1194/SpacePlane%20Corrections/download/v0.14",
+    "download_size": 6601678,
+    "download_hash": {
+        "sha1": "29D98F2554EB9DE336921602BE6A4BE27BAF5565",
+        "sha256": "EA5EC524285C565CBA792B8AF1DD783A0A5138C3C9E9F344E0332DD2749A1A81"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/SpaceplaneCorrections/SpaceplaneCorrections-v0.15.ckan
+++ b/SpaceplaneCorrections/SpaceplaneCorrections-v0.15.ckan
@@ -1,0 +1,40 @@
+{
+    "spec_version": 1,
+    "identifier": "SpaceplaneCorrections",
+    "name": "Spaceplane Corrections",
+    "abstract": "SPC replaces the stock plane parts with revamped textures, and integrates with FStextureSwitch to let the player customize which textures and colors to use.",
+    "author": "Avera9eJoe",
+    "version": "v0.15",
+    "ksp_version": "1.3.0",
+    "license": "MIT",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106489-12-spc-v014-spaceplane-corrections-fstextureswitch-integration-19-october-16/",
+        "spacedock": "https://spacedock.info/mod/1194/SpacePlane%20Corrections",
+        "x_screenshot": "https://spacedock.info/content/Avera9eJoe_1835/SpacePlane_Corrections/SpacePlane_Corrections-1486134673.581347.png"
+    },
+    "tags": [
+        "config"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "FirespitterCore"
+        }
+    ],
+    "install": [
+        {
+            "file": "SPC",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://spacedock.info/mod/1194/SpacePlane%20Corrections/download/v0.15",
+    "download_size": 6834716,
+    "download_hash": {
+        "sha1": "4ECEF0E198DEF98497BE91B624FCD87CCBC349E1",
+        "sha256": "885F4617BE477FB9E0B3E9FB3CEB30D0B8A1902A3F601003FA42BCD7C76D270B"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/SpaceplaneCorrections/SpaceplaneCorrections-v0.17.ckan
+++ b/SpaceplaneCorrections/SpaceplaneCorrections-v0.17.ckan
@@ -1,0 +1,40 @@
+{
+    "spec_version": 1,
+    "identifier": "SpaceplaneCorrections",
+    "name": "Spaceplane Corrections",
+    "abstract": "SPC replaces the stock plane parts with revamped textures, and integrates with FStextureSwitch to let the player customize which textures and colors to use.",
+    "author": "Avera9eJoe",
+    "version": "v0.17",
+    "ksp_version": "1.3.0",
+    "license": "MIT",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106489-12-spc-v014-spaceplane-corrections-fstextureswitch-integration-19-october-16/",
+        "spacedock": "https://spacedock.info/mod/1194/SpacePlane%20Corrections",
+        "x_screenshot": "https://spacedock.info/content/Avera9eJoe_1835/SpacePlane_Corrections/SpacePlane_Corrections-1486134673.581347.png"
+    },
+    "tags": [
+        "config"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "FirespitterCore"
+        }
+    ],
+    "install": [
+        {
+            "file": "SPC",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://spacedock.info/mod/1194/SpacePlane%20Corrections/download/v0.17",
+    "download_size": 6834722,
+    "download_hash": {
+        "sha1": "9C535E714796275D0F8373D892EA9671E4460570",
+        "sha256": "3BD202698CCE2F7D621AD5100B317C210FA8A73596B4CD758B4A3A87F874AA43"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}

--- a/SpaceplaneCorrections/SpaceplaneCorrections-v0.18.ckan
+++ b/SpaceplaneCorrections/SpaceplaneCorrections-v0.18.ckan
@@ -1,0 +1,40 @@
+{
+    "spec_version": 1,
+    "identifier": "SpaceplaneCorrections",
+    "name": "Spaceplane Corrections",
+    "abstract": "SPC replaces the stock plane parts with revamped textures, and integrates with FStextureSwitch to let the player customize which textures and colors to use.",
+    "author": "Avera9eJoe",
+    "version": "v0.18",
+    "ksp_version": "1.3.0",
+    "license": "MIT",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106489-12-spc-v014-spaceplane-corrections-fstextureswitch-integration-19-october-16/",
+        "spacedock": "https://spacedock.info/mod/1194/SpacePlane%20Corrections",
+        "x_screenshot": "https://spacedock.info/content/Avera9eJoe_1835/SpacePlane_Corrections/SpacePlane_Corrections-1486134673.581347.png"
+    },
+    "tags": [
+        "config"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "FirespitterCore"
+        }
+    ],
+    "install": [
+        {
+            "file": "GameData/SPC",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://spacedock.info/mod/1194/SpacePlane%20Corrections/download/v0.18",
+    "download_size": 6933650,
+    "download_hash": {
+        "sha1": "0ECF4F03D0D1C5EE9C832AD55F027F31E3FB8699",
+        "sha256": "67DB096C874D1206CE80DEDCE18AB0C29EF5CE9D566B3011BFCE9DC041BEC4A6"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
In https://github.com/KSP-CKAN/NetKAN/issues/7672 it was requested to remove the one indexed version of SPPCC, which was a development release for SpaceplaneCorrections.

Instead of removing it, I switched the identifier to SpaceplaneCorrections and replace the broken dropbox download link with the archive.org archive.
This way the old version does not vanish, but it's now part of the SpaceplaneCorections versions.

I also gernerated netkans for the unindexed versions of SpaceplaneCorrections.
This was possible for all but one version, the v0.16, because the zip has no common root folder.

(To be able to do this I had to patch netkan.exe to have an option to skip releases. I wanted this feature for a long long time, and finally implemented it. A PR to CKAN is coming up.)

Closes KSP-CKAN/NetKAN/issues/7672