### PR TITLE
Set compat max for historical PreciseNodes

### DIFF
--- a/PreciseNode/PreciseNode-1.2.10.2.ckan
+++ b/PreciseNode/PreciseNode-1.2.10.2.ckan
@@ -15,6 +15,7 @@
     },
     "version": "1.2.10.2",
     "ksp_version_min": "1.5.1",
+    "ksp_version_max": "1.7",
     "depends": [
         {
             "name": "ClickThroughBlocker"

--- a/PreciseNode/PreciseNode-1.2.10.ckan
+++ b/PreciseNode/PreciseNode-1.2.10.ckan
@@ -15,6 +15,7 @@
     },
     "version": "1.2.10",
     "ksp_version_min": "1.5.1",
+    "ksp_version_max": "1.7",
     "depends": [
         {
             "name": "ClickThroughBlocker"

--- a/PreciseNode/PreciseNode-1.2.9.4.ckan
+++ b/PreciseNode/PreciseNode-1.2.9.4.ckan
@@ -15,6 +15,7 @@
     },
     "version": "1.2.9.4",
     "ksp_version_min": "1.5.1",
+    "ksp_version_max": "1.7",
     "depends": [
         {
             "name": "ClickThroughBlocker"


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/74454453-88079980-4e49-11ea-8784-4abd3f386709.png)

Not good to have old versions installing like that.

## Changes

Now they go up to KSP 1.7, since they probably broke with the Unity upgrade in KSP 1.8 (see the compatibility range of 1.2.10.3).