### PR TITLE
Set compat max for historical DiazosLandingHeight

### DIFF
--- a/DiazosLandingHeight/DiazosLandingHeight-2.2.0.4.ckan
+++ b/DiazosLandingHeight/DiazosLandingHeight-2.2.0.4.ckan
@@ -12,6 +12,7 @@
     },
     "version": "2.2.0.4",
     "ksp_version_min": "1.5.1",
+    "ksp_version_max": "1.6.1",
     "conflicts": [
         {
             "name": "LandingHeight"


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/74454991-50e5b800-4e4a-11ea-80d0-271bc4eedc86.png)

Not good to have old versions installing like that.

## Changes

Now it shares a max compat with the subsequent version.