### PR TITLE
Clean up historical resource properties

### DIFF
--- a/AlternateResourcePanel/AlternateResourcePanel-2.6.2.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.6.2.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
         "kerbalstuff": "https://kerbalstuff.com/mod/195/Alternate%20Resource%20Panel",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
     },
     "version": "2.6.2.0",
     "ksp_version": "0.90",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.6.2.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.6.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.6.3.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.6.3.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
         "kerbalstuff": "https://kerbalstuff.com/mod/195/Alternate%20Resource%20Panel",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
     },
     "version": "2.6.3.0",
     "ksp_version": "0.90",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.6.3.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.6.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.0.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.0.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.0.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
         "kerbalstuff": "https://kerbalstuff.com/mod/195/Alternate%20Resource%20Panel",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
     },
     "version": "2.7.0.0",
     "ksp_version": "1.0",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.1.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.1.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
         "kerbalstuff": "https://kerbalstuff.com/mod/195/Alternate%20Resource%20Panel",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
     },
     "version": "2.7.1.0",
     "ksp_version_min": "1.0.0",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.1.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.2.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.2.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.2.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
         "kerbalstuff": "https://kerbalstuff.com/mod/195/Alternate%20Resource%20Panel",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel",
         "x_screenshot": "https://kerbalstuff.com/content/TriggerAu_1745/Alternate_Resource_Panel/Alternate_Resource_Panel.png"
     },
     "version": "2.7.2.0",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.2.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.2.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.2.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
         "kerbalstuff": "https://kerbalstuff.com/mod/195/Alternate%20Resource%20Panel",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel",
         "x_screenshot": "https://kerbalstuff.com/content/TriggerAu_1745/Alternate_Resource_Panel/Alternate_Resource_Panel.png"
     },
     "version": "2.7.2",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.3.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.3.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.3.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
         "kerbalstuff": "https://kerbalstuff.com/mod/195/Alternate%20Resource%20Panel",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel",
         "x_screenshot": "https://kerbalstuff.com/content/TriggerAu_1745/Alternate_Resource_Panel/Alternate_Resource_Panel.png"
     },
     "version": "2.7.3.0",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.4.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.4.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
         "kerbalstuff": "https://kerbalstuff.com/mod/195/Alternate%20Resource%20Panel",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel",
         "x_screenshot": "https://kerbalstuff.com/content/TriggerAu_1745/Alternate_Resource_Panel/Alternate_Resource_Panel.png"
     },
     "version": "2.7.4.0",

--- a/AlternateResourcePanel/AlternateResourcePanel-2.7.4.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-2.7.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.7.4.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.7.4.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/AlternateResourcePanel",
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
     },
     "version": "v2.7.4.0",
     "ksp_version_min": "1.0.0",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.7.4.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.7.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.8.0.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.8.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/AlternateResourcePanel",
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
     },
     "version": "v2.8.0.0",
     "ksp_version_min": "1.1.0",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.8.0.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.8.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.8.1.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.8.1.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/AlternateResourcePanel",
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
     },
     "version": "v2.8.1.0",
     "ksp_version_min": "1.1.0",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.8.1.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.8.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.9.0.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.9.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/AlternateResourcePanel",
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
     },
     "version": "v2.9.0.0",
     "ksp_version_min": "1.2.0",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.9.0.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.9.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.9.1.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.9.1.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/AlternateResourcePanel",
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
     },
     "version": "v2.9.1.0",
     "ksp_version_min": "1.2.0",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.9.1.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.9.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.9.2.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.9.2.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/AlternateResourcePanel",
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
     },
     "version": "v2.9.2.0",
     "ksp_version_min": "1.3.0",

--- a/AlternateResourcePanel/AlternateResourcePanel-v2.9.2.0.ckan
+++ b/AlternateResourcePanel/AlternateResourcePanel-v2.9.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "AlternateResourcePanel",
     "name": "Alternate Resource Panel",
     "abstract": "An alternate view of vessel resources plugin for Kerbal Space Program",

--- a/BoxSat-prototypes/BoxSat-prototypes-A.02c.kerbalstuff
+++ b/BoxSat-prototypes/BoxSat-prototypes-A.02c.kerbalstuff
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "BoxSat-prototypes",
     "name": "BoxSat prototype parts",
     "release_status": "development",

--- a/BoxSat-prototypes/BoxSat-prototypes-A.02c.kerbalstuff
+++ b/BoxSat-prototypes/BoxSat-prototypes-A.02c.kerbalstuff
@@ -6,7 +6,7 @@
     "license": "restricted",
     "x_netkan_license_ok": true,
     "resources": {
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
         "kerbalstuff": "https://kerbalstuff.com/mod/118/BoxSat"
     },
     "install": [

--- a/BoxSat-prototypes/BoxSat-prototypes-A.02d.kerbalstuff
+++ b/BoxSat-prototypes/BoxSat-prototypes-A.02d.kerbalstuff
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "BoxSat-prototypes",
     "name": "BoxSat prototype parts",
     "release_status": "development",

--- a/BoxSat-prototypes/BoxSat-prototypes-A.02d.kerbalstuff
+++ b/BoxSat-prototypes/BoxSat-prototypes-A.02d.kerbalstuff
@@ -6,7 +6,7 @@
     "license": "restricted",
     "x_netkan_license_ok": true,
     "resources": {
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
         "kerbalstuff": "https://kerbalstuff.com/mod/118/BoxSat"
     },
     "install": [

--- a/BoxSat-prototypes/BoxSat-prototypes-A.02e.ckan
+++ b/BoxSat-prototypes/BoxSat-prototypes-A.02e.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "BoxSat-prototypes",
     "name": "BoxSat prototype parts",
     "abstract": "A modular, stackable, serviceable, & customizable satellite in a box!",

--- a/BoxSat-prototypes/BoxSat-prototypes-A.02e.ckan
+++ b/BoxSat-prototypes/BoxSat-prototypes-A.02e.ckan
@@ -11,7 +11,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91616",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat"
     },
     "version": "A.02e",
     "ksp_version": "1.0.2",

--- a/BoxSat/BoxSat-A.02c.kerbalstuff
+++ b/BoxSat/BoxSat-A.02c.kerbalstuff
@@ -4,7 +4,7 @@
     "license": "restricted",
     "x_netkan_license_ok": true,
     "resources": {
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
         "kerbalstuff": "https://kerbalstuff.com/mod/118/BoxSat"
     },
     "install": [

--- a/BoxSat/BoxSat-A.02c.kerbalstuff
+++ b/BoxSat/BoxSat-A.02c.kerbalstuff
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "BoxSat",
     "license": "restricted",
     "x_netkan_license_ok": true,

--- a/BoxSat/BoxSat-A.02d.kerbalstuff
+++ b/BoxSat/BoxSat-A.02d.kerbalstuff
@@ -4,7 +4,7 @@
     "license": "restricted",
     "x_netkan_license_ok": true,
     "resources": {
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
         "kerbalstuff": "https://kerbalstuff.com/mod/118/BoxSat"
     },
     "install": [

--- a/BoxSat/BoxSat-A.02d.kerbalstuff
+++ b/BoxSat/BoxSat-A.02d.kerbalstuff
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "BoxSat",
     "license": "restricted",
     "x_netkan_license_ok": true,

--- a/BoxSat/BoxSat-A.02e.ckan
+++ b/BoxSat/BoxSat-A.02e.ckan
@@ -10,7 +10,7 @@
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91616",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat"
     },
     "version": "A.02e",
     "ksp_version": "1.0.2",

--- a/BoxSat/BoxSat-A.02e.ckan
+++ b/BoxSat/BoxSat-A.02e.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "BoxSat",
     "name": "BoxSat",
     "abstract": "A modular, stackable, serviceable, & customizable satellite in a box!",

--- a/Corvus125mTwoKerbalPod/Corvus125mTwoKerbalPod-1.1.1.kerbalstuff
+++ b/Corvus125mTwoKerbalPod/Corvus125mTwoKerbalPod-1.1.1.kerbalstuff
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/121062",
         "kerbalstuff": "https://kerbalstuff.com/mod/837/Corvus%20-1.25m%20Two%20Kerbal%20Pod",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/230467-corvus-a-small-two-kerbal-pod",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/230467-corvus-a-small-two-kerbal-pod",
         "x_screenshot": "https://kerbalstuff.com/content/OrionKermin_9505/Corvus_-1.25m_Two_Kerbal_Pod/Corvus_-1.25m_Two_Kerbal_Pod-1432437982.497984.png"
     },
     "version": "1.1.1",

--- a/Corvus125mTwoKerbalPod/Corvus125mTwoKerbalPod-1.1.1.kerbalstuff
+++ b/Corvus125mTwoKerbalPod/Corvus125mTwoKerbalPod-1.1.1.kerbalstuff
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "Corvus125mTwoKerbalPod",
     "name": "Corvus -1.25m Two Kerbal Pod",
     "abstract": "A set of early tech tree parts to make a \"Kerbalized\" Gemini inspired spacecraft.",

--- a/CrewManifest/CrewManifest-0.5.10-25.ckan
+++ b/CrewManifest/CrewManifest-0.5.10-25.ckan
@@ -21,7 +21,7 @@
     },
     "ksp_version": "0.90",
     "version": "0.5.10-25",
-    "download": "https://ksp.sarbian.com/jenkins/job/CrewManifest/lastStableBuild/artifact/CrewManifest-0.6.0.0.zip",
+    "download": "https://ksp.sarbian.com/jenkins/job/CrewManifest/25/artifact/CrewManifest-0.6.0.0.zip",
     "x_generated_by": "netkan",
     "download_size": 24595
 }

