### PR TITLE
Clean up tenth group of historical resources

### DIFF
--- a/ShipManifest/ShipManifest-0.25.0_3.3.2b.ckan
+++ b/ShipManifest/ShipManifest-0.25.0_3.3.2b.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.25.0_3.3.2b",
     "ksp_version": "0.25",

--- a/ShipManifest/ShipManifest-0.90.0_3.3.4.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_3.3.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_3.3.4",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.0.0.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.0.0",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.0.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.0.1",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.0.2.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.0.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.0.2",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.0.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.0",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.0a.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.0a.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.0a",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.0b.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.0b.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.0b",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.1",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.2.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.2",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.3.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.3.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.3.1",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.3.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.3",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.4.0.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.4.0",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-0.90.0_4.1.4.1.ckan
+++ b/ShipManifest/ShipManifest-0.90.0_4.1.4.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to move your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "0.90.0_4.1.4.1",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-4.1.4.2.ckan
+++ b/ShipManifest/ShipManifest-4.1.4.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.1.4.2",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-4.1.4.3.ckan
+++ b/ShipManifest/ShipManifest-4.1.4.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.1.4.3",
     "ksp_version": "0.90",

--- a/ShipManifest/ShipManifest-4.1.4.4.ckan
+++ b/ShipManifest/ShipManifest-4.1.4.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.1.4.4",
     "ksp_version": "1.0.0",

--- a/ShipManifest/ShipManifest-4.2.0.0.ckan
+++ b/ShipManifest/ShipManifest-4.2.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.2.0.0",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.2.0.1.ckan
+++ b/ShipManifest/ShipManifest-4.2.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.2.0.1",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.2.0.2.ckan
+++ b/ShipManifest/ShipManifest-4.2.0.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.2.0.2",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.2.1.0.ckan
+++ b/ShipManifest/ShipManifest-4.2.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science and Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas and Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.2.1.0",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.2.1.1.ckan
+++ b/ShipManifest/ShipManifest-4.2.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science & Resources around from part to part within your ship or station.  It also manages Hatches, Solar Panels, Antennas & Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.2.1.1",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.3.0.0.ckan
+++ b/ShipManifest/ShipManifest-4.3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science & Resources around your vessel.  It also manages Hatches, Solar Panels, Antennas & Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.3.0.0",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.3.0.1.ckan
+++ b/ShipManifest/ShipManifest-4.3.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science & Resources around your vessel.  It also manages Hatches, Solar Panels, Antennas & Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.3.0.1",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.3.0.2.ckan
+++ b/ShipManifest/ShipManifest-4.3.0.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science & Resources around your vessel.  It also manages Hatches, Solar Panels, Antennas & Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.3.0.2",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.3.1.0.ckan
+++ b/ShipManifest/ShipManifest-4.3.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves crew, Science & Resources around your vessel.  It also manages Hatches, Solar Panels, Antennas & Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.3.1.0",
     "ksp_version": "1.0.2",

--- a/ShipManifest/ShipManifest-4.4.0.0.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.4.0.0",
     "ksp_version": "1.0.3",

--- a/ShipManifest/ShipManifest-4.4.0.1.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.4.0.1",
     "ksp_version": "1.0.4",

--- a/ShipManifest/ShipManifest-4.4.0.2.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.4.0.2",
     "ksp_version": "1.0.4",

--- a/ShipManifest/ShipManifest-4.4.0.3.ckan
+++ b/ShipManifest/ShipManifest-4.4.0.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.4.0.3",
     "ksp_version": "1.0.4",

--- a/ShipManifest/ShipManifest-4.4.1.0.ckan
+++ b/ShipManifest/ShipManifest-4.4.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "4.4.1.0",
     "ksp_version": "1.0.4",

--- a/ShipManifest/ShipManifest-4.4.1.1.ckan
+++ b/ShipManifest/ShipManifest-4.4.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".  Ship Manifest moves Crew, Science & Resources around your vessel.  It manages docked vessel resources too!.  It also manages Hatches, Solar Panels, Antennas & Lights.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/62270",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
         "kerbalstuff": "https://kerbalstuff.com/mod/261/Ship%20Manifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://kerbalstuff.com/content/Papa_Joe_2689/Ship_Manifest/Ship_Manifest-1434605028.0250149.png"
     },
     "version": "4.4.1.1",

