### PR TITLE
Clean up third group of historical resource properties

### DIFF
--- a/FMRS/FMRS-1.0.0.kerbalstuff
+++ b/FMRS/FMRS-1.0.0.kerbalstuff
@@ -3,10 +3,9 @@
     "identifier": "FMRS",
     "resources": {
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
         "kerbalstuff": "https://kerbalstuff.com/mod/172/Flight%20Manager%20for%20Reusable%20Stages%20[FMRS]",
-        "x_screenshot": "https://kerbalstuff.com/content/SIT89_726/Flight_Manager_for_Reusable_Stages_FMRS/Flight_Manager_for_Reusable_Stages_FMRS.png"
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1"
     },
     "depends": [
         {

--- a/FMRS/FMRS-1.0.00.kerbalstuff
+++ b/FMRS/FMRS-1.0.00.kerbalstuff
@@ -9,8 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
         "kerbalstuff": "https://kerbalstuff.com/mod/172/Flight%20Manager%20for%20Reusable%20Stages%20[FMRS]",
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
-        "x_screenshot": "https://kerbalstuff.com/content/SIT89_726/Flight_Manager_for_Reusable_Stages_FMRS/Flight_Manager_for_Reusable_Stages_FMRS.png"
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1"
     },
     "version": "1.0.00",
     "ksp_version_min": "1.0.2",

--- a/FMRS/FMRS-v0.3.00.kerbalstuff
+++ b/FMRS/FMRS-v0.3.00.kerbalstuff
@@ -3,7 +3,7 @@
   "identifier": "FMRS",
   "resources": {
     "repository": "https://github.com/SIT89/FMRS",
-    "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
+    "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1",
     "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
     "kerbalstuff": "https://kerbalstuff.com/mod/172/Flight%20Manager%20for%20Reusable%20Stages%20%5BFMRS%5D"
   },

--- a/FMRS/FMRS-v0.3.01.kerbalstuff
+++ b/FMRS/FMRS-v0.3.01.kerbalstuff
@@ -3,7 +3,7 @@
     "identifier": "FMRS",
     "resources": {
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
         "kerbalstuff": "https://kerbalstuff.com/mod/172/Flight%20Manager%20for%20Reusable%20Stages%20%5BFMRS%5D"
     },

--- a/FMRS/FMRS-v0.3.02.kerbalstuff
+++ b/FMRS/FMRS-v0.3.02.kerbalstuff
@@ -3,7 +3,7 @@
     "identifier": "FMRS",
     "resources": {
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
         "kerbalstuff": "https://kerbalstuff.com/mod/172/Flight%20Manager%20for%20Reusable%20Stages%20[FMRS]"
     },

--- a/FMRS/FMRS-v1.0.1.ckan
+++ b/FMRS/FMRS-v1.0.1.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80292-0-23-5-Flight-Manager-for-Reusable-Stages-(FMRS)",
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1"
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1"
     },
     "version": "v1.0.1",
     "ksp_version_min": "1.0.2",

--- a/FMRS/FMRS-v1.1.0.1.ckan
+++ b/FMRS/FMRS-v1.1.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FMRS",
     "name": "Flight Manager for Reusable Stages [FMRS]",
     "abstract": "FMRS lets you jump back and forth in time. So you can land an recover your launch vehicles.",
@@ -11,8 +11,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72605-110-flight-manager-for-reusable-stages-fmrs-x110-experimental/",
         "curse": "https://kerbal.curseforge.com/projects/220566",
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1",
-        "x_screenshot": "https://media.forgecdn.net/avatars/thumbnails/9/964/120/120/635443108968717464.png"
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1"
     },
     "version": "v1.1.0.1",
     "ksp_version_min": "1.1.0",