--- a/CrewManifest/CrewManifest-0.5.10-25.ckan
+++ b/CrewManifest/CrewManifest-0.5.10-25.ckan
@@ -8,7 +8,6 @@
         "sarbian"
     ],
     "license": "MIT",
-    "x_ci_version_base": "0.5.10",
     "install": [
         {
             "find": "CrewManifest",
@@ -16,7 +15,7 @@
         }
     ],
     "resources": {
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/",
+        "ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60936",
         "repository": "https://github.com/sarbian/CrewManifest/"
     },

--- a/CrewManifest/CrewManifest-0.5.10-26.ckan
+++ b/CrewManifest/CrewManifest-0.5.10-26.ckan
@@ -8,7 +8,6 @@
         "sarbian"
     ],
     "license": "MIT",
-    "x_ci_version_base": "0.5.10",
     "install": [
         {
             "find": "CrewManifest",
@@ -16,7 +15,7 @@
         }
     ],
     "resources": {
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/",
+        "ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60936",
         "repository": "https://github.com/sarbian/CrewManifest/"
     },

--- a/CrewManifest/CrewManifest-0.5.10-26.ckan
+++ b/CrewManifest/CrewManifest-0.5.10-26.ckan
@@ -21,7 +21,7 @@
     },
     "ksp_version": "0.90",
     "version": "0.5.10-26",
-    "download": "https://ksp.sarbian.com/jenkins/job/CrewManifest/lastStableBuild/artifact/CrewManifest-0.6.1.0.zip",
+    "download": "https://ksp.sarbian.com/jenkins/job/CrewManifest/26/artifact/CrewManifest-0.6.1.0.zip",
     "x_generated_by": "netkan",
     "download_size": 24630
 }

--- a/CrewManifest/CrewManifest-0.5.10.ckan
+++ b/CrewManifest/CrewManifest-0.5.10.ckan
@@ -11,9 +11,8 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60936",
         "repository": "https://github.com/sarbian/CrewManifest/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/"
     },
-    "version": "0.5.10",
     "ksp_version": "0.90",
     "install": [
         {

--- a/CrewManifest/CrewManifest-0.6.0.ckan
+++ b/CrewManifest/CrewManifest-0.6.0.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60936",
         "repository": "https://github.com/sarbian/CrewManifest/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/"
     },
     "version": "0.6.0",
     "ksp_version": "1.0",

--- a/CustomBarnKit/CustomBarnKit-1.1.1.ckan
+++ b/CustomBarnKit/CustomBarnKit-1.1.1.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/121100",
         "repository": "https://github.com/sarbian/CustomBarnKit",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CustomBarnKit/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/CustomBarnKit/"
     },
     "version": "1.1.1",
     "ksp_version": "1.0.2",

--- a/CustomBarnKit/CustomBarnKit-1.1.2.ckan
+++ b/CustomBarnKit/CustomBarnKit-1.1.2.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/121100",
         "repository": "https://github.com/sarbian/CustomBarnKit",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CustomBarnKit/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/CustomBarnKit/"
     },
     "version": "1.1.2",
     "ksp_version": "1.0.5",

--- a/DiscordRP/DiscordRP-1.0.3.ckan
+++ b/DiscordRP/DiscordRP-1.0.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "DiscordRP",
     "name": "DiscordRP",
     "abstract": "DiscordRP introduces Rich Presence integration for KSP",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.0.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.1.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.2.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.3.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.1.1.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.1.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.10.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.10.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.11.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.11.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.2.0.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.2.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.2.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.3.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.4.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.5.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.6.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.7.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.8.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.9.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/ExperimentTracker/ExperimentTracker-v1.2.ckan
+++ b/ExperimentTracker/ExperimentTracker-v1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ExperimentTracker",
     "name": "ExperimentTracker",
     "abstract": "This mod lists all science experiments and helps to deploy them fast and easy.",

--- a/ExperimentTracker/ExperimentTracker-v1.3.ckan
+++ b/ExperimentTracker/ExperimentTracker-v1.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ExperimentTracker",
     "name": "ExperimentTracker",
     "abstract": "This mod lists all science experiments and helps to deploy them fast and easy.",

--- a/FMRS/FMRS-1.0.0.kerbalstuff
+++ b/FMRS/FMRS-1.0.0.kerbalstuff
@@ -3,10 +3,9 @@
     "identifier": "FMRS",
     "resources": {
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
         "kerbalstuff": "https://kerbalstuff.com/mod/172/Flight%20Manager%20for%20Reusable%20Stages%20[FMRS]",
-        "x_screenshot": "https://kerbalstuff.com/content/SIT89_726/Flight_Manager_for_Reusable_Stages_FMRS/Flight_Manager_for_Reusable_Stages_FMRS.png"
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1"
     },
     "depends": [
         {

--- a/FMRS/FMRS-1.0.00.kerbalstuff
+++ b/FMRS/FMRS-1.0.00.kerbalstuff
@@ -9,8 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
         "kerbalstuff": "https://kerbalstuff.com/mod/172/Flight%20Manager%20for%20Reusable%20Stages%20[FMRS]",
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
-        "x_screenshot": "https://kerbalstuff.com/content/SIT89_726/Flight_Manager_for_Reusable_Stages_FMRS/Flight_Manager_for_Reusable_Stages_FMRS.png"
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1"
     },
     "version": "1.0.00",
     "ksp_version_min": "1.0.2",

--- a/FMRS/FMRS-v0.3.00.kerbalstuff
+++ b/FMRS/FMRS-v0.3.00.kerbalstuff
@@ -3,7 +3,7 @@
   "identifier": "FMRS",
   "resources": {
     "repository": "https://github.com/SIT89/FMRS",
-    "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
+    "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1",
     "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
     "kerbalstuff": "https://kerbalstuff.com/mod/172/Flight%20Manager%20for%20Reusable%20Stages%20%5BFMRS%5D"
   },

--- a/FMRS/FMRS-v0.3.01.kerbalstuff
+++ b/FMRS/FMRS-v0.3.01.kerbalstuff
@@ -3,7 +3,7 @@
     "identifier": "FMRS",
     "resources": {
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
         "kerbalstuff": "https://kerbalstuff.com/mod/172/Flight%20Manager%20for%20Reusable%20Stages%20%5BFMRS%5D"
     },

--- a/FMRS/FMRS-v0.3.02.kerbalstuff
+++ b/FMRS/FMRS-v0.3.02.kerbalstuff
@@ -3,7 +3,7 @@
     "identifier": "FMRS",
     "resources": {
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
         "kerbalstuff": "https://kerbalstuff.com/mod/172/Flight%20Manager%20for%20Reusable%20Stages%20[FMRS]"
     },

--- a/FMRS/FMRS-v1.0.1.ckan
+++ b/FMRS/FMRS-v1.0.1.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1"
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1"
     },
     "version": "v1.0.1",
     "ksp_version_min": "1.0.2",

--- a/FMRS/FMRS-v1.1.0.1.ckan
+++ b/FMRS/FMRS-v1.1.0.1.ckan
@@ -11,8 +11,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72605-110-flight-manager-for-reusable-stages-fmrs-x110-experimental/",
         "curse": "https://kerbal.curseforge.com/projects/220566",
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
-        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/9/964/120/120/635443108968717464.png"
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1"
     },
     "version": "v1.1.0.1",
     "ksp_version_min": "1.1.0",

--- a/FMRS/FMRS-v1.1.0.1.ckan
+++ b/FMRS/FMRS-v1.1.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FMRS",
     "name": "Flight Manager for Reusable Stages [FMRS]",
     "abstract": "FMRS lets you jump back and forth in time. So you can land an recover your launch vehicles.",

--- a/FinalFrontier/FinalFrontier-0.5.10-178.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.10-178.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "The Final Frontier plugin will handle ribbons for extraordinary merits for you. And the number of missions flown (i.e. vessel recovered) is recorded, too.",

--- a/FinalFrontier/FinalFrontier-0.5.10-178.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.10-178.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.10-178",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.5.11-246.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.11-246.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.5.11-246.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.11-246.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.11-246",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.5.14-304.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.14-304.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.14-304",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.5.14-304.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.14-304.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.5.15.308.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.15.308.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.5.15.308.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.15.308.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.15.308",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.5.16-317.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.16-317.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.16-317",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.5.16-317.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.16-317.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.5.9-177.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.9-177.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "The Final Frontier plugin will handle ribbons for extraordinary merits for you. And the number of missions flown (i.e. vessel recovered) is recorded, too.",

--- a/FinalFrontier/FinalFrontier-0.5.9-177.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.9-177.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.9-177",
     "ksp_version": "0.25",

--- a/FinalFrontier/FinalFrontier-0.6.1-604.ckan
+++ b/FinalFrontier/FinalFrontier-0.6.1-604.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.6.1-604",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.6.1-604.ckan
+++ b/FinalFrontier/FinalFrontier-0.6.1-604.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.6.4-689.ckan
+++ b/FinalFrontier/FinalFrontier-0.6.4-689.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.6.4-689.ckan
+++ b/FinalFrontier/FinalFrontier-0.6.4-689.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.6.4-689",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.6.5-697.ckan
+++ b/FinalFrontier/FinalFrontier-0.6.5-697.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.6.5-697",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.6.5-697.ckan
+++ b/FinalFrontier/FinalFrontier-0.6.5-697.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.7.12-985.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.12-985.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.12-985",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.7.12-985.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.12-985.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.7.14-1042.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.14-1042.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.14-1042",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.7.14-1042.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.14-1042.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.7.15-1047.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.15-1047.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.15-1047",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.7.15-1047.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.15-1047.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.7.4-870.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.4-870.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.4-870",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.7.4-870.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.4-870.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.7.5-933.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.5-933.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.5-933",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.7.5-933.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.5-933.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.7.6-949.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.6-949.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.6-949",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.7.6-949.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.6-949.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.7.7-956.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.7-956.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.7-956",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.7.7-956.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.7-956.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.7.8-969.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.8-969.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.8-969",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.7.8-969.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.8-969.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.7.9-972.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.9-972.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.9-972",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.7.9-972.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.9-972.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.8.1-1282.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.1-1282.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.8.1-1282",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.8.1-1282.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.1-1282.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.8.10-1609.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.10-1609.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.8.10-1609",