--- a/ShipManifest/ShipManifest-4.4.2.0.ckan
+++ b/ShipManifest/ShipManifest-4.4.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "4.4.2.0",

--- a/ShipManifest/ShipManifest-5.0.0.0.ckan
+++ b/ShipManifest/ShipManifest-5.0.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.0.0.0",

--- a/ShipManifest/ShipManifest-5.0.0.1.ckan
+++ b/ShipManifest/ShipManifest-5.0.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.0.0.1",

--- a/ShipManifest/ShipManifest-5.0.1.0.ckan
+++ b/ShipManifest/ShipManifest-5.0.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.0.1.0",

--- a/ShipManifest/ShipManifest-5.0.9.0.ckan
+++ b/ShipManifest/ShipManifest-5.0.9.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.0.9.0",

--- a/ShipManifest/ShipManifest-5.1.0.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.0.0",

--- a/ShipManifest/ShipManifest-5.1.1.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.1.0",

--- a/ShipManifest/ShipManifest-5.1.1.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.1.1",

--- a/ShipManifest/ShipManifest-5.1.1.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.1.2",

--- a/ShipManifest/ShipManifest-5.1.2.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.2.0",

--- a/ShipManifest/ShipManifest-5.1.2.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.2.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.2.1",

--- a/ShipManifest/ShipManifest-5.1.2.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.2.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.2.2",

--- a/ShipManifest/ShipManifest-5.1.3.0.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.3.0",

--- a/ShipManifest/ShipManifest-5.1.3.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.3.1",

--- a/ShipManifest/ShipManifest-5.1.3.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "ShipManifest",
     "abstract": "Ship Manifest is a tool to manage your ship's \"things\".",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "spacedock": "https://spacedock.info/mod/189/ShipManifest",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest",
         "x_screenshot": "https://spacedock.info/content/Papa_Joe_926/ShipManifest/ShipManifest-1455928385.1139288.png"
     },
     "version": "5.1.3.2",

--- a/ShipManifest/ShipManifest-5.1.3.3.ckan
+++ b/ShipManifest/ShipManifest-5.1.3.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Manages Crew, Science, & Resources on a given vessel.",
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "5.1.3.3",
     "ksp_version_min": "1.2.0",

--- a/ShipManifest/ShipManifest-5.1.4.1.ckan
+++ b/ShipManifest/ShipManifest-5.1.4.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Manages Crew, Science, & Resources on a given vessel.",
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "5.1.4.1",
     "ksp_version": "1.3.0",

--- a/ShipManifest/ShipManifest-5.1.4.2.ckan
+++ b/ShipManifest/ShipManifest-5.1.4.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Manages Crew, Science, & Resources on a given vessel.",
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "5.1.4.2",
     "ksp_version": "1.3.0",

--- a/ShipManifest/ShipManifest-5.1.4.3.ckan
+++ b/ShipManifest/ShipManifest-5.1.4.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Manages Crew, Science, & Resources on a given vessel.",
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-/",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "5.1.4.3",
     "ksp_version": "1.3.0",

--- a/ShipManifest/ShipManifest-5.2.0.0.ckan
+++ b/ShipManifest/ShipManifest-5.2.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "ShipManifest",
     "name": "Ship Manifest",
     "abstract": "Manages Crew, Science, & Resources on a given vessel.",
@@ -9,7 +9,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-*",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "version": "5.2.0.0",
     "ksp_version_min": "1.3.0",


### PR DESCRIPTION
Successor to #1849, see #1816.

> This PR changes every `x_ci` to `ci`, `x_preview` to `x_screenshot`, and `x_curse` to `curse` (and adjusts the `spec_version` where needed).
Additionally, one mistyped `respository` resource has been fixed and the `x_textures` property has been removed from `NavBallTextureExport`, since it doesn't have any real use (especially because the bit.ly link has long expired).