--- a/FinalFrontier/FinalFrontier-0.5.10-178.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.10-178.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "The Final Frontier plugin will handle ribbons for extraordinary merits for you. And the number of missions flown (i.e. vessel recovered) is recorded, too.",
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.10-178",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.5.11-246.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.11-246.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.11-246",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.5.14-304.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.14-304.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.14-304",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.5.15.308.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.15.308.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.15.308",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.5.16-317.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.16-317.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.16-317",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.5.9-177.ckan
+++ b/FinalFrontier/FinalFrontier-0.5.9-177.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "The Final Frontier plugin will handle ribbons for extraordinary merits for you. And the number of missions flown (i.e. vessel recovered) is recorded, too.",
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.5.9-177",
     "ksp_version": "0.25",

--- a/FinalFrontier/FinalFrontier-0.6.1-604.ckan
+++ b/FinalFrontier/FinalFrontier-0.6.1-604.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.6.1-604",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.6.4-689.ckan
+++ b/FinalFrontier/FinalFrontier-0.6.4-689.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.6.4-689",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.6.5-697.ckan
+++ b/FinalFrontier/FinalFrontier-0.6.5-697.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.6.5-697",
     "ksp_version": "0.90",

--- a/FinalFrontier/FinalFrontier-0.7.12-985.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.12-985.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.12-985",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.7.14-1042.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.14-1042.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.14-1042",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.7.15-1047.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.15-1047.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.15-1047",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.7.4-870.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.4-870.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.4-870",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.7.5-933.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.5-933.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.5-933",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.7.6-949.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.6-949.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.6-949",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.7.7-956.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.7-956.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.7-956",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.7.8-969.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.8-969.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.8-969",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.7.9-972.ckan
+++ b/FinalFrontier/FinalFrontier-0.7.9-972.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.7.9-972",
     "ksp_version": "1.0.0",

--- a/FinalFrontier/FinalFrontier-0.8.1-1282.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.1-1282.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.8.1-1282",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.8.10-1609.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.10-1609.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.8.10-1609",

--- a/FinalFrontier/FinalFrontier-0.8.13-1728.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.13-1728.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.8.13-1728",

--- a/FinalFrontier/FinalFrontier-0.8.2-1285.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.2-1285.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.8.2-1285",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.8.3-1361.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.3-1361.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier"
     },
     "version": "0.8.3-1361",
     "ksp_version": "1.0.2",

--- a/FinalFrontier/FinalFrontier-0.8.6-1370.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.6-1370.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.8.6-1370",

--- a/FinalFrontier/FinalFrontier-0.8.8-1410.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.8-1410.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.8.8-1410",

--- a/FinalFrontier/FinalFrontier-0.8.9-1414.ckan
+++ b/FinalFrontier/FinalFrontier-0.8.9-1414.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.8.9-1414",

--- a/FinalFrontier/FinalFrontier-0.9.1-1749.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.1-1749.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.9.1-1749",

--- a/FinalFrontier/FinalFrontier-0.9.4-1798.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.4-1798.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.9.4-1798",

--- a/FinalFrontier/FinalFrontier-0.9.6-1826.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.6-1826.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.9.6-1826",

--- a/FinalFrontier/FinalFrontier-0.9.8-1882.ckan
+++ b/FinalFrontier/FinalFrontier-0.9.8-1882.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "FinalFrontier",
     "name": "Final Frontier",
     "abstract": "kerbal individual merits",
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/67246-0-24-0-Final-Frontier-kerbal-individual-merits-0-5-3",
         "repository": "http://github.com/Nereid42/FinalFrontier",
         "kerbalstuff": "https://kerbalstuff.com/mod/428/Final%20Frontier",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
+        "curse": "http://www.curse.com/ksp-mods/kerbal/221413-final-frontier",
         "x_screenshot": "https://kerbalstuff.com/content/Nereid_5234/Final_Frontier/Final_Frontier.jpg"
     },
     "version": "0.9.8-1882",


### PR DESCRIPTION
Successor to #1819, see #1816.

> This PR changes every `x_ci` to `ci`, `x_preview` to `x_screenshot`, and `x_curse` to `curse`.
Additionally, one mistyped respository resource has been fixed and the `x_textures` property has been removed from `NavBallTextureExport`, since it doesn't have any real use (especially because the bit.ly link has long expired).