--- a/FinalFrontier/FinalFrontier-0.8.10-1609.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.10-1609.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.8.13-1728.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.13-1728.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.8.13-1728",

--- a/FinalFrontier/FinalFrontier-0.8.13-1728.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.13-1728.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.8.2-1285.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.2-1285.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.8.2-1285",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.8.2-1285.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.2-1285.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.8.3-1361.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.3-1361.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.8.3-1361",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.8.3-1361.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.3-1361.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.8.6-1370.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.6-1370.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.8.6-1370",

--- a/FinalFrontier/FinalFrontier-0.8.6-1370.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.6-1370.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.8.8-1410.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.8-1410.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.8.8-1410",

--- a/FinalFrontier/FinalFrontier-0.8.8-1410.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.8-1410.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.8.9-1414.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.9-1414.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.8.9-1414",

--- a/FinalFrontier/FinalFrontier-0.8.9-1414.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.9-1414.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.9.1-1749.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.1-1749.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.9.1-1749",

--- a/FinalFrontier/FinalFrontier-0.9.1-1749.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.1-1749.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.9.4-1798.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.4-1798.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.9.4-1798",

--- a/FinalFrontier/FinalFrontier-0.9.4-1798.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.4-1798.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.9.6-1826.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.6-1826.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.9.6-1826",

--- a/FinalFrontier/FinalFrontier-0.9.6-1826.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.6-1826.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/FinalFrontier/FinalFrontier-0.9.8-1882.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.8-1882.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.9.8-1882",

--- a/FinalFrontier/FinalFrontier-0.9.8-1882.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.8-1882.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",

--- a/ForScience/ForScience-v1.4.1.ckan
+++ b/ForScience/ForScience-v1.4.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "ForScience",
     "name": "ForScience!",
     "abstract": "ForScience is autopilot for running, collecting and resetting experiments.",

--- a/ForScience/ForScience-v1.5.0.ckan
+++ b/ForScience/ForScience-v1.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.5",
+    "spec_version": "v1.20",
     "identifier": "ForScience",
     "name": "ForScience!",
     "abstract": "ForScience is autopilot for running, collecting and resetting experiments.",

--- a/ForScience/ForScience-v1.5.2.ckan
+++ b/ForScience/ForScience-v1.5.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.5",
+    "spec_version": "v1.20",
     "identifier": "ForScience",
     "name": "ForScience!",
     "abstract": "ForScience is autopilot for running, collecting and resetting experiments.",

--- a/Fusebox/Fusebox-1.2.ckan
+++ b/Fusebox/Fusebox-1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "Fusebox",
     "name": "Fusebox",
     "abstract": "Fusebox - electric charge tracker and build helper.",

--- a/Fusebox/Fusebox-1.2.ckan
+++ b/Fusebox/Fusebox-1.2.ckan
@@ -7,7 +7,7 @@
     "license": "GPL-2.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/50077",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220284-fusebox"
+        "curse": "http://kerbal.curseforge.com/plugins/220284-fusebox"
     },
     "version": "1.2",
     "ksp_version": "0.90",

--- a/GCMonitor/GCMonitor-1.2.1.0.ckan
+++ b/GCMonitor/GCMonitor-1.2.1.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92907",
         "repository": "https://github.com/sarbian/GCMonitor/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
     },
     "version": "1.2.1.0",
     "ksp_version": "0.90",

--- a/GCMonitor/GCMonitor-1.2.2.0.ckan
+++ b/GCMonitor/GCMonitor-1.2.2.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92907",
         "repository": "https://github.com/sarbian/GCMonitor/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
     },
     "version": "1.2.2.0",
     "ksp_version": "0.90",

--- a/GCMonitor/GCMonitor-1.2.3.0.ckan
+++ b/GCMonitor/GCMonitor-1.2.3.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92907",
         "repository": "https://github.com/sarbian/GCMonitor/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
     },
     "version": "1.2.3.0",
     "ksp_version": "0.90",

--- a/GCMonitor/GCMonitor-1.2.4.0.ckan
+++ b/GCMonitor/GCMonitor-1.2.4.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92907",
         "repository": "https://github.com/sarbian/GCMonitor/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
     },
     "version": "1.2.4.0",
     "ksp_version": "1.0.2",

--- a/HGR-Props/HGR-Props-1.2.1.ckan
+++ b/HGR-Props/HGR-Props-1.2.1.ckan
@@ -10,7 +10,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60974",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
     },
     "version": "1.2.1",
     "ksp_version": "1.0.2",

--- a/HGR-Props/HGR-Props-1.2.1.ckan
+++ b/HGR-Props/HGR-Props-1.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "HGR-Props",
     "name": "HGR Props",
     "abstract": "Common props for HGR packs",

--- a/HGR-Props/HGR-Props-1.3.0.kerbalstuff
+++ b/HGR-Props/HGR-Props-1.3.0.kerbalstuff
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60974",
         "kerbalstuff": "https://kerbalstuff.com/mod/869/HGR%201.875m%20Parts",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts",
         "x_screenshot": "https://kerbalstuff.com/content/OrionKermin_9505/HGR_1.875m_Parts/HGR_1.875m_Parts-1433253511.7370584.png"
     },
     "version": "1.3.0",

--- a/HGR-Props/HGR-Props-1.3.0.kerbalstuff
+++ b/HGR-Props/HGR-Props-1.3.0.kerbalstuff
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "HGR-Props",
     "name": "HGR Props",
     "abstract": "A set of 1.875m parts to fill the gap between the basic and Rockomax size parts",

--- a/HGR/HGR-1.2.1.ckan
+++ b/HGR/HGR-1.2.1.ckan
@@ -10,7 +10,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60974",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
     },
     "version": "1.2.1",
     "ksp_version": "1.0.2",

--- a/HGR/HGR-1.2.1.ckan
+++ b/HGR/HGR-1.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "HGR",
     "name": "HGR 1.875m parts",
     "abstract": "Stock alike command pods and an 1.875m diameter of parts",

--- a/HGR/HGR-1.3.0.kerbalstuff
+++ b/HGR/HGR-1.3.0.kerbalstuff
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60974",
         "kerbalstuff": "https://kerbalstuff.com/mod/869/HGR%201.875m%20Parts",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts",
         "x_screenshot": "https://kerbalstuff.com/content/OrionKermin_9505/HGR_1.875m_Parts/HGR_1.875m_Parts-1433253511.7370584.png"
     },
     "version": "1.3.0",

--- a/HGR/HGR-1.3.0.kerbalstuff
+++ b/HGR/HGR-1.3.0.kerbalstuff
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "HGR",
     "name": "HGR 1.875m Parts",
     "abstract": "A set of 1.875m parts to fill the gap between the basic and Rockomax size parts",

--- a/HooliganLabsAirships/HooliganLabsAirships-3.0.0.ckan
+++ b/HooliganLabsAirships/HooliganLabsAirships-3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HooliganLabsAirships",
     "name": "HL Airships",
     "abstract": "HL Airships adds several airship parts to the game, allowing you to build and design absurd flying contraptions that would make Willy Wonka proud.",

--- a/HooliganLabsAirships/HooliganLabsAirships-3.0.0.ckan
+++ b/HooliganLabsAirships/HooliganLabsAirships-3.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/53961",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220395-hl-airships-v3-0-0-for-ksp-0-25"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220395-hl-airships-v3-0-0-for-ksp-0-25"
     },
     "version": "3.0.0",
     "ksp_version": "0.25",

--- a/HullcamVDS/HullcamVDS-0.33.ckan
+++ b/HullcamVDS/HullcamVDS-0.33.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",

--- a/HullcamVDS/HullcamVDS-0.33.ckan
+++ b/HullcamVDS/HullcamVDS-0.33.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
     },
     "version": "0.33",
     "ksp_version": "0.90",

--- a/HullcamVDS/HullcamVDS-0.34.1.ckan
+++ b/HullcamVDS/HullcamVDS-0.34.1.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
     },
     "version": "0.34.1",
     "ksp_version": "1.0.2",

--- a/HullcamVDS/HullcamVDS-0.34.1.ckan
+++ b/HullcamVDS/HullcamVDS-0.34.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",

--- a/HullcamVDS/HullcamVDS-0.34.ckan
+++ b/HullcamVDS/HullcamVDS-0.34.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
     },
     "version": "0.34",
     "ksp_version": "1.0.0",

--- a/HullcamVDS/HullcamVDS-0.34.ckan
+++ b/HullcamVDS/HullcamVDS-0.34.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",

--- a/HullcamVDS/HullcamVDS-0.40.ckan
+++ b/HullcamVDS/HullcamVDS-0.40.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",

--- a/HullcamVDS/HullcamVDS-0.40.ckan
+++ b/HullcamVDS/HullcamVDS-0.40.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "repository": "http://www.mediafire.com/download/u6j84zu6x8uauau/HullCamerav0.3-src.zip",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
         "x_screenshot": "https://kerbalstuff.com/content/Albert_VDS_5574/Hullcam_VDS/Hullcam_VDS-1431085757.6662536.jpg"
     },
     "version": "0.40",

