### PR TITLE
Clean up fourth group of historical resource properties

### DIFF
--- a/ForScience/ForScience-v1.4.1.ckan
+++ b/ForScience/ForScience-v1.4.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "ForScience",
     "name": "ForScience!",
     "abstract": "ForScience is autopilot for running, collecting and resetting experiments.",

--- a/ForScience/ForScience-v1.5.0.ckan
+++ b/ForScience/ForScience-v1.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.5",
+    "spec_version": "v1.20",
     "identifier": "ForScience",
     "name": "ForScience!",
     "abstract": "ForScience is autopilot for running, collecting and resetting experiments.",

--- a/ForScience/ForScience-v1.5.2.ckan
+++ b/ForScience/ForScience-v1.5.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.5",
+    "spec_version": "v1.20",
     "identifier": "ForScience",
     "name": "ForScience!",
     "abstract": "ForScience is autopilot for running, collecting and resetting experiments.",

--- a/Fusebox/Fusebox-1.2.ckan
+++ b/Fusebox/Fusebox-1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "Fusebox",
     "name": "Fusebox",
     "abstract": "Fusebox - electric charge tracker and build helper.",
@@ -7,7 +7,7 @@
     "license": "GPL-2.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/50077",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220284-fusebox"
+        "curse": "http://kerbal.curseforge.com/plugins/220284-fusebox"
     },
     "version": "1.2",
     "ksp_version": "0.90",

--- a/GCMonitor/GCMonitor-1.2.1.0.ckan
+++ b/GCMonitor/GCMonitor-1.2.1.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92907",
         "repository": "https://github.com/sarbian/GCMonitor/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
     },
     "version": "1.2.1.0",
     "ksp_version": "0.90",

--- a/GCMonitor/GCMonitor-1.2.2.0.ckan
+++ b/GCMonitor/GCMonitor-1.2.2.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92907",
         "repository": "https://github.com/sarbian/GCMonitor/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
     },
     "version": "1.2.2.0",
     "ksp_version": "0.90",

--- a/GCMonitor/GCMonitor-1.2.3.0.ckan
+++ b/GCMonitor/GCMonitor-1.2.3.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92907",
         "repository": "https://github.com/sarbian/GCMonitor/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
     },
     "version": "1.2.3.0",
     "ksp_version": "0.90",

--- a/GCMonitor/GCMonitor-1.2.4.0.ckan
+++ b/GCMonitor/GCMonitor-1.2.4.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92907",
         "repository": "https://github.com/sarbian/GCMonitor/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/GCMonitor/"
     },
     "version": "1.2.4.0",
     "ksp_version": "1.0.2",

--- a/HGR-Props/HGR-Props-1.2.1.ckan
+++ b/HGR-Props/HGR-Props-1.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "HGR-Props",
     "name": "HGR Props",
     "abstract": "Common props for HGR packs",
@@ -10,7 +10,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60974",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
     },
     "version": "1.2.1",
     "ksp_version": "1.0.2",

--- a/HGR-Props/HGR-Props-1.3.0.kerbalstuff
+++ b/HGR-Props/HGR-Props-1.3.0.kerbalstuff
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "HGR-Props",
     "name": "HGR Props",
     "abstract": "A set of 1.875m parts to fill the gap between the basic and Rockomax size parts",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60974",
         "kerbalstuff": "https://kerbalstuff.com/mod/869/HGR%201.875m%20Parts",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts",
         "x_screenshot": "https://kerbalstuff.com/content/OrionKermin_9505/HGR_1.875m_Parts/HGR_1.875m_Parts-1433253511.7370584.png"
     },
     "version": "1.3.0",

--- a/HGR/HGR-1.2.1.ckan
+++ b/HGR/HGR-1.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "HGR",
     "name": "HGR 1.875m parts",
     "abstract": "Stock alike command pods and an 1.875m diameter of parts",
@@ -10,7 +10,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60974",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
     },
     "version": "1.2.1",
     "ksp_version": "1.0.2",

--- a/HGR/HGR-1.3.0.kerbalstuff
+++ b/HGR/HGR-1.3.0.kerbalstuff
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "HGR",
     "name": "HGR 1.875m Parts",
     "abstract": "A set of 1.875m parts to fill the gap between the basic and Rockomax size parts",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/60974",
         "kerbalstuff": "https://kerbalstuff.com/mod/869/HGR%201.875m%20Parts",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts",
         "x_screenshot": "https://kerbalstuff.com/content/OrionKermin_9505/HGR_1.875m_Parts/HGR_1.875m_Parts-1433253511.7370584.png"
     },
     "version": "1.3.0",

--- a/HooliganLabsAirships/HooliganLabsAirships-3.0.0.ckan
+++ b/HooliganLabsAirships/HooliganLabsAirships-3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HooliganLabsAirships",
     "name": "HL Airships",
     "abstract": "HL Airships adds several airship parts to the game, allowing you to build and design absurd flying contraptions that would make Willy Wonka proud.",
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/53961",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220395-hl-airships-v3-0-0-for-ksp-0-25"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220395-hl-airships-v3-0-0-for-ksp-0-25"
     },
     "version": "3.0.0",
     "ksp_version": "0.25",

--- a/HullcamVDS/HullcamVDS-0.33.ckan
+++ b/HullcamVDS/HullcamVDS-0.33.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
     },
     "version": "0.33",
     "ksp_version": "0.90",

--- a/HullcamVDS/HullcamVDS-0.34.1.ckan
+++ b/HullcamVDS/HullcamVDS-0.34.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
     },
     "version": "0.34.1",
     "ksp_version": "1.0.2",

--- a/HullcamVDS/HullcamVDS-0.34.ckan
+++ b/HullcamVDS/HullcamVDS-0.34.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
     },
     "version": "0.34",
     "ksp_version": "1.0.0",

--- a/HullcamVDS/HullcamVDS-0.40.ckan
+++ b/HullcamVDS/HullcamVDS-0.40.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "repository": "http://www.mediafire.com/download/u6j84zu6x8uauau/HullCamerav0.3-src.zip",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
         "x_screenshot": "https://kerbalstuff.com/content/Albert_VDS_5574/Hullcam_VDS/Hullcam_VDS-1431085757.6662536.jpg"
     },
     "version": "0.40",

--- a/HullcamVDS/HullcamVDS-0.50.ckan
+++ b/HullcamVDS/HullcamVDS-0.50.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "repository": "http://www.mediafire.com/download/u6j84zu6x8uauau/HullCamerav0.3-src.zip",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
         "x_screenshot": "https://kerbalstuff.com/content/Albert_VDS_5574/Hullcam_VDS/Hullcam_VDS-1431085757.6662536.jpg"
     },
     "version": "0.50",

--- a/HullcamVDS/HullcamVDS-0.51.ckan
+++ b/HullcamVDS/HullcamVDS-0.51.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
         "repository": "http://www.mediafire.com/download/u6j84zu6x8uauau/HullCamerav0.3-src.zip",
         "kerbalstuff": "https://kerbalstuff.com/mod/450/Hullcam%20VDS",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds",
         "x_screenshot": "https://kerbalstuff.com/content/Albert_VDS_5574/Hullcam_VDS/Hullcam_VDS-1431085757.6662536.jpg"
     },
     "version": "0.51",

--- a/HullcamVDS/HullcamVDS-0.52.ckan
+++ b/HullcamVDS/HullcamVDS-0.52.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "name": "Hullcam VDS",
     "abstract": "Hullcam let's you add cameras to any part of your vehicle or construction.",
@@ -7,7 +7,7 @@
     "license": "LGPL-3.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/46365-0-90-Hullcam-VDS-0-90-update-Updated-16-Dec",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
     },
     "version": "0.52",
     "ksp_version": "1.1.0",

--- a/HumanColoredFaces/HumanColoredFaces-17.ckan
+++ b/HumanColoredFaces/HumanColoredFaces-17.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "HumanColoredFaces",
     "name": "Human Colored Faces",
     "abstract": "Giving the Kerbals human colored heads.",


### PR DESCRIPTION
Successor to #1820, see #1816.

> This PR changes every `x_ci` to `ci`, `x_preview` to `x_screenshot`, and `x_curse` to `curse`.
Additionally, one mistyped respository resource has been fixed and the `x_textures` property has been removed from `NavBallTextureExport`, since it doesn't have any real use (especially because the bit.ly link has long expired).

ckan compat add 1.2