### PR TITLE
Clean up ninth group of historical resource properties

### DIFF
--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.1.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine-Config-Default",
     "name": "PlanetShine - Default configuration",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.2.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine-Config-Default",
     "name": "PlanetShine - Default configuration",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.ckan
+++ b/PlanetShine-Config-Default/PlanetShine-Config-Default-0.2.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine-Config-Default",
     "name": "PlanetShine - Default configuration",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/PlanetShine/PlanetShine-0.2.5.1.ckan
+++ b/PlanetShine/PlanetShine-0.2.5.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine",
     "name": "PlanetShine",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/PlanetShine/PlanetShine-0.2.5.2.ckan
+++ b/PlanetShine/PlanetShine-0.2.5.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine",
     "name": "PlanetShine",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/PlanetShine/PlanetShine-0.2.5.ckan
+++ b/PlanetShine/PlanetShine-0.2.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "PlanetShine",
     "name": "PlanetShine",
     "abstract": "Planets and moons reflects their light to your vessel + other ambient light improvements",

--- a/RCSBuildAid/RCSBuildAid-v0.9.1.ckan
+++ b/RCSBuildAid/RCSBuildAid-v0.9.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "RCSBuildAid",
     "name": "RCS Build Aid",
     "abstract": "This is something I made for placing RCS thrusters in the right positions in the first try without having to go back and forth between the VAB and the hacked gravity launchpad.  Features: Display thrust and torque forces caused by RCS or engines. Delta V readout for RCS. Dry center of mass marker. Average center of mass marker. Ability to resize editor's overlay markers. Display total mass of resources.",

--- a/RCSBuildAid/RCSBuildAid-v0.9.ckan
+++ b/RCSBuildAid/RCSBuildAid-v0.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "RCSBuildAid",
     "name": "RCS Build Aid",
     "abstract": "This is something I made for placing RCS thrusters in the right positions in the first try without having to go back and forth between the VAB and the hacked gravity launchpad.  Features: Display thrust and torque forces caused by RCS or engines. Delta V readout for RCS. Dry center of mass marker. Average center of mass marker. Ability to resize editor's overlay markers. Display total mass of resources.",

--- a/RealisticAtmospheres/RealisticAtmospheres-1.2.2.ckan
+++ b/RealisticAtmospheres/RealisticAtmospheres-1.2.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "RealisticAtmospheres",
     "name": "Realistic Atmospheres",
     "abstract": "Modifies the atmospheres of all planets and moons to conform to a more lifelike model.",

--- a/RealisticAtmospheres/RealisticAtmospheres-1.2.3.ckan
+++ b/RealisticAtmospheres/RealisticAtmospheres-1.2.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "RealisticAtmospheres",
     "name": "Realistic Atmospheres",
     "abstract": "Modifies the atmospheres of all planets and moons to conform to a more lifelike model.",

--- a/RemoteTechRedevAntennas/RemoteTechRedevAntennas-0.1.ckan
+++ b/RemoteTechRedevAntennas/RemoteTechRedevAntennas-0.1.ckan
@@ -9,7 +9,6 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/139167-*",
         "spacedock": "https://spacedock.info/mod/1929/RemoteTech%20Redev%20Antennas",
         "repository": "https://github.com/RemoteTechnologiesGroup/RemoteTech-Antennas",
-        "respository": "https://github.com/RemoteTechnologiesGroup/RemoteTech-Antennas",
         "x_screenshot": "https://spacedock.info/content/TaxiService_12023/RemoteTech_Redev_Antennas/RemoteTech_Redev_Antennas-1533451078.0075202.png"
     },
     "version": "0.1",

--- a/SamBelangerFlags/SamBelangerFlags-1.4.9.1.ckan
+++ b/SamBelangerFlags/SamBelangerFlags-1.4.9.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "comment": "flagmod",
     "identifier": "SamBelangerFlags",
     "name": "Sam Belanger Flags",

--- a/ShowFPS/ShowFPS-v1.1.ckan
+++ b/ShowFPS/ShowFPS-v1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "ShowFPS",
     "name": "Show FPS",
     "abstract": "Simple framerate counter, enable with F8.",

--- a/SmokeScreen/SmokeScreen-2.6.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.0.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",
         "repository": "https://github.com/sarbian/SmokeScreen/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.6.0",
     "ksp_version_min": "1.0.0",

--- a/SmokeScreen/SmokeScreen-2.6.1.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.1.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",
         "repository": "https://github.com/sarbian/SmokeScreen/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.6.1",
     "ksp_version_min": "1.0.0",