--- a/HullcamVDS/HullcamVDS-0.50.ckan
+++ b/HullcamVDS/HullcamVDS-0.50.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",

--- a/HullcamVDS/HullcamVDS-0.50.ckan
+++ b/HullcamVDS/HullcamVDS-0.50.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "repository": "http://www.mediafire.com/download/u6j84zu6x8uauau/HullCamerav0.3-src.zip",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
         "x_screenshot": "https://kerbalstuff.com/content/Albert_VDS_5574/Hullcam_VDS/Hullcam_VDS-1431085757.6662536.jpg"
     },
     "version": "0.50",

--- a/HullcamVDS/HullcamVDS-0.51.ckan
+++ b/HullcamVDS/HullcamVDS-0.51.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",

--- a/HullcamVDS/HullcamVDS-0.51.ckan
+++ b/HullcamVDS/HullcamVDS-0.51.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "repository": "http://www.mediafire.com/download/u6j84zu6x8uauau/HullCamerav0.3-src.zip",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
         "x_screenshot": "https://kerbalstuff.com/content/Albert_VDS_5574/Hullcam_VDS/Hullcam_VDS-1431085757.6662536.jpg"
     },
     "version": "0.51",

--- a/HullcamVDS/HullcamVDS-0.52.ckan
+++ b/HullcamVDS/HullcamVDS-0.52.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",

--- a/HullcamVDS/HullcamVDS-0.52.ckan
+++ b/HullcamVDS/HullcamVDS-0.52.ckan
@@ -7,7 +7,7 @@
     "license": "LGPL-3.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
     },
     "version": "0.52",
     "ksp_version": "1.1.0",

--- a/HumanColoredFaces/HumanColoredFaces-17.ckan
+++ b/HumanColoredFaces/HumanColoredFaces-17.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "HumanColoredFaces",
     "name": "Human Colored Faces",
     "abstract": "Giving the Kerbals human colored heads.",

--- a/KAS/KAS-0.4.10.ckan
+++ b/KAS/KAS-0.4.10.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.4.7.ckan
+++ b/KAS/KAS-0.4.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.4.8.ckan
+++ b/KAS/KAS-0.4.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.4.9.ckan
+++ b/KAS/KAS-0.4.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.4.ckan
+++ b/KAS/KAS-0.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.0.ckan
+++ b/KAS/KAS-0.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.1.ckan
+++ b/KAS/KAS-0.5.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.2.ckan
+++ b/KAS/KAS-0.5.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.3.ckan
+++ b/KAS/KAS-0.5.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.4.ckan
+++ b/KAS/KAS-0.5.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.5.ckan
+++ b/KAS/KAS-0.5.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.6.ckan
+++ b/KAS/KAS-0.5.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.7.ckan
+++ b/KAS/KAS-0.5.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.8.0.ckan
+++ b/KAS/KAS-0.5.8.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.9.0.ckan
+++ b/KAS/KAS-0.5.9.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.6.0.0.ckan
+++ b/KAS/KAS-0.6.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.6.1.0.ckan
+++ b/KAS/KAS-0.6.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.6.2.0.ckan
+++ b/KAS/KAS-0.6.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.6.3.0.ckan
+++ b/KAS/KAS-0.6.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.6.4.ckan
+++ b/KAS/KAS-0.6.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-1.0.ckan
+++ b/KAS/KAS-1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-1.1.ckan
+++ b/KAS/KAS-1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-1.2.ckan
+++ b/KAS/KAS-1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-1.3.ckan
+++ b/KAS/KAS-1.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-1.4.ckan
+++ b/KAS/KAS-1.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KIS/KIS-1.0.0.ckan
+++ b/KIS/KIS-1.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.0.1.ckan
+++ b/KIS/KIS-1.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.0.2.ckan
+++ b/KIS/KIS-1.0.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.0.ckan
+++ b/KIS/KIS-1.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.1.ckan
+++ b/KIS/KIS-1.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.2.ckan
+++ b/KIS/KIS-1.1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.3.ckan
+++ b/KIS/KIS-1.1.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.4.ckan
+++ b/KIS/KIS-1.1.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.5.ckan
+++ b/KIS/KIS-1.1.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.10.ckan
+++ b/KIS/KIS-1.10.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.11.ckan
+++ b/KIS/KIS-1.11.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.12.ckan
+++ b/KIS/KIS-1.12.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.13.ckan
+++ b/KIS/KIS-1.13.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.14.ckan
+++ b/KIS/KIS-1.14.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.15.ckan
+++ b/KIS/KIS-1.15.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.16.ckan
+++ b/KIS/KIS-1.16.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.17.ckan
+++ b/KIS/KIS-1.17.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.18.ckan
+++ b/KIS/KIS-1.18.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.19.ckan
+++ b/KIS/KIS-1.19.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.0.ckan
+++ b/KIS/KIS-1.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.1.ckan
+++ b/KIS/KIS-1.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.10.0.ckan
+++ b/KIS/KIS-1.2.10.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.11.0.ckan
+++ b/KIS/KIS-1.2.11.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.12.0.ckan
+++ b/KIS/KIS-1.2.12.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.2.ckan
+++ b/KIS/KIS-1.2.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.3.ckan
+++ b/KIS/KIS-1.2.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.4.ckan
+++ b/KIS/KIS-1.2.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.5.ckan
+++ b/KIS/KIS-1.2.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.6.ckan
+++ b/KIS/KIS-1.2.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.7.ckan
+++ b/KIS/KIS-1.2.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.8.ckan
+++ b/KIS/KIS-1.2.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.9.ckan
+++ b/KIS/KIS-1.2.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.20.ckan
+++ b/KIS/KIS-1.20.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.21.ckan
+++ b/KIS/KIS-1.21.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.22.ckan
+++ b/KIS/KIS-1.22.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.3.0.0.ckan
+++ b/KIS/KIS-1.3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.3.1.0.ckan
+++ b/KIS/KIS-1.3.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.4.0.ckan
+++ b/KIS/KIS-1.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.4.1.ckan
+++ b/KIS/KIS-1.4.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.4.2.ckan
+++ b/KIS/KIS-1.4.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.4.3.ckan
+++ b/KIS/KIS-1.4.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.4.4.ckan
+++ b/KIS/KIS-1.4.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.5.0.ckan
+++ b/KIS/KIS-1.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.6.ckan
+++ b/KIS/KIS-1.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.7.ckan
+++ b/KIS/KIS-1.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.8.ckan
+++ b/KIS/KIS-1.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.9.ckan
+++ b/KIS/KIS-1.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KSPCalendar/KSPCalendar-1.5.ckan
+++ b/KSPCalendar/KSPCalendar-1.5.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/68270",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/223684-kerbin-date-calendar"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/223684-kerbin-date-calendar"
     },
     "version": "1.5",
     "ksp_version": "0.90",

--- a/KSPCalendar/KSPCalendar-1.5.ckan
+++ b/KSPCalendar/KSPCalendar-1.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KSPCalendar",
     "name": "KSPCalendar",
     "abstract": "Kerbin Date Calendar",

--- a/KSPTips/KSPTips-1.0.0.1.ckan
+++ b/KSPTips/KSPTips-1.0.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KSPTips",
     "name": "KSP Tips",
     "abstract": "Plugin that provides 'Helpful' in game tips and tricks",

--- a/KSPTips/KSPTips-1.0.0.1.ckan
+++ b/KSPTips/KSPTips-1.0.0.1.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KSPTips",
         "license": "https://github.com/TriggerAu/KSPTips/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/416/KSP%20Tips",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
     },
     "version": "1.0.0.1",
     "ksp_version": "0.90",

--- a/KSPTips/KSPTips-2.0.0.0.ckan
+++ b/KSPTips/KSPTips-2.0.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KSPTips",
         "license": "https://github.com/TriggerAu/KSPTips/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/416/KSP%20Tips",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
     },
     "version": "2.0.0.0",
     "ksp_version": "0.90",

--- a/KSPTips/KSPTips-2.0.0.0.ckan
+++ b/KSPTips/KSPTips-2.0.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KSPTips",
     "name": "KSP Tips",
     "abstract": "Plugin that provides 'Helpful' in game tips and tricks",

--- a/KSPTips/KSPTips-2.1.0.0.ckan
+++ b/KSPTips/KSPTips-2.1.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KSPTips",
         "license": "https://github.com/TriggerAu/KSPTips/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/416/KSP%20Tips",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
     },
     "version": "2.1.0.0",
     "ksp_version": "0.90",

--- a/KSPTips/KSPTips-2.1.0.0.ckan
+++ b/KSPTips/KSPTips-2.1.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KSPTips",
     "name": "KSP Tips",
     "abstract": "Plugin that provides 'Helpful' in game tips and tricks",

--- a/KSPTips/KSPTips-3.0.0.0.ckan
+++ b/KSPTips/KSPTips-3.0.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KSPTips",
         "license": "https://github.com/TriggerAu/KSPTips/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/416/KSP%20Tips",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
     },
     "version": "3.0.0.0",
     "ksp_version": "0.90",

--- a/KSPTips/KSPTips-3.0.0.0.ckan
+++ b/KSPTips/KSPTips-3.0.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KSPTips",
     "name": "KSP Tips",
     "abstract": "Plugin that provides 'Helpful' in game tips and tricks",

