### PR TITLE
Clean up seventh group of historical resource properties

### DIFF
--- a/KSPCalendar/KSPCalendar-1.5.ckan
+++ b/KSPCalendar/KSPCalendar-1.5.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "http://ksp.gurkensalat.com/archive/KSPCalendar-1.5.zip",
+    "download": "https://archive.org/download/KSPCalendar-1.5/B7244674-KSPCalendar-1.5.zip",
     "download_size": 11496,
     "download_hash": {
         "sha1": "B72446746493DB1078BD3A1BB3A95B27891F99B5",

--- a/KSPCalendar/KSPCalendar-1.5.ckan
+++ b/KSPCalendar/KSPCalendar-1.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KSPCalendar",
     "name": "KSPCalendar",
     "abstract": "Kerbin Date Calendar",
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/68270",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/223684-kerbin-date-calendar"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/223684-kerbin-date-calendar"
     },
     "version": "1.5",
     "ksp_version": "0.90",

--- a/KSPTips/KSPTips-1.0.0.1.ckan
+++ b/KSPTips/KSPTips-1.0.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KSPTips",
     "name": "KSP Tips",
     "abstract": "Plugin that provides 'Helpful' in game tips and tricks",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KSPTips",
         "license": "https://github.com/TriggerAu/KSPTips/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/416/KSP%20Tips",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
     },
     "version": "1.0.0.1",
     "ksp_version": "0.90",

--- a/KSPTips/KSPTips-2.0.0.0.ckan
+++ b/KSPTips/KSPTips-2.0.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KSPTips",
     "name": "KSP Tips",
     "abstract": "Plugin that provides 'Helpful' in game tips and tricks",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KSPTips",
         "license": "https://github.com/TriggerAu/KSPTips/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/416/KSP%20Tips",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
     },
     "version": "2.0.0.0",
     "ksp_version": "0.90",

--- a/KSPTips/KSPTips-2.1.0.0.ckan
+++ b/KSPTips/KSPTips-2.1.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KSPTips",
     "name": "KSP Tips",
     "abstract": "Plugin that provides 'Helpful' in game tips and tricks",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KSPTips",
         "license": "https://github.com/TriggerAu/KSPTips/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/416/KSP%20Tips",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
     },
     "version": "2.1.0.0",
     "ksp_version": "0.90",

--- a/KSPTips/KSPTips-3.0.0.0.ckan
+++ b/KSPTips/KSPTips-3.0.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KSPTips",
     "name": "KSP Tips",
     "abstract": "Plugin that provides 'Helpful' in game tips and tricks",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KSPTips",
         "license": "https://github.com/TriggerAu/KSPTips/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/416/KSP%20Tips",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
     },
     "version": "3.0.0.0",
     "ksp_version": "0.90",

--- a/KSPTips/KSPTips-4.0.0.0.ckan
+++ b/KSPTips/KSPTips-4.0.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KSPTips",
     "name": "KSP Tips",
     "abstract": "Plugin that provides 'Helpful' in game tips and tricks",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KSPTips",
         "license": "https://github.com/TriggerAu/KSPTips/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/416/KSP%20Tips",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips",
         "x_screenshot": "https://kerbalstuff.com/content/TriggerAu_1745/KSP_Tips/KSP_Tips.png"
     },
     "version": "4.0.0.0",

--- a/KerbalAdventure/KerbalAdventure-V1.0.ckan
+++ b/KerbalAdventure/KerbalAdventure-V1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KerbalAdventure",
     "name": "Kerbal Adventure",
     "abstract": "This mod introduces stories to the Kerbal Universe.  ",
@@ -7,7 +7,7 @@
     "license": "CC-BY-NC-SA-3.0",
     "resources": {
         "kerbalstuff": "https://kerbalstuff.com/mod/390/Kerbal%20Adventure",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/225951-kerbal-adventure"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/225951-kerbal-adventure"
     },
     "version": "V1.0",
     "ksp_version": "0.25.0",

--- a/KerbalAircraftExpansion/KerbalAircraftExpansion-3-v2.6.4.ckan
+++ b/KerbalAircraftExpansion/KerbalAircraftExpansion-3-v2.6.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.18",
+    "spec_version": "v1.20",
     "identifier": "KerbalAircraftExpansion",
     "name": "Kerbal Aircraft Expansion",
     "abstract": "A pack of select vanilla-inspired parts for your aircrafting needs.",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.0.4.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.0.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "Create reminder alarms to help manage flights and not warp past important times",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.0.4.0",
     "ksp_version": "0.25",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.0.5.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.0.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "Create reminder alarms to help manage flights and not warp past important times",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.0.5.0",
     "ksp_version": "0.25",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.0.6.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.0.6.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.0.6.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.1.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.1.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.1.0.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.1.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.1.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.1.1.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.1.2.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.1.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.1.2.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.10.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.10.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.10.0.0",
     "ksp_version_min": "1.6.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.11.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.11.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.11.0.0",
     "ksp_version_min": "1.7.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.2.0.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.2.1.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.2.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.2.2.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.3.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.2.3.0",
     "ksp_version_max": "0.90",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.2.4.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.2.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.2.4.0",
     "ksp_version": "0.90.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.3.0.0",
     "ksp_version": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.3.0.1",
     "ksp_version": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.1.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.3.1.1",
     "ksp_version_min": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.3.2.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.3.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.3.2.1",
     "ksp_version_min": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.4.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.4.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "kerbalstuff": "https://kerbalstuff.com/mod/231/Kerbal%20Alarm%20Clock",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.4.0.0",
     "ksp_version_min": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.5.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.5.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.5.0.0",
     "ksp_version_min": "1.0.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.6.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.6.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.6.1.0",
     "ksp_version_min": "1.1.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.6.2.1.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.6.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.6.2.1",
     "ksp_version_min": "1.1.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.6.3.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.6.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.6.3.0",
     "ksp_version_min": "1.1.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.7.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.7.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.7.0.0",
     "ksp_version_min": "1.1.3",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.7.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.7.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.7.1.0",
     "ksp_version_min": "1.1.3",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.0.0",
     "ksp_version_min": "1.2.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.1.0",
     "ksp_version_min": "1.2.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.2.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.2.0",
     "ksp_version_min": "1.2.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.3.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.3.0",
     "ksp_version_min": "1.2.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.4.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.4.0",
     "ksp_version_min": "1.2.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.8.5.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.8.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.8.5.0",
     "ksp_version_min": "1.3.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.9.0.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.9.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.9.0.0",
     "ksp_version_min": "1.4.0",

--- a/KerbalAlarmClock/KerbalAlarmClock-v3.9.1.0.ckan
+++ b/KerbalAlarmClock/KerbalAlarmClock-v3.9.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "KerbalAlarmClock",
     "name": "Kerbal Alarm Clock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/KerbalAlarmClock",
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "version": "v3.9.1.0",
     "ksp_version_min": "1.4.0",


### PR DESCRIPTION
Successor to #1825, see #1816.

> This PR changes every `x_ci` to `ci`, `x_preview` to `x_screenshot`, and `x_curse` to `curse` (and adjusts the `spec_version` where needed).
Additionally, one mistyped respository resource has been fixed and the `x_textures` property has been removed from `NavBallTextureExport`, since it doesn't have any real use (especially because the bit.ly link has long expired).