--- a/SmokeScreen/SmokeScreen-2.6.2.ckan
+++ b/SmokeScreen/SmokeScreen-2.6.2.ckan
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/71630",
         "repository": "https://github.com/sarbian/SmokeScreen/",
-        "x_ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
+        "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.6.2",
     "ksp_version_min": "1.0.0",

--- a/StationScience/StationScience-1.3.1.ckan
+++ b/StationScience/StationScience-1.3.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "StationScience",
     "name": "Station Science",
     "abstract": "Station Science mod adds several large parts designed to be integrated into a permanent space station.",
@@ -9,8 +9,8 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220216",
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.3.1",
     "ksp_version": "0.25",
@@ -26,7 +26,7 @@
             "filter": "OldParts.zip"
         }
     ],
-    "download": "http://addons.cursecdn.com/files/2219%5C707/StationScience-1.3.1.zip",
+    "download": "http://addons-origin.cursecdn.com/files/2219/707/StationScience-1.3.1.zip",
     "download_size": 5137074,
     "download_hash": {
         "sha1": "262733275A4651D32EE84891C50251C859133AE9",

--- a/StationScience/StationScience-1.4.ckan
+++ b/StationScience/StationScience-1.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "StationScience",
     "name": "Station Science",
     "abstract": "Station Science mod adds several large parts designed to be integrated into a permanent space station.",
@@ -9,8 +9,8 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220216",
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.4",
     "ksp_version": "0.90",
@@ -29,7 +29,7 @@
             "filter": "OldParts.zip"
         }
     ],
-    "download": "http://kerbal.curseforge.com/ksp-mods/220216-station-science-v-0-4/files/2222038/download",
+    "download": "http://addons-origin.cursecdn.com/files/2222/38/StationScience-1.4.zip",
     "download_size": 5569478,
     "download_hash": {
         "sha1": "3BD0DFB7F7C186FF9B0D6E4985F39078731454D9",

--- a/StationScience/StationScience-1.5.ckan
+++ b/StationScience/StationScience-1.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "StationScience",
     "name": "Station Science",
     "abstract": "Station Science mod adds several large parts designed to be integrated into a permanent space station.",
@@ -9,8 +9,8 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220216",
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.5",
     "ksp_version_min": "1.0.2",

--- a/StationScience/StationScience-1.6.ckan
+++ b/StationScience/StationScience-1.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "StationScience",
     "name": "Station Science",
     "abstract": "Station Science mod adds several large parts designed to be integrated into a permanent space station.",
@@ -9,8 +9,8 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/54774",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220216",
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "1.6",
     "ksp_version_min": "1.1.0",

--- a/StationScienceContinued/StationScienceContinued-2.1.0.ckan
+++ b/StationScienceContinued/StationScienceContinued-2.1.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "2.1.0",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-2.5.3.frozen
+++ b/StationScienceContinued/StationScienceContinued-2.5.3.frozen
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "2.5.3",
     "ksp_version_min": "1.6.0",

--- a/StationScienceContinued/StationScienceContinued-v2.1.1.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.1.1.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.1.1",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-v2.1.2.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.1.2.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.1.2",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-v2.1.3.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.1.3.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.1.3",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-v2.2.0.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.2.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.2.0",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-v2.2.1.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.2.1.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.2.1",
     "ksp_version_min": "1.2.0",

--- a/StationScienceContinued/StationScienceContinued-v2.3.0.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.3.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.3.0",
     "ksp_version_min": "1.3.0",

--- a/StationScienceContinued/StationScienceContinued-v2.4.0.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.4.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.4.0",
     "ksp_version_min": "1.4.0",

--- a/StationScienceContinued/StationScienceContinued-v2.4.1.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.4.1.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.4.1",
     "ksp_version_min": "1.4.0",

--- a/StationScienceContinued/StationScienceContinued-v2.4.2.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.4.2.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.4.2",
     "ksp_version_min": "1.4.0",

--- a/StationScienceContinued/StationScienceContinued-v2.5.2.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.5.2.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "version": "v2.5.2",
     "ksp_version": "1.6",

--- a/StationScienceContinued/StationScienceContinued-v2.5.3.ckan
+++ b/StationScienceContinued/StationScienceContinued-v2.5.3.ckan
@@ -13,7 +13,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-*",
         "repository": "https://github.com/tomforwood/StationScience",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "tags": [
         "parts",


### PR DESCRIPTION
Successor to #1827, see #1816.

> This PR changes every `x_ci` to `ci`, `x_preview` to `x_screenshot`, and `x_curse` to `curse` (and adjusts the `spec_version` where needed).
Additionally, one mistyped `respository` resource has been fixed and the `x_textures` property has been removed from `NavBallTextureExport`, since it doesn't have any real use (especially because the bit.ly link has long expired).