--- a/KSPTips/KSPTips-4.0.0.0.ckan
+++ b/KSPTips/KSPTips-4.0.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KSPTips",
     "name": "KSP Tips",
     "abstract": "Plugin that provides 'Helpful' in game tips and tricks",

--- a/KSPTips/KSPTips-4.0.0.0.ckan
+++ b/KSPTips/KSPTips-4.0.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KSPTips",
         "license": "https://github.com/TriggerAu/KSPTips/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/416/KSP%20Tips",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips",
         "x_screenshot": "https://kerbalstuff.com/content/TriggerAu_1745/KSP_Tips/KSP_Tips.png"
     },
     "version": "4.0.0.0",

--- a/KerbalAdventure/KerbalAdventure-V1.0.ckan
+++ b/KerbalAdventure/KerbalAdventure-V1.0.ckan
@@ -7,7 +7,7 @@
     "license": "CC-BY-NC-SA-3.0",
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/390/Kerbal%20Adventure",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/225951-kerbal-adventure"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/225951-kerbal-adventure"
     },
     "version": "V1.0",
     "ksp_version": "0.25.0",

--- a/KerbalAdventure/KerbalAdventure-V1.0.ckan
+++ b/KerbalAdventure/KerbalAdventure-V1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KerbalAdventure",
     "name": "Kerbal Adventure",
     "abstract": "This mod introduces stories to the Kerbal Universe.  ",

--- a/KerbalAircraftExpansion/KerbalAircraftExpansion-3-v2.6.4.ckan
+++ b/KerbalAircraftExpansion/KerbalAircraftExpansion-3-v2.6.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.18",
+    "spec_version": "v1.20",
     "identifier": "KerbalAircraftExpansion",
     "name": "Kerbal Aircraft Expansion",
     "abstract": "A pack of select vanilla-inspired parts for your aircrafting needs.",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.0.4.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.0.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "Create reminder alarms to help manage flights and not warp past important times",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.0.4.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.0.4.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.0.4.0",
     "ksp_version": "0.25",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.0.5.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.0.5.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.0.5.0",
     "ksp_version": "0.25",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.0.5.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.0.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "Create reminder alarms to help manage flights and not warp past important times",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.0.6.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.0.6.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.0.6.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.0.6.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.0.6.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.1.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.1.0.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.1.0.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.1.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.1.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.1.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.1.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.1.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.1.1.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.1.1.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.1.2.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.1.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.1.2.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.1.2.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.1.2.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.10.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.10.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.10.0.0",
     "ksp_version_min": "1.6.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.10.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.10.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.11.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.11.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.11.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.11.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.11.0.0",
     "ksp_version_min": "1.7.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.0.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.2.0.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.1.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.2.1.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.2.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.2.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.2.2.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.2.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.3.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.3.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.2.3.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.3.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.4.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.4.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.4.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.2.4.0",
     "ksp_version": "0.90.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.3.0.0",
     "ksp_version": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.1.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.3.0.1",
     "ksp_version": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.1.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.1.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.1.1.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.3.1.1",
     "ksp_version_min": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.2.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.2.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.2.1.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.3.2.1",
     "ksp_version_min": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.4.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.4.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.4.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.4.0.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.4.0.0",
     "ksp_version_min": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.5.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.5.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.5.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.5.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.5.0.0",
     "ksp_version_min": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.6.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.6.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.6.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.6.1.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.6.1.0",
     "ksp_version_min": "1.1.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.6.2.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.6.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.6.2.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.6.2.1.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.6.2.1",
     "ksp_version_min": "1.1.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.6.3.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.6.3.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.6.3.0",
     "ksp_version_min": "1.1.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.6.3.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.6.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.7.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.7.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.7.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.7.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.7.0.0",
     "ksp_version_min": "1.1.3",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.7.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.7.1.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.7.1.0",
     "ksp_version_min": "1.1.3",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.7.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.7.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.0.0",
     "ksp_version_min": "1.2.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.1.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.1.0",
     "ksp_version_min": "1.2.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.2.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.2.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.2.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.2.0",
     "ksp_version_min": "1.2.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.3.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.3.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.3.0",
     "ksp_version_min": "1.2.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.3.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.4.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.4.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.4.0",
     "ksp_version_min": "1.2.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.4.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.5.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.5.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.5.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.5.0",
     "ksp_version_min": "1.3.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.9.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.9.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.9.0.0",
     "ksp_version_min": "1.4.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.9.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.9.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.9.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.9.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.9.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.9.1.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.9.1.0",
     "ksp_version_min": "1.4.0",

--- a/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.3.0.ckan
+++ b/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.3.0.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55985",
         "repository": "https://github.com/sarbian/km_Gimbal",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
     },
     "version": "3.0.3.0",
     "ksp_version": "1.0",

--- a/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.4.0.ckan
+++ b/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.4.0.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55985",
         "repository": "https://github.com/sarbian/km_Gimbal",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
     },
     "version": "3.0.4.0",
     "ksp_version": "1.0",

--- a/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.5.0.ckan
+++ b/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.5.0.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55985",
         "repository": "https://github.com/sarbian/km_Gimbal",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
     },
     "version": "3.0.5.0",
     "ksp_version": "1.0",

--- a/LanderControl/LanderControl-814.ckan
+++ b/LanderControl/LanderControl-814.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "LanderControl",
     "name": "Lander Orientation Improvement",
     "abstract": "This mod allows the user to fly the lander with a proper IVA configuration to make landing in IVA much better.",

--- a/Mk2Essentials/Mk2Essentials-5.ckan
+++ b/Mk2Essentials/Mk2Essentials-5.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/99661-1-0-2-Mk2-Essentials",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
     },
     "version": "5",
     "ksp_version_min": "0.90",

--- a/Mk2Essentials/Mk2Essentials-5.ckan
+++ b/Mk2Essentials/Mk2Essentials-5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "Mk2Essentials",
     "name": "Mk 2 Essentials",
     "abstract": "Some Mk2 parts which I felt were missing from the game",

--- a/Mk2Essentials/Mk2Essentials-6.ckan
+++ b/Mk2Essentials/Mk2Essentials-6.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/89875-104",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
     },
     "version": "6",
     "ksp_version_min": "0.90",

--- a/Mk2Essentials/Mk2Essentials-6.ckan
+++ b/Mk2Essentials/Mk2Essentials-6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "Mk2Essentials",
     "name": "Mk 2 Essentials",
     "abstract": "Some Mk2 parts which I felt were missing from the game",

--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/118088",
         "repository": "https://github.com/sarbian/ModularFlightIntegrator",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
     },
     "version": "1.0",
     "ksp_version_min": "1.0.0",

--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.0.repackaged0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.0.repackaged0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/118088",
         "repository": "https://github.com/sarbian/ModularFlightIntegrator",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
     },
     "version": "1.0.repackaged0",
     "ksp_version_min": "1.0.0",

--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.1.0.0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.1.0.0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/118088",
         "repository": "https://github.com/sarbian/ModularFlightIntegrator",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
     },
     "version": "1.1.0.0",
     "ksp_version": "1.0.4",

--- a/ModuleManager/ModuleManager-2.5.10.ckan
+++ b/ModuleManager/ModuleManager-2.5.10.ckan
@@ -11,7 +11,7 @@
     "release_status": "stable",
     "ksp_version": "0.90",
     "resources": {
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/",
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager"
     },

--- a/ModuleManager/ModuleManager-2.5.9.ckan
+++ b/ModuleManager/ModuleManager-2.5.9.ckan
@@ -11,7 +11,7 @@
     "release_status": "stable",
     "ksp_version": "0.90",
     "resources": {
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/",
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager"
     },

--- a/ModuleManager/ModuleManager-2.6.0.ckan
+++ b/ModuleManager/ModuleManager-2.6.0.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
     },
     "version": "2.6.0",
     "ksp_version": "0.90",

--- a/ModuleManager/ModuleManager-2.6.1.ckan
+++ b/ModuleManager/ModuleManager-2.6.1.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
     },
     "version": "2.6.1",
     "ksp_version": "1.0.0",

--- a/ModuleManager/ModuleManager-2.6.2.ckan
+++ b/ModuleManager/ModuleManager-2.6.2.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
     },
     "version": "2.6.2",
     "ksp_version": "1.0",

--- a/ModuleManager/ModuleManager-2.6.3.ckan
+++ b/ModuleManager/ModuleManager-2.6.3.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
     },
     "version": "2.6.3",
     "ksp_version": "1.0",

--- a/ModuleManager/ModuleManager-2.6.5.ckan
+++ b/ModuleManager/ModuleManager-2.6.5.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
     },
     "version": "2.6.5",
     "ksp_version": "1.0",

--- a/NavBallTextureExport/NavBallTextureExport-1.3.ckan
+++ b/NavBallTextureExport/NavBallTextureExport-1.3.ckan
@@ -9,8 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/63113-making-high-contrast-nav-ball/&do=findComment&comment=959807",
-        "repository": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger",
-        "x_textures": "http://bit.ly/navballs"
+        "repository": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger"
     },
     "version": "1.3",
     "ksp_version_min": "0.24",

--- a/NavBallTextureExport/NavBallTextureExport-1.5.ckan
+++ b/NavBallTextureExport/NavBallTextureExport-1.5.ckan
@@ -9,8 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/63113-making-high-contrast-nav-ball/&do=findComment&comment=959807",
-        "repository": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger",
-        "x_textures": "http://bit.ly/navballs"
+        "repository": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger"
     },
     "version": "1.5",
     "ksp_version": "1.2",

--- a/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.0.ckan
+++ b/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.9",
+    "spec_version": "v1.20",
     "identifier": "OPTSpacePlaneMain",
     "name": "OPT Space Plane Parts",
     "abstract": "Over 50 stock-a-like, large space plane oriented parts",

