### PR TITLE
Clean up sixth group of historical resource properties

### DIFF
--- a/KIS/KIS-1.0.0.ckan
+++ b/KIS/KIS-1.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.0.1.ckan
+++ b/KIS/KIS-1.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.0.2.ckan
+++ b/KIS/KIS-1.0.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.0.ckan
+++ b/KIS/KIS-1.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.1.ckan
+++ b/KIS/KIS-1.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.2.ckan
+++ b/KIS/KIS-1.1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.3.ckan
+++ b/KIS/KIS-1.1.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.4.ckan
+++ b/KIS/KIS-1.1.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.1.5.ckan
+++ b/KIS/KIS-1.1.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.10.ckan
+++ b/KIS/KIS-1.10.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.11.ckan
+++ b/KIS/KIS-1.11.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.12.ckan
+++ b/KIS/KIS-1.12.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.13.ckan
+++ b/KIS/KIS-1.13.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.14.ckan
+++ b/KIS/KIS-1.14.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.15.ckan
+++ b/KIS/KIS-1.15.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.16.ckan
+++ b/KIS/KIS-1.16.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.17.ckan
+++ b/KIS/KIS-1.17.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.18.ckan
+++ b/KIS/KIS-1.18.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.19.ckan
+++ b/KIS/KIS-1.19.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.0.ckan
+++ b/KIS/KIS-1.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.1.ckan
+++ b/KIS/KIS-1.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.10.0.ckan
+++ b/KIS/KIS-1.2.10.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.11.0.ckan
+++ b/KIS/KIS-1.2.11.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.12.0.ckan
+++ b/KIS/KIS-1.2.12.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.2.ckan
+++ b/KIS/KIS-1.2.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.3.ckan
+++ b/KIS/KIS-1.2.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.4.ckan
+++ b/KIS/KIS-1.2.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.5.ckan
+++ b/KIS/KIS-1.2.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.6.ckan
+++ b/KIS/KIS-1.2.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.7.ckan
+++ b/KIS/KIS-1.2.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.8.ckan
+++ b/KIS/KIS-1.2.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.2.9.ckan
+++ b/KIS/KIS-1.2.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.20.ckan
+++ b/KIS/KIS-1.20.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.21.ckan
+++ b/KIS/KIS-1.21.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.22.ckan
+++ b/KIS/KIS-1.22.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.3.0.0.ckan
+++ b/KIS/KIS-1.3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.3.1.0.ckan
+++ b/KIS/KIS-1.3.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.4.0.ckan
+++ b/KIS/KIS-1.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.4.1.ckan
+++ b/KIS/KIS-1.4.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.4.2.ckan
+++ b/KIS/KIS-1.4.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.4.3.ckan
+++ b/KIS/KIS-1.4.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.4.4.ckan
+++ b/KIS/KIS-1.4.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.5.0.ckan
+++ b/KIS/KIS-1.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.6.ckan
+++ b/KIS/KIS-1.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.7.ckan
+++ b/KIS/KIS-1.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.8.ckan
+++ b/KIS/KIS-1.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",

--- a/KIS/KIS-1.9.ckan
+++ b/KIS/KIS-1.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KIS",
     "name": "Kerbal Inventory System",
     "abstract": "KIS introduces new gameplay mechanics by adding a brand new inventory system and EVA usables items as tools. You want to build a rover on Duna from scratch? Now you can...",


### PR DESCRIPTION
Successor to #1822, see #1816.

> This PR changes every `x_ci` to `ci`, `x_preview` to `x_screenshot`, and `x_curse` to `curse` (and adjusts the `spec_version` where needed).
Additionally, one mistyped respository resource has been fixed and the `x_textures` property has been removed from `NavBallTextureExport`, since it doesn't have any real use (especially because the bit.ly link has long expired).

Looks like this one only contains spec version updates because it hasn't been updated for the `curse` field when it has been added back then.
I'm submitting it nevertheless, does no harm.
I'll check in the NetKAN repo after I'm through with this whether some netkans containing the `curse` resource also need the spec adjusted (aside from those that I added myself)