### PR TITLE
Clean up eighth group of historical resource properties

### DIFF
--- a/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.3.0.ckan
+++ b/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.3.0.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55985",
         "repository": "https://github.com/sarbian/km_Gimbal",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
     },
     "version": "3.0.3.0",
     "ksp_version": "1.0",

--- a/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.4.0.ckan
+++ b/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.4.0.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55985",
         "repository": "https://github.com/sarbian/km_Gimbal",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
     },
     "version": "3.0.4.0",
     "ksp_version": "1.0",

--- a/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.5.0.ckan
+++ b/KlockheedMartian-Gimbal/KlockheedMartian-Gimbal-3.0.5.0.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55985",
         "repository": "https://github.com/sarbian/km_Gimbal",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/km_Gimbal/"
     },
     "version": "3.0.5.0",
     "ksp_version": "1.0",

--- a/LanderControl/LanderControl-814.ckan
+++ b/LanderControl/LanderControl-814.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "LanderControl",
     "name": "Lander Orientation Improvement",
     "abstract": "This mod allows the user to fly the lander with a proper IVA configuration to make landing in IVA much better.",

--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/118088",
         "repository": "https://github.com/sarbian/ModularFlightIntegrator",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
     },
     "version": "1.0",
     "ksp_version_min": "1.0.0",

--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.0.repackaged0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.0.repackaged0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/118088",
         "repository": "https://github.com/sarbian/ModularFlightIntegrator",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
     },
     "version": "1.0.repackaged0",
     "ksp_version_min": "1.0.0",

--- a/ModularFlightIntegrator/ModularFlightIntegrator-1.1.0.0.ckan
+++ b/ModularFlightIntegrator/ModularFlightIntegrator-1.1.0.0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/118088",
         "repository": "https://github.com/sarbian/ModularFlightIntegrator",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/"
     },
     "version": "1.1.0.0",
     "ksp_version": "1.0.4",

--- a/ModuleManager/ModuleManager-2.5.10.ckan
+++ b/ModuleManager/ModuleManager-2.5.10.ckan
@@ -11,7 +11,7 @@
     "release_status": "stable",
     "ksp_version": "0.90",
     "resources": {
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/",
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager"
     },

--- a/ModuleManager/ModuleManager-2.5.9.ckan
+++ b/ModuleManager/ModuleManager-2.5.9.ckan
@@ -11,7 +11,7 @@
     "release_status": "stable",
     "ksp_version": "0.90",
     "resources": {
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/",
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/",
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager"
     },

--- a/ModuleManager/ModuleManager-2.6.0.ckan
+++ b/ModuleManager/ModuleManager-2.6.0.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
     },
     "version": "2.6.0",
     "ksp_version": "0.90",

--- a/ModuleManager/ModuleManager-2.6.1.ckan
+++ b/ModuleManager/ModuleManager-2.6.1.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
     },
     "version": "2.6.1",
     "ksp_version": "1.0.0",

--- a/ModuleManager/ModuleManager-2.6.2.ckan
+++ b/ModuleManager/ModuleManager-2.6.2.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
     },
     "version": "2.6.2",
     "ksp_version": "1.0",

--- a/ModuleManager/ModuleManager-2.6.3.ckan
+++ b/ModuleManager/ModuleManager-2.6.3.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
     },
     "version": "2.6.3",
     "ksp_version": "1.0",

--- a/ModuleManager/ModuleManager-2.6.5.ckan
+++ b/ModuleManager/ModuleManager-2.6.5.ckan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
     },
     "version": "2.6.5",
     "ksp_version": "1.0",

--- a/NavBallTextureExport/NavBallTextureExport-1.3.ckan
+++ b/NavBallTextureExport/NavBallTextureExport-1.3.ckan
@@ -9,8 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/63113-making-high-contrast-nav-ball/&do=findComment&comment=959807",
-        "repository": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger",
-        "x_textures": "http://bit.ly/navballs"
+        "repository": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger"
     },
     "version": "1.3",
     "ksp_version_min": "0.24",

--- a/NavBallTextureExport/NavBallTextureExport-1.5.ckan
+++ b/NavBallTextureExport/NavBallTextureExport-1.5.ckan
@@ -9,8 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/63113-making-high-contrast-nav-ball/&do=findComment&comment=959807",
-        "repository": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger",
-        "x_textures": "http://bit.ly/navballs"
+        "repository": "https://bitbucket.org/xEvilReeperx/ksp_navballtexturechanger"
     },
     "version": "1.5",
     "ksp_version": "1.2",

--- a/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.0.ckan
+++ b/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.9",
+    "spec_version": "v1.20",
     "identifier": "OPTSpacePlaneMain",
     "name": "OPT Space Plane Parts",
     "abstract": "Over 50 stock-a-like, large space plane oriented parts",

--- a/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.1.ckan
+++ b/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.9",
+    "spec_version": "v1.20",
     "identifier": "OPTSpacePlaneMain",
     "name": "OPT Space Plane Parts",
     "abstract": "Over 50 stock-a-like, large space plane oriented parts",

--- a/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.2.ckan
+++ b/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.9",
+    "spec_version": "v1.20",
     "identifier": "OPTSpacePlaneMain",
     "name": "OPT Space Plane Parts",
     "abstract": "Over 50 stock-a-like, large space plane oriented parts",

--- a/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.9.ckan
+++ b/OPTSpacePlaneMain/OPTSpacePlaneMain-1.9.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.9",
+    "spec_version": "v1.20",
     "identifier": "OPTSpacePlaneMain",
     "name": "OPT Space Plane Parts",
     "abstract": "Over 50 stock-a-like, large space plane oriented parts",

--- a/OPTSpacePlaneMain/OPTSpacePlaneMain-2.0.ckan
+++ b/OPTSpacePlaneMain/OPTSpacePlaneMain-2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.9",
+    "spec_version": "v1.20",
     "identifier": "OPTSpacePlaneMain",
     "name": "OPT Space Plane Parts",
     "abstract": "Over 50 stock-a-like, large space plane oriented parts",

--- a/OptionalAtm/OptionalAtm-1.4.9.1.ckan
+++ b/OptionalAtm/OptionalAtm-1.4.9.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "OptionalAtm",
     "name": "OptionalAtmospheres",
     "abstract": "Adds atmospheres to those planets and moons which don't have atmospheres of the kerbol system",

--- a/OptionalAtm/OptionalAtm-1.4.9.ckan
+++ b/OptionalAtm/OptionalAtm-1.4.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "OptionalAtm",
     "name": "OptionalAtmospheres",
     "abstract": "Adds atmospheres to those planets and moons which don't have atmospheres of the kerbol system",

--- a/PartWizard/PartWizard-1.1.2.ckan
+++ b/PartWizard/PartWizard-1.1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "PartWizard",
     "name": "Part Wizard",
     "abstract": "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.",
@@ -10,7 +10,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80124",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220530-part-wizard"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220530-part-wizard"
     },
     "version": "1.1.2",
     "ksp_version": "0.90",

--- a/PartWizard/PartWizard-1.2.1.ckan
+++ b/PartWizard/PartWizard-1.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "PartWizard",
     "name": "Part Wizard",
     "abstract": "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.",
@@ -10,7 +10,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80124",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220530-part-wizard"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220530-part-wizard"
     },
     "version": "1.2.1",
     "ksp_version_min": "1.0.2",

--- a/PartWizard/PartWizard-v1.2.4.0.ckan
+++ b/PartWizard/PartWizard-v1.2.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PartWizard",
     "name": "Part Wizard",
     "abstract": "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.  It provides a list of parts with part highlighting for easier identification, allows deleting of parts from the list on eligible parts, allows complete control of symmetry on eligible parts, allows selecting parts for Action Group assignment, shows either all parts or only those that are hidden from the editor's Parts List. (Helpful in finding obsolete parts when mod authors make updates.) and shows unavailable parts in career modes with options to buy one or all necessary parts for launch.",
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72468-11-part-wizard-124-20-apr-2016/",
         "repository": "https://github.com/ozraven/PartWizard",
-        "x_curse": "http://kerbal.curseforge.com/projects/part-wizard"
+        "curse": "http://kerbal.curseforge.com/projects/part-wizard"
     },
     "version": "v1.2.4.0",
     "ksp_version": "1.1.0",

--- a/PartWizard/PartWizard-v1.2.5.0.ckan
+++ b/PartWizard/PartWizard-v1.2.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PartWizard",
     "name": "Part Wizard",
     "abstract": "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.  It provides a list of parts with part highlighting for easier identification, allows deleting of parts from the list on eligible parts, allows complete control of symmetry on eligible parts, allows selecting parts for Action Group assignment, shows either all parts or only those that are hidden from the editor's Parts List. (Helpful in finding obsolete parts when mod authors make updates.) and shows unavailable parts in career modes with options to buy one or all necessary parts for launch.",
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72468-11-part-wizard-124-20-apr-2016/",
         "repository": "https://github.com/ozraven/PartWizard",
-        "x_curse": "http://kerbal.curseforge.com/projects/part-wizard"
+        "curse": "http://kerbal.curseforge.com/projects/part-wizard"
     },
     "version": "v1.2.5.0",
     "ksp_version": "1.1.3",


### PR DESCRIPTION
Successor to #1826, see #1816.

> This PR changes every `x_ci` to `ci`, `x_preview` to `x_screenshot`, and `x_curse` to `curse` (and adjusts the `spec_version` where needed).
Additionally, one mistyped `respository` resource has been fixed and the `x_textures` property has been removed from `NavBallTextureExport`, since it doesn't have any real use (especially because the bit.ly link has long expired).

ckan compat add 1.2