--- a/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.1.ckan
+++ b/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.9",
+    "spec_version": "v1.20",
     "identifier": "OPTSpacePlaneMain",
     "name": "OPT Space Plane Parts",
     "abstract": "Over 50 stock-a-like, large space plane oriented parts",

--- a/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.2.ckan
+++ b/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.9",
+    "spec_version": "v1.20",
     "identifier": "OPTSpacePlaneMain",
     "name": "OPT Space Plane Parts",
     "abstract": "Over 50 stock-a-like, large space plane oriented parts",

--- a/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.9.ckan
+++ b/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.9",
+    "spec_version": "v1.20",
     "identifier": "OPTSpacePlaneMain",
     "name": "OPT Space Plane Parts",
     "abstract": "Over 50 stock-a-like, large space plane oriented parts",

--- a/OPTSpacePlaneMain/OPTSpacePlaneMain-2.0.ckan
+++ b/OPTSpacePlaneMain/OPTSpacePlaneMain-2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.9",
+    "spec_version": "v1.20",
     "identifier": "OPTSpacePlaneMain",
     "name": "OPT Space Plane Parts",
     "abstract": "Over 50 stock-a-like, large space plane oriented parts",

--- a/OptionalAtm/OptionalAtm-1.4.9.1.ckan
+++ b/OptionalAtm/OptionalAtm-1.4.9.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "OptionalAtm",
     "name": "OptionalAtmospheres",
     "abstract": "Adds atmospheres to those planets and moons which don't have atmospheres of the kerbol system",

--- a/OptionalAtm/OptionalAtm-1.4.9.ckan
+++ b/OptionalAtm/OptionalAtm-1.4.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "OptionalAtm",
     "name": "OptionalAtmospheres",
     "abstract": "Adds atmospheres to those planets and moons which don't have atmospheres of the kerbol system",

--- a/PartWizard/PartWizard-1.1.2.ckan
+++ b/PartWizard/PartWizard-1.1.2.ckan
@@ -10,7 +10,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80124",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220530-part-wizard"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220530-part-wizard"
     },
     "version": "1.1.2",
     "ksp_version": "0.90",

--- a/PartWizard/PartWizard-1.1.2.ckan
+++ b/PartWizard/PartWizard-1.1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "PartWizard",
     "name": "Part Wizard",
     "abstract": "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.",

--- a/PartWizard/PartWizard-1.2.1.ckan
+++ b/PartWizard/PartWizard-1.2.1.ckan
@@ -10,7 +10,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80124",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220530-part-wizard"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220530-part-wizard"
     },
     "version": "1.2.1",
     "ksp_version_min": "1.0.2",

--- a/PartWizard/PartWizard-1.2.1.ckan
+++ b/PartWizard/PartWizard-1.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "PartWizard",
     "name": "Part Wizard",
     "abstract": "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.",

--- a/PartWizard/PartWizard-v1.2.4.0.ckan
+++ b/PartWizard/PartWizard-v1.2.4.0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72468-11-part-wizard-124-20-apr-2016/",
         "repository": "https://github.com/ozraven/PartWizard",
-        "x_curse": "http://kerbal.curseforge.com/projects/part-wizard"
+        "curse": "http://kerbal.curseforge.com/projects/part-wizard"
     },
     "version": "v1.2.4.0",
     "ksp_version": "1.1.0",

--- a/PartWizard/PartWizard-v1.2.4.0.ckan
+++ b/PartWizard/PartWizard-v1.2.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PartWizard",
     "name": "Part Wizard",
     "abstract": "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.  It provides a list of parts with part highlighting for easier identification, allows deleting of parts from the list on eligible parts, allows complete control of symmetry on eligible parts, allows selecting parts for Action Group assignment, shows either all parts or only those that are hidden from the editor's Parts List. (Helpful in finding obsolete parts when mod authors make updates.) and shows unavailable parts in career modes with options to buy one or all necessary parts for launch.",

--- a/PartWizard/PartWizard-v1.2.5.0.ckan
+++ b/PartWizard/PartWizard-v1.2.5.0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72468-11-part-wizard-124-20-apr-2016/",
         "repository": "https://github.com/ozraven/PartWizard",
-        "x_curse": "http://kerbal.curseforge.com/projects/part-wizard"
+        "curse": "http://kerbal.curseforge.com/projects/part-wizard"
     },
     "version": "v1.2.5.0",
     "ksp_version": "1.1.3",

--- a/PartWizard/PartWizard-v1.2.5.0.ckan
+++ b/PartWizard/PartWizard-v1.2.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PartWizard",
     "name": "Part Wizard",
     "abstract": "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.  It provides a list of parts with part highlighting for easier identification, allows deleting of parts from the list on eligible parts, allows complete control of symmetry on eligible parts, allows selecting parts for Action Group assignment, shows either all parts or only those that are hidden from the editor's Parts List. (Helpful in finding obsolete parts when mod authors make updates.) and shows unavailable parts in career modes with options to buy one or all necessary parts for launch.",

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.1.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine-Config-Default",
     "name": "PlanetShine - Default configuration",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.2.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine-Config-Default",
     "name": "PlanetShine - Default configuration",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine-Config-Default",
     "name": "PlanetShine - Default configuration",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/PlanetShine/PlanetShine-0.2.5.1.ckan
+++ b/PlanetShine/PlanetShine-0.2.5.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine",
     "name": "PlanetShine",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/PlanetShine/PlanetShine-0.2.5.2.ckan
+++ b/PlanetShine/PlanetShine-0.2.5.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine",
     "name": "PlanetShine",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/PlanetShine/PlanetShine-0.2.5.ckan
+++ b/PlanetShine/PlanetShine-0.2.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine",
     "name": "PlanetShine",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/RCSBuildAid/RCSBuildAid-v0.9.1.ckan
+++ b/RCSBuildAid/RCSBuildAid-v0.9.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "RCSBuildAid",
     "name": "RCS Build Aid",
     "abstract": "This is something I made for placing RCS thrusters in the right positions in the first try without having to go back and forth between the VAB and the hacked gravity launchpad.  Features: Display thrust and torque forces caused by RCS or engines. Delta V readout for RCS. Dry center of mass marker. Average center of mass marker. Ability to resize editor's overlay markers. Display total mass of resources.",

--- a/RCSBuildAid/RCSBuildAid-v0.9.ckan
+++ b/RCSBuildAid/RCSBuildAid-v0.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "RCSBuildAid",
     "name": "RCS Build Aid",
     "abstract": "This is something I made for placing RCS thrusters in the right positions in the first try without having to go back and forth between the VAB and the hacked gravity launchpad.  Features: Display thrust and torque forces caused by RCS or engines. Delta V readout for RCS. Dry center of mass marker. Average center of mass marker. Ability to resize editor's overlay markers. Display total mass of resources.",

--- a/RealisticAtmospheres/RealisticAtmospheres-1.2.2.ckan
+++ b/RealisticAtmospheres/RealisticAtmospheres-1.2.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "RealisticAtmospheres",
     "name": "Realistic Atmospheres",
     "abstract": "Modifies the atmospheres of all planets and moons to conform to a more lifelike model.",

--- a/RealisticAtmospheres/RealisticAtmospheres-1.2.3.ckan
+++ b/RealisticAtmospheres/RealisticAtmospheres-1.2.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "RealisticAtmospheres",
     "name": "Realistic Atmospheres",
     "abstract": "Modifies the atmospheres of all planets and moons to conform to a more lifelike model.",

--- a/RemoteTechRedevAntennas/RemoteTechRedevAntennas-0.1.ckan
+++ b/RemoteTechRedevAntennas/RemoteTechRedevAntennas-0.1.ckan
@@ -9,7 +9,6 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/139167-*",
         "spacedock": "https://spacedock.info/mod/1929/RemoteTech%20Redev%20Antennas",
         "repository": "https://github.com/RemoteTechnologiesGroup/RemoteTech-Antennas",
-        "respository": "https://github.com/RemoteTechnologiesGroup/RemoteTech-Antennas",
         "x_screenshot": "https://spacedock.info/content/TaxiService_12023/RemoteTech_Redev_Antennas/RemoteTech_Redev_Antennas-1533451078.0075202.png"
     },
     "version": "0.1",

--- a/SamBelangerFlags/SamBelangerFlags-1.4.9.1.ckan
+++ b/SamBelangerFlags/SamBelangerFlags-1.4.9.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "comment": "flagmod",
     "identifier": "SamBelangerFlags",
     "name": "Sam Belanger Flags",

--- a/ShipManifest/ShipManifest-0.25.0_3.3.2b.ckan
+++ b/ShipManifest/ShipManifest-0.25.0_3.3.2b.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.25.0_3.3.2b.ckan
+++ b/ShipManifest/ShipManifest-0.25.0_3.3.2b.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.25.0_3.3.2b",
     "ksp_version": "0.25",

--- a/ShipManifest/ShipManifest-0.90.0_3.3.4.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_3.3.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_3.3.4.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_3.3.4.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_3.3.4",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.0.0.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.0.0.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.0.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.0.0",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.0.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.0.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.0.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.0.1",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.0.2.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.0.2.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.0.2",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.0.2.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.0.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.0.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.0.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.0",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.0a.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.0a.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.0a",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.0a.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.0a.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.0b.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.0b.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.0b.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.0b.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.0b",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.1",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.2.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.2.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.2.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.2",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.3.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.3.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.3.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.3.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.3.1",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.3.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.3.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.3.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.3",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.4.0.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.4.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.4.0",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.4.0.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.4.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.4.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.4.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.4.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.4.1",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-4.1.4.2.ckan
+++ b/ShipManifest/ShipManifest-4.1.4.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",

