### PR TITLE
Set compatibility for historical AntaresCygnus

### DIFF
--- a/AntaresCygnus/AntaresCygnus-1-v1.3.ckan
+++ b/AntaresCygnus/AntaresCygnus-1-v1.3.ckan
@@ -14,6 +14,8 @@
         "repository": "https://github.com/KSP-RO/Antares-Cygnus"
     },
     "version": "1:v1.3",
+    "ksp_version_min": "1.1.1",
+    "ksp_version_max": "1.4.99",
     "install": [
         {
             "find": "KK_Antares",


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/74455279-b3d74f00-4e4a-11ea-9220-aefb790e3f4c.png)

Not good to have old versions installing like that.

## Changes

Now it shares min and max compat with the subsequent version.