### PR TITLE
Fix max compat for historical SpacetuxSA

### DIFF
--- a/SpacetuxSA/SpacetuxSA-0.3.12.4.ckan
+++ b/SpacetuxSA/SpacetuxSA-0.3.12.4.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.3.12.4",
     "ksp_version_min": "1.1.3",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.4.99",
     "install": [
         {
             "find": "SpaceTuxSA",


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/74454132-0adc2480-4e49-11ea-8133-806fe3cdbf1b.png)

Not good to have old versions installing randomly like that.

## Changes

Now it shares the same max compat as the preceding release.