### PR TITLE
Set max compat for historical ClickThroughBlocker

### DIFF
--- a/ClickThroughBlocker/ClickThroughBlocker-0.1.6.10.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-0.1.6.10.ckan
@@ -11,6 +11,7 @@
     },
     "version": "0.1.6.10",
     "ksp_version_min": "1.5.1",
+    "ksp_version_max": "1.5.99",
     "install": [
         {
             "install_to": "GameData",


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/74453755-7671c200-4e48-11ea-9bb3-ecd51f20338c.png)

Not good to have old versions installing randomly like that.

## Changes

Now it shares the same max compat as the preceding release.