### PR TITLE
Set compatibility for historical B9-PWings-Fork

### DIFF
--- a/B9-PWings-Fork/B9-PWings-Fork-1-0.90.ckan
+++ b/B9-PWings-Fork/B9-PWings-Fork-1-0.90.ckan
@@ -15,6 +15,7 @@
         "repository": "https://github.com/Rafterman82/B9-PWings-Fork"
     },
     "version": "1:0.90",
+    "ksp_version": "1.7",
     "conflicts": [
         {
             "name": "B9AerospaceProceduralParts"

--- a/B9-PWings-Fork/B9-PWings-Fork-1-0.91.ckan
+++ b/B9-PWings-Fork/B9-PWings-Fork-1-0.91.ckan
@@ -15,6 +15,7 @@
         "repository": "https://github.com/Rafterman82/B9-PWings-Fork"
     },
     "version": "1:0.91",
+    "ksp_version": "1.7",
     "conflicts": [
         {
             "name": "B9AerospaceProceduralParts"


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/74455762-758e5f80-4e4b-11ea-8736-5a79247643eb.png)

Not good to have old versions installing like that.

## Changes

Now they're set to KSP 1.7, since the change log says they were recompiled for it (and we know KSP 1.8 required recompiles as well).