### PR TITLE
Fix CameraTools-v1.12.0 compatibility

### DIFF
--- a/CameraTools/CameraTools-v1.12.0.ckan
+++ b/CameraTools/CameraTools-v1.12.0.ckan
@@ -12,7 +12,7 @@
     },
     "version": "v1.12.0",
     "ksp_version_min": "1.7.0",
-    "ksp_version_max": "1.10.99",
+    "ksp_version_max": "1.7.99",
     "depends": [
         {
             "name": "ModuleManager"


### PR DESCRIPTION
`"ksp_version_max"` was set to `"1.10.99"`, the new release is only 1.8 compatible.

![grafik](https://user-images.githubusercontent.com/28812678/74661555-78b18480-5198-11ea-98d0-487d54386f53.png)

This commit reduces it to KSP 1.7 compatibility, so that the older version doesn't get pulled in on KSP 1.9.