### PR TITLE
Set max compat for historical MagiCore

### DIFF
--- a/MagiCore/MagiCore-1.3.1.4.ckan
+++ b/MagiCore/MagiCore-1.3.1.4.ckan
@@ -11,6 +11,7 @@
     },
     "version": "1.3.1.4",
     "ksp_version_min": "1.2.0",
+    "ksp_version_max": "1.5.9",
     "install": [
         {
             "find": "MagiCore",


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/74454723-ee8cb780-4e49-11ea-980e-075fc6de0625.png)

Not good to have old versions installing like that.

## Changes

Now it shares a max compat with the preceding version.