### PR TITLE
Clean up second group of historical resource properties

### DIFF
--- a/BoxSat-prototypes/BoxSat-prototypes-A.02c.kerbalstuff
+++ b/BoxSat-prototypes/BoxSat-prototypes-A.02c.kerbalstuff
@@ -1,12 +1,12 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "BoxSat-prototypes",
     "name": "BoxSat prototype parts",
     "release_status": "development",
     "license": "restricted",
     "x_netkan_license_ok": true,
     "resources": {
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
         "kerbalstuff": "https://kerbalstuff.com/mod/118/BoxSat"
     },
     "install": [

--- a/BoxSat-prototypes/BoxSat-prototypes-A.02d.kerbalstuff
+++ b/BoxSat-prototypes/BoxSat-prototypes-A.02d.kerbalstuff
@@ -1,12 +1,12 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "BoxSat-prototypes",
     "name": "BoxSat prototype parts",
     "release_status": "development",
     "license": "restricted",
     "x_netkan_license_ok": true,
     "resources": {
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
         "kerbalstuff": "https://kerbalstuff.com/mod/118/BoxSat"
     },
     "install": [

--- a/BoxSat-prototypes/BoxSat-prototypes-A.02e.ckan
+++ b/BoxSat-prototypes/BoxSat-prototypes-A.02e.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "BoxSat-prototypes",
     "name": "BoxSat prototype parts",
     "abstract": "A modular, stackable, serviceable, & customizable satellite in a box!",
@@ -11,7 +11,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91616",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat"
     },
     "version": "A.02e",
     "ksp_version": "1.0.2",

--- a/CrewManifest/CrewManifest-0.5.10-25.ckan
+++ b/CrewManifest/CrewManifest-0.5.10-25.ckan
@@ -8,7 +8,6 @@
         "sarbian"
     ],
     "license": "MIT",
-    "x_ci_version_base": "0.5.10",
     "install": [
         {
             "find": "CrewManifest",
@@ -16,13 +15,13 @@
         }
     ],
     "resources": {
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/",
+        "ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60936",
         "repository": "https://github.com/sarbian/CrewManifest/"
     },
     "ksp_version": "0.90",
     "version": "0.5.10-25",
-    "download": "https://ksp.sarbian.com/jenkins/job/CrewManifest/lastStableBuild/artifact/CrewManifest-0.6.0.0.zip",
+    "download": "https://ksp.sarbian.com/jenkins/job/CrewManifest/25/artifact/CrewManifest-0.6.0.0.zip",
     "x_generated_by": "netkan",
     "download_size": 24595
 }

--- a/CrewManifest/CrewManifest-0.5.10-26.ckan
+++ b/CrewManifest/CrewManifest-0.5.10-26.ckan
@@ -8,7 +8,6 @@
         "sarbian"
     ],
     "license": "MIT",
-    "x_ci_version_base": "0.5.10",
     "install": [
         {
             "find": "CrewManifest",
@@ -16,13 +15,13 @@
         }
     ],
     "resources": {
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/",
+        "ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60936",
         "repository": "https://github.com/sarbian/CrewManifest/"
     },
     "ksp_version": "0.90",
     "version": "0.5.10-26",
-    "download": "https://ksp.sarbian.com/jenkins/job/CrewManifest/lastStableBuild/artifact/CrewManifest-0.6.1.0.zip",
+    "download": "https://ksp.sarbian.com/jenkins/job/CrewManifest/26/artifact/CrewManifest-0.6.1.0.zip",
     "x_generated_by": "netkan",
     "download_size": 24630
 }

--- a/CrewManifest/CrewManifest-0.5.10.ckan
+++ b/CrewManifest/CrewManifest-0.5.10.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60936",
         "repository": "https://github.com/sarbian/CrewManifest/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/"
     },
     "version": "0.5.10",
     "ksp_version": "0.90",

--- a/CrewManifest/CrewManifest-0.6.0.ckan
+++ b/CrewManifest/CrewManifest-0.6.0.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60936",
         "repository": "https://github.com/sarbian/CrewManifest/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/CrewManifest/"
     },
     "version": "0.6.0",
     "ksp_version": "1.0",

--- a/CustomBarnKit/CustomBarnKit-1.1.1.ckan
+++ b/CustomBarnKit/CustomBarnKit-1.1.1.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/121100",
         "repository": "https://github.com/sarbian/CustomBarnKit",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CustomBarnKit/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/CustomBarnKit/"
     },
     "version": "1.1.1",
     "ksp_version": "1.0.2",

--- a/CustomBarnKit/CustomBarnKit-1.1.2.ckan
+++ b/CustomBarnKit/CustomBarnKit-1.1.2.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/121100",
         "repository": "https://github.com/sarbian/CustomBarnKit",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/CustomBarnKit/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/CustomBarnKit/"
     },
     "version": "1.1.2",
     "ksp_version": "1.0.5",

--- a/DiscordRP/DiscordRP-1.0.3.ckan
+++ b/DiscordRP/DiscordRP-1.0.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "DiscordRP",
     "name": "DiscordRP",
     "abstract": "DiscordRP introduces Rich Presence integration for KSP",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.0.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.1.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.2.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.0.3.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.0.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.1.1.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.1.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.10.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.10.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.11.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.11.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.2.0.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.2.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.2.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.3.0.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.4.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.5.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.6.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.7.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.8.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/EasyVesselSwitch/EasyVesselSwitch-1.9.ckan
+++ b/EasyVesselSwitch/EasyVesselSwitch-1.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "EasyVesselSwitch",
     "name": "Easy Vessel Switch (EVS)",
     "abstract": "The stock game doesn't offer a consistent model of the camera positioning when the active vessel is switched. The EVS does. Now, your camera won't jump randomly as you switch between the vessels. Additionally to that you get some more features (see the forum).",

--- a/ExperimentTracker/ExperimentTracker-v1.2.ckan
+++ b/ExperimentTracker/ExperimentTracker-v1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ExperimentTracker",
     "name": "ExperimentTracker",
     "abstract": "This mod lists all science experiments and helps to deploy them fast and easy.",

--- a/ExperimentTracker/ExperimentTracker-v1.3.ckan
+++ b/ExperimentTracker/ExperimentTracker-v1.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ExperimentTracker",
     "name": "ExperimentTracker",
     "abstract": "This mod lists all science experiments and helps to deploy them fast and easy.",


### PR DESCRIPTION
Successor to #1818, see #1816.

> This PR changes every x_ci to ci, x_preview to x_screenshot, and x_curse to curse.
Additionally, one mistyped respository resource has been fixed and the x_textures property has been removed from NavBallTextureExport, since it doesn't have any real use (especially because the bit.ly link has long expired).