--- a/ShipManifest/ShipManifest-4.1.4.2.ckan
+++ b/ShipManifest/ShipManifest-4.1.4.2.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.1.4.2",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-4.1.4.3.ckan
+++ b/ShipManifest/ShipManifest-4.1.4.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",

--- a/ShipManifest/ShipManifest-4.1.4.3.ckan
+++ b/ShipManifest/ShipManifest-4.1.4.3.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.1.4.3",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-4.1.4.4.ckan
+++ b/ShipManifest/ShipManifest-4.1.4.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",

--- a/ShipManifest/ShipManifest-4.1.4.4.ckan
+++ b/ShipManifest/ShipManifest-4.1.4.4.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.1.4.4",
     "ksp_version": "1.0.0",

--- a/ShipManifest/ShipManifest-4.2.0.0.ckan
+++ b/ShipManifest/ShipManifest-4.2.0.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.2.0.0",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.2.0.0.ckan
+++ b/ShipManifest/ShipManifest-4.2.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",

--- a/ShipManifest/ShipManifest-4.2.0.1.ckan
+++ b/ShipManifest/ShipManifest-4.2.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",

--- a/ShipManifest/ShipManifest-4.2.0.1.ckan
+++ b/ShipManifest/ShipManifest-4.2.0.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.2.0.1",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.2.0.2.ckan
+++ b/ShipManifest/ShipManifest-4.2.0.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",

--- a/ShipManifest/ShipManifest-4.2.0.2.ckan
+++ b/ShipManifest/ShipManifest-4.2.0.2.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.2.0.2",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.2.1.0.ckan
+++ b/ShipManifest/ShipManifest-4.2.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",

--- a/ShipManifest/ShipManifest-4.2.1.0.ckan
+++ b/ShipManifest/ShipManifest-4.2.1.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.2.1.0",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.2.1.1.ckan
+++ b/ShipManifest/ShipManifest-4.2.1.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.2.1.1",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.2.1.1.ckan
+++ b/ShipManifest/ShipManifest-4.2.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science & Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas & Lights.",

--- a/ShipManifest/ShipManifest-4.3.0.0.ckan
+++ b/ShipManifest/ShipManifest-4.3.0.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.3.0.0",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.3.0.0.ckan
+++ b/ShipManifest/ShipManifest-4.3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science & Resources around your vessel.  It also manages Hatches, Solar Panels, Antennas & Lights.",

--- a/ShipManifest/ShipManifest-4.3.0.1.ckan
+++ b/ShipManifest/ShipManifest-4.3.0.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.3.0.1",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.3.0.1.ckan
+++ b/ShipManifest/ShipManifest-4.3.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science & Resources around your vessel.  It also manages Hatches, Solar Panels, Antennas & Lights.",

--- a/ShipManifest/ShipManifest-4.3.0.2.ckan
+++ b/ShipManifest/ShipManifest-4.3.0.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science & Resources around your vessel.  It also manages Hatches, Solar Panels, Antennas & Lights.",

--- a/ShipManifest/ShipManifest-4.3.0.2.ckan
+++ b/ShipManifest/ShipManifest-4.3.0.2.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.3.0.2",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.3.1.0.ckan
+++ b/ShipManifest/ShipManifest-4.3.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science & Resources around your vessel.  It also manages Hatches, Solar Panels, Antennas & Lights.",

--- a/ShipManifest/ShipManifest-4.3.1.0.ckan
+++ b/ShipManifest/ShipManifest-4.3.1.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.3.1.0",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.4.0.0.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",

--- a/ShipManifest/ShipManifest-4.4.0.0.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.4.0.0",
     "ksp_version": "1.0.3",

--- a/ShipManifest/ShipManifest-4.4.0.1.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",

--- a/ShipManifest/ShipManifest-4.4.0.1.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.4.0.1",
     "ksp_version": "1.0.4",

--- a/ShipManifest/ShipManifest-4.4.0.2.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",

--- a/ShipManifest/ShipManifest-4.4.0.2.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.2.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.4.0.2",
     "ksp_version": "1.0.4",

--- a/ShipManifest/ShipManifest-4.4.0.3.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.3.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.4.0.3",
     "ksp_version": "1.0.4",

--- a/ShipManifest/ShipManifest-4.4.0.3.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",

--- a/ShipManifest/ShipManifest-4.4.1.0.ckan
+++ b/ShipManifest/ShipManifest-4.4.1.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.4.1.0",
     "ksp_version": "1.0.4",

--- a/ShipManifest/ShipManifest-4.4.1.0.ckan
+++ b/ShipManifest/ShipManifest-4.4.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",

--- a/ShipManifest/ShipManifest-4.4.1.1.ckan
+++ b/ShipManifest/ShipManifest-4.4.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",

--- a/ShipManifest/ShipManifest-4.4.1.1.ckan
+++ b/ShipManifest/ShipManifest-4.4.1.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://kerbalstuff.com/content/Papa_Joe_2689/Ship_Manifest/Ship_Manifest-1434605028.0250149.png"
     },
     "version": "4.4.1.1",

--- a/ShipManifest/ShipManifest-4.4.2.0.ckan
+++ b/ShipManifest/ShipManifest-4.4.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-4.4.2.0.ckan
+++ b/ShipManifest/ShipManifest-4.4.2.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "4.4.2.0",

--- a/ShipManifest/ShipManifest-5.0.0.0.ckan
+++ b/ShipManifest/ShipManifest-5.0.0.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.0.0.0",

--- a/ShipManifest/ShipManifest-5.0.0.0.ckan
+++ b/ShipManifest/ShipManifest-5.0.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.0.0.1.ckan
+++ b/ShipManifest/ShipManifest-5.0.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.0.0.1.ckan
+++ b/ShipManifest/ShipManifest-5.0.0.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.0.0.1",

--- a/ShipManifest/ShipManifest-5.0.1.0.ckan
+++ b/ShipManifest/ShipManifest-5.0.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.0.1.0.ckan
+++ b/ShipManifest/ShipManifest-5.0.1.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.0.1.0",

--- a/ShipManifest/ShipManifest-5.0.9.0.ckan
+++ b/ShipManifest/ShipManifest-5.0.9.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.0.9.0.ckan
+++ b/ShipManifest/ShipManifest-5.0.9.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.0.9.0",

--- a/ShipManifest/ShipManifest-5.1.0.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.0.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.0.0",

--- a/ShipManifest/ShipManifest-5.1.0.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.1.1.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.1.1.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.1.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.1.0",

--- a/ShipManifest/ShipManifest-5.1.1.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.1.1.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.1.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.1.1",

--- a/ShipManifest/ShipManifest-5.1.1.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.1.2.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.1.2",

--- a/ShipManifest/ShipManifest-5.1.1.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.1.2.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.1.2.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.2.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.2.0",

--- a/ShipManifest/ShipManifest-5.1.2.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.2.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.2.1",

--- a/ShipManifest/ShipManifest-5.1.2.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.1.2.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.2.2.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.2.2",

--- a/ShipManifest/ShipManifest-5.1.2.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.2.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.1.3.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.1.3.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.0.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.3.0",

--- a/ShipManifest/ShipManifest-5.1.3.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.1.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.3.1",

--- a/ShipManifest/ShipManifest-5.1.3.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.1.3.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",

--- a/ShipManifest/ShipManifest-5.1.3.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.2.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.3.2",

--- a/ShipManifest/ShipManifest-5.1.3.3.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.3.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "5.1.3.3",
     "ksp_version_min": "1.2.0",

--- a/ShipManifest/ShipManifest-5.1.3.3.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Manages Crew, Science, & Resources on a given vessel.",

--- a/ShipManifest/ShipManifest-5.1.4.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.4.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Manages Crew, Science, & Resources on a given vessel.",

--- a/ShipManifest/ShipManifest-5.1.4.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.4.1.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "5.1.4.1",
     "ksp_version": "1.3.0",

--- a/ShipManifest/ShipManifest-5.1.4.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.4.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Manages Crew, Science, & Resources on a given vessel.",

--- a/ShipManifest/ShipManifest-5.1.4.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.4.2.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "5.1.4.2",
     "ksp_version": "1.3.0",

--- a/ShipManifest/ShipManifest-5.1.4.3.ckan
+++ b/ShipManifest/ShipManifest-5.1.4.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Manages Crew, Science, & Resources on a given vessel.",

--- a/ShipManifest/ShipManifest-5.1.4.3.ckan
+++ b/ShipManifest/ShipManifest-5.1.4.3.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "5.1.4.3",
     "ksp_version": "1.3.0",

--- a/ShipManifest/ShipManifest-5.2.0.0.ckan
+++ b/ShipManifest/ShipManifest-5.2.0.0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-*",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "5.2.0.0",
     "ksp_version_min": "1.3.0",

--- a/ShipManifest/ShipManifest-5.2.0.0.ckan
+++ b/ShipManifest/ShipManifest-5.2.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Manages Crew, Science, & Resources on a given vessel.",

--- a/ShowFPS/ShowFPS-v1.1.ckan
+++ b/ShowFPS/ShowFPS-v1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "ShowFPS",
     "name": "Show FPS",
     "abstract": "Simple framerate counter, enable with F8.",

--- a/SmokeScreen/SmokeScreen-2.6.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",
         "repository": "https://github.com/sarbian/SmokeScreen/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.6.0",
     "ksp_version_min": "1.0.0",

--- a/SmokeScreen/SmokeScreen-2.6.1.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.1.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",
         "repository": "https://github.com/sarbian/SmokeScreen/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.6.1",
     "ksp_version_min": "1.0.0",

--- a/SmokeScreen/SmokeScreen-2.6.2.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.2.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",
         "repository": "https://github.com/sarbian/SmokeScreen/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.6.2",
     "ksp_version_min": "1.0.0",

--- a/StationScience/StationScience-1.3.1.ckan
+++ b/StationScience/StationScience-1.3.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "StationScience",
     "name": "Station Science",
     "abstract": "Station Science mod adds several large parts designed to be integrated into a permanent space station.",

--- a/StationScience/StationScience-1.3.1.ckan
+++ b/StationScience/StationScience-1.3.1.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
         "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.3.1",
     "ksp_version": "0.25",

--- a/StationScience/StationScience-1.3.1.ckan
+++ b/StationScience/StationScience-1.3.1.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220216",
         "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.3.1",

--- a/StationScience/StationScience-1.4.ckan
+++ b/StationScience/StationScience-1.4.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
         "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.4",
     "ksp_version": "0.90",

--- a/StationScience/StationScience-1.4.ckan
+++ b/StationScience/StationScience-1.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "StationScience",
     "name": "Station Science",
     "abstract": "Station Science mod adds several large parts designed to be integrated into a permanent space station.",

--- a/StationScience/StationScience-1.4.ckan
+++ b/StationScience/StationScience-1.4.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220216",
         "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.4",

--- a/StationScience/StationScience-1.5.ckan
+++ b/StationScience/StationScience-1.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "StationScience",
     "name": "Station Science",
     "abstract": "Station Science mod adds several large parts designed to be integrated into a permanent space station.",

--- a/StationScience/StationScience-1.5.ckan
+++ b/StationScience/StationScience-1.5.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
         "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.5",
     "ksp_version_min": "1.0.2",

--- a/StationScience/StationScience-1.5.ckan
+++ b/StationScience/StationScience-1.5.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220216",
         "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.5",

--- a/StationScience/StationScience-1.6.ckan
+++ b/StationScience/StationScience-1.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "StationScience",
     "name": "Station Science",
     "abstract": "Station Science mod adds several large parts designed to be integrated into a permanent space station.",

--- a/StationScience/StationScience-1.6.ckan
+++ b/StationScience/StationScience-1.6.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
         "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.6",
     "ksp_version_min": "1.1.0",

--- a/StationScience/StationScience-1.6.ckan
+++ b/StationScience/StationScience-1.6.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220216",
         "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.6",

--- a/StationScienceContinued/StationScienceContinued-2.1.0.ckan
+++ b/StationScienceContinued/StationScienceContinued-2.1.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "2.1.0",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-2.5.3.frozen
+++ b/StationScienceContinued/StationScienceContinued-2.5.3.frozen
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "2.5.3",
     "ksp_version_min": "1.6.0",

--- a/StationScienceContinued/StationScienceContinued-v2.1.1.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.1.1.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.1.1",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-v2.1.2.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.1.2.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.1.2",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-v2.1.3.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.1.3.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.1.3",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-v2.2.0.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.2.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.2.0",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-v2.2.1.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.2.1.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.2.1",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-v2.3.0.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.3.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.3.0",
     "ksp_version_min": "1.3.0",

--- a/StationScienceContinued/StationScienceContinued-v2.4.0.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.4.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.4.0",
     "ksp_version_min": "1.4.0",

--- a/StationScienceContinued/StationScienceContinued-v2.4.1.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.4.1.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.4.1",
     "ksp_version_min": "1.4.0",

--- a/StationScienceContinued/StationScienceContinued-v2.4.2.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.4.2.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.4.2",
     "ksp_version_min": "1.4.0",

--- a/StationScienceContinued/StationScienceContinued-v2.5.2.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.5.2.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.5.2",
     "ksp_version": "1.6",

--- a/StationScienceContinued/StationScienceContinued-v2.5.3.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.5.3.ckan
@@ -13,7 +13,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-*",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "tags": [
         "parts",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.1.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.2.1.0",
     "ksp_version": "0.90.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.2.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.2.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.2.2.0",
     "ksp_version": "0.90.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.2.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.3.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.3.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.3.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.2.3.0",
     "ksp_version": "0.90.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.3.0.0",
     "ksp_version": "1.0.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.1.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.1.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.1.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.3.0.1",
     "ksp_version": "1.0.2",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.1.0.ckan
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.3.1.0",
     "ksp_version": "1.0.4",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.4.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.4.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.4.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.4.0.0.ckan
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.4.0.0",
     "ksp_version": "1.0.5",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.5.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.5.0.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.5.0.0",
     "ksp_version_min": "1.1.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.5.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.5.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.5.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.5.1.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.5.1.0",
     "ksp_version_min": "1.1.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.5.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.5.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.0.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.6.0.0",
     "ksp_version_min": "1.2.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.1.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.6.1.0",
     "ksp_version_min": "1.2.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.2.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.2.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.2.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.6.2.0",
     "ksp_version_min": "1.3.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.3.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.3.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.3.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.6.3.0",
     "ksp_version_min": "1.4.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.7.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.7.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.7.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.7.1.0.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.7.1.0",
     "ksp_version_min": "1.7.0",

--- a/WaterSounds/WaterSounds-2.2.ckan
+++ b/WaterSounds/WaterSounds-2.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "WaterSounds",
     "name": "Water Sounds",
     "abstract": "Adds the sound of water gently lapping at the sides of your craft when splashed down.",

--- a/kTunes/kTunes-1.2.ckan
+++ b/kTunes/kTunes-1.2.ckan
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/89055",
         "repository": "https://github.com/cwc/kTunes",
         "bugtracker": "https://github.com/cwc/kTunes/issues",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/222945-ktunes"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/222945-ktunes"
     },
     "version": "1.2",
     "ksp_version_min": "0.24.2",

--- a/kTunes/kTunes-1.2.ckan
+++ b/kTunes/kTunes-1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "kTunes",
     "name": "kTunes",
     "abstract": "Control your media player from within KSP.",

--- a/surfacelights/surfacelights-1.0.ckan
+++ b/surfacelights/surfacelights-1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Lights",
     "abstract": "Surface mounted stock-alike lights for self-illumination",

--- a/surfacelights/surfacelights-1.0.ckan
+++ b/surfacelights/surfacelights-1.0.ckan
@@ -9,7 +9,7 @@
     "license": "CC-BY-NC-ND-3.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/57778",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220942-surfacelights-surface-mounted-stock-alike-lights"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220942-surfacelights-surface-mounted-stock-alike-lights"
     },
     "version": "1.0",
     "ksp_version_min": "0.24",

--- a/surfacelights/surfacelights-1.10.ckan
+++ b/surfacelights/surfacelights-1.10.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.11.ckan
+++ b/surfacelights/surfacelights-1.11.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.12.ckan
+++ b/surfacelights/surfacelights-1.12.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.13.ckan
+++ b/surfacelights/surfacelights-1.13.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.4.0.ckan
+++ b/surfacelights/surfacelights-1.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Stock-Alike Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations and ships.",

--- a/surfacelights/surfacelights-1.5.ckan
+++ b/surfacelights/surfacelights-1.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Stock-Alike Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations and ships.",

--- a/surfacelights/surfacelights-1.6.ckan
+++ b/surfacelights/surfacelights-1.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Stock-Alike Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations and ships.",

--- a/surfacelights/surfacelights-1.7.ckan
+++ b/surfacelights/surfacelights-1.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.8.ckan
+++ b/surfacelights/surfacelights-1.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.9.ckan
+++ b/surfacelights/surfacelights-1.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",


### PR DESCRIPTION
Historical follow-up for https://github.com/KSP-CKAN/NetKAN/pull/7687

This PR changes every `x_ci` to `ci`, `x_preview` to `x_screenshot`, and `x_curse` to `curse`.
Additionally, one mistyped `respository` resource has been fixed and the `x_textures` property has been removed from `NavBallTextureExport`, since it doesn't have any real use (especially because the bit.ly link has long expired).

Before:
```
18559 "homepage"
14681 "repository"
9662  "x_screenshot"
9529  "spacedock"
3483  "kerbalstuff"
1320  "bugtracker"
475   "manual"
413   "license"
195   "ci"
187   "metanetkan"
181   "x_curse"
139   "curse"
26    "x_ci"
24    "x_preview"
2     "x_textures"
1     "respository"
```

After
```
18559 "homepage"
14681 "repository"
9683  "x_screenshot"
9529  "spacedock"
3483  "kerbalstuff"
1320  "bugtracker"
475   "manual"
413   "license"
320   "curse"
221   "ci"
187   "metanetkan"
```

---

The commands I hacked together, because I might need them again later:
```sh
## To display the count of each resource type.
for C in **/*; do
    cat $C | jq '
        select(.resources) |
            .resources | keys[]
    '
done | sort | uniq -c | sort -n

## To display which mods have the resource type XXX
for C in **/*; do
    cat $C | jq '
        select(.resources and .resources.curse) |
            [.identifier, .version, (.spec_version | tostring)] | join("-")
    '
done # 2>/dev/null

## To swap out `"x_curse"` with `"curse"`
sed -i "s/\"x_curse\"/\"curse\"/" */*

## To bump spec_version for ckans with `"curse"` resource:
for F in $(grep -l \"curse\" */*); do
	sed -ri "s/(\"spec_version\"\s*:\s*)\"?([a-zA-Z0-9.]+)\"?/\1\"v1\.20\"/gm" $F
done
```