### PR TITLE
Clean up fifth group of historical resource properties

### DIFF
--- a/KAS/KAS-0.4.10.ckan
+++ b/KAS/KAS-0.4.10.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.4.7.ckan
+++ b/KAS/KAS-0.4.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.4.8.ckan
+++ b/KAS/KAS-0.4.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.4.9.ckan
+++ b/KAS/KAS-0.4.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.4.ckan
+++ b/KAS/KAS-0.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.0.ckan
+++ b/KAS/KAS-0.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.1.ckan
+++ b/KAS/KAS-0.5.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.2.ckan
+++ b/KAS/KAS-0.5.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.3.ckan
+++ b/KAS/KAS-0.5.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.4.ckan
+++ b/KAS/KAS-0.5.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.5.ckan
+++ b/KAS/KAS-0.5.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.6.ckan
+++ b/KAS/KAS-0.5.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.7.ckan
+++ b/KAS/KAS-0.5.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.8.0.ckan
+++ b/KAS/KAS-0.5.8.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.5.9.0.ckan
+++ b/KAS/KAS-0.5.9.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.6.0.0.ckan
+++ b/KAS/KAS-0.6.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.6.1.0.ckan
+++ b/KAS/KAS-0.6.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.6.2.0.ckan
+++ b/KAS/KAS-0.6.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.6.3.0.ckan
+++ b/KAS/KAS-0.6.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-0.6.4.ckan
+++ b/KAS/KAS-0.6.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-1.0.ckan
+++ b/KAS/KAS-1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-1.1.ckan
+++ b/KAS/KAS-1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-1.2.ckan
+++ b/KAS/KAS-1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-1.3.ckan
+++ b/KAS/KAS-1.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",

--- a/KAS/KAS-1.4.ckan
+++ b/KAS/KAS-1.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KAS",
     "name": "Kerbal Attachment System",
     "abstract": "KAS introduces new gameplay mechanics by adding winches, struts, and pipes. Now you can easily connect vessels in EVA without docking them!",


### PR DESCRIPTION
Successor to #1820, see #1816.

> This PR changes every `x_ci` to `ci`, `x_preview` to `x_screenshot`, and `x_curse` to `curse` (and adjusts the `spec_version` where needed).
Additionally, one mistyped respository resource has been fixed and the `x_textures` property has been removed from `NavBallTextureExport`, since it doesn't have any real use (especially because the bit.ly link has long expired).

Looks like this one only contains spec version updates because it hasn't been updated for the `curse` field when it has been added back then.
I'll submit it nevertheless, does no harm.
I'll check in the NetKAN repo after I'm through with this whether some netkans containing the `curse` resource also need the spec adjusted (aside from those that I added myself)