### PR TITLE
Set historical compat for PlanetaryDiversity

### DIFF
--- a/PlanetaryDiversity/PlanetaryDiversity-1-1.7.3.2.ckan
+++ b/PlanetaryDiversity/PlanetaryDiversity-1-1.7.3.2.ckan
@@ -14,6 +14,7 @@
         "repository": "https://github.com/linuxgurugamer/Planetary-Diversity"
     },
     "version": "1:1.7.3.2",
+    "ksp_version": "1.7",
     "localizations": [
         "en-us"
     ],

--- a/PlanetaryDiversity/PlanetaryDiversity-1-1.7.3.3.ckan
+++ b/PlanetaryDiversity/PlanetaryDiversity-1-1.7.3.3.ckan
@@ -14,6 +14,7 @@
         "repository": "https://github.com/linuxgurugamer/Planetary-Diversity"
     },
     "version": "1:1.7.3.3",
+    "ksp_version": "1.7",
     "localizations": [
         "en-us"
     ],

--- a/PlanetaryDiversity/PlanetaryDiversity-1.3.0-2.ckan
+++ b/PlanetaryDiversity/PlanetaryDiversity-1.3.0-2.ckan
@@ -11,6 +11,7 @@
         "repository": "https://github.com/StollD/Planetary-Diversity"
     },
     "version": "1.3.0-2",
+    "ksp_version": "1.3",
     "install": [
         {
             "find": "PlanetaryDiversity",

--- a/PlanetaryDiversity/PlanetaryDiversity-1.3.0-3.ckan
+++ b/PlanetaryDiversity/PlanetaryDiversity-1.3.0-3.ckan
@@ -11,6 +11,7 @@
         "repository": "https://github.com/StollD/Planetary-Diversity"
     },
     "version": "1.3.0-3",
+    "ksp_version": "1.3",
     "install": [
         {
             "find": "PlanetaryDiversity",

--- a/PlanetaryDiversity/PlanetaryDiversity-1.3.0-4.ckan
+++ b/PlanetaryDiversity/PlanetaryDiversity-1.3.0-4.ckan
@@ -11,6 +11,7 @@
         "repository": "https://github.com/StollD/Planetary-Diversity"
     },
     "version": "1.3.0-4",
+    "ksp_version": "1.3",
     "install": [
         {
             "find": "PlanetaryDiversity",

--- a/PlanetaryDiversity/PlanetaryDiversity-1.7.3.1.ckan
+++ b/PlanetaryDiversity/PlanetaryDiversity-1.7.3.1.ckan
@@ -14,6 +14,7 @@
         "repository": "https://github.com/linuxgurugamer/Planetary-Diversity"
     },
     "version": "1.7.3.1",
+    "ksp_version": "1.7",
     "localizations": [
         "en-us"
     ],

--- a/PlanetaryDiversity/PlanetaryDiversity-1.7.3.2.ckan
+++ b/PlanetaryDiversity/PlanetaryDiversity-1.7.3.2.ckan
@@ -14,6 +14,7 @@
         "repository": "https://github.com/linuxgurugamer/Planetary-Diversity"
     },
     "version": "1.7.3.2",
+    "ksp_version": "1.7",
     "localizations": [
         "en-us"
     ],

--- a/PlanetaryDiversity/PlanetaryDiversity-release-1.4.2-1.ckan
+++ b/PlanetaryDiversity/PlanetaryDiversity-release-1.4.2-1.ckan
@@ -11,6 +11,7 @@
         "repository": "https://github.com/StollD/Planetary-Diversity"
     },
     "version": "release-1.4.2-1",
+    "ksp_version": "1.4",
     "localizations": [
         "en-us"
     ],


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/74457059-60b2cb80-4e4d-11ea-8236-e28df0df13c1.png)

This mod followed a Kopernicus-style versioning system where the first three pieces are the game version, but somehow we missed it until recently. The release notes even say specifically that they are compatible with specific game versions.

## Changes

Now each version is compatible with the game versions designated by its version number.