### PR TITLE
Add previous DE-IVAExtension version

### DIFF
--- a/DE-IVAExtension/DE-IVAExtension-v1.0.1.ckan
+++ b/DE-IVAExtension/DE-IVAExtension-v1.0.1.ckan
@@ -1,0 +1,58 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "DE-IVAExtension",
+    "name": "DE IVAExtension",
+    "abstract": "An IVA mod for KSP, to add more interactive IVAs",
+    "author": "DemonEin",
+    "version": "v1.0.1",
+    "ksp_version": "1.7",
+    "license": "CC-BY-NC-SA-3.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/186715-*",
+        "repository": "https://github.com/DemonEin/DE_IVAExtension"
+    },
+    "tags": [
+        "config",
+        "crewed"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "RasterPropMonitor-Core"
+        },
+        {
+            "name": "ASETProps"
+        },
+        {
+            "name": "ToolbarController"
+        },
+        {
+            "name": "ClickThroughBlocker"
+        }
+    ],
+    "supports": [
+        {
+            "name": "ProbeControlRoom"
+        }
+    ],
+    "install": [
+        {
+            "find": "DE_IVAExtension",
+            "install_to": "GameData"
+        },
+        {
+            "find": "ProbeControlRoom",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/DemonEin/DE_IVAExtension/releases/download/v1.0.1/DE_IVAExtension_1.0.1.zip",
+    "download_size": 115091,
+    "download_hash": {
+        "sha1": "649B4EC430D23D4A0AC87EC9F10BBB38903BC3F4",
+        "sha256": "EC89DF5E39E174A512D4E60A3ECA69B2BF22872FEA9FFC23AF5F067534717C8B"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
There is some demand for the previous version of this mod.
The forum page says to use RPM v0.30.6, but that mod's forum thread only certifies it up to KSP 1.6, so users will need to add 1.6 as a compatible version manually to install.

ckan compat add 1.6