### PR TITLE
Clean up eleventh group of historical resources

### DIFF
--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.2.1.0",
     "ksp_version": "0.90.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.2.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.2.2.0",
     "ksp_version": "0.90.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.2.3.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.2.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.2.3.0",
     "ksp_version": "0.90.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.3.0.0",
     "ksp_version": "1.0.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.1.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.0.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.3.0.1",
     "ksp_version": "1.0.2",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.3.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.3.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
         "kerbalstuff": "https://kerbalstuff.com/mod/268/Transfer%20Window%20Planner",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.3.1.0",
     "ksp_version": "1.0.4",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.4.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.4.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -11,7 +11,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224116-transfer-window-planner"
     },
     "version": "v1.4.0.0",
     "ksp_version": "1.0.5",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.5.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.5.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.5.0.0",
     "ksp_version_min": "1.1.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.5.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.5.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.5.1.0",
     "ksp_version_min": "1.1.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.0.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.6.0.0",
     "ksp_version_min": "1.2.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.6.1.0",
     "ksp_version_min": "1.2.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.2.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.6.2.0",
     "ksp_version_min": "1.3.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.6.3.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.6.3.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.6.3.0",
     "ksp_version_min": "1.4.0",

--- a/TransferWindowPlanner/TransferWindowPlanner-v1.7.1.0.ckan
+++ b/TransferWindowPlanner/TransferWindowPlanner-v1.7.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "name": "Transfer Window Planner",
     "abstract": "An ingame implementation of Alexmun's Launch Window Planner",
@@ -10,7 +10,7 @@
         "repository": "https://github.com/TriggerAu/TransferWindowPlanner",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "version": "v1.7.1.0",
     "ksp_version_min": "1.7.0",

--- a/WaterSounds/WaterSounds-2.2.ckan
+++ b/WaterSounds/WaterSounds-2.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "WaterSounds",
     "name": "Water Sounds",
     "abstract": "Adds the sound of water gently lapping at the sides of your craft when splashed down.",

--- a/kTunes/kTunes-1.2.ckan
+++ b/kTunes/kTunes-1.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "kTunes",
     "name": "kTunes",
     "abstract": "Control your media player from within KSP.",
@@ -10,7 +10,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/89055",
         "repository": "https://github.com/cwc/kTunes",
         "bugtracker": "https://github.com/cwc/kTunes/issues",
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/222945-ktunes"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/222945-ktunes"
     },
     "version": "1.2",
     "ksp_version_min": "0.24.2",

--- a/surfacelights/surfacelights-1.0.ckan
+++ b/surfacelights/surfacelights-1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Lights",
     "abstract": "Surface mounted stock-alike lights for self-illumination",
@@ -9,7 +9,7 @@
     "license": "CC-BY-NC-ND-3.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/57778",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220942-surfacelights-surface-mounted-stock-alike-lights"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220942-surfacelights-surface-mounted-stock-alike-lights"
     },
     "version": "1.0",
     "ksp_version_min": "0.24",

--- a/surfacelights/surfacelights-1.10.ckan
+++ b/surfacelights/surfacelights-1.10.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.11.ckan
+++ b/surfacelights/surfacelights-1.11.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.12.ckan
+++ b/surfacelights/surfacelights-1.12.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.13.ckan
+++ b/surfacelights/surfacelights-1.13.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.4.0.ckan
+++ b/surfacelights/surfacelights-1.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Stock-Alike Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations and ships.",

--- a/surfacelights/surfacelights-1.5.ckan
+++ b/surfacelights/surfacelights-1.5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Stock-Alike Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations and ships.",

--- a/surfacelights/surfacelights-1.6.ckan
+++ b/surfacelights/surfacelights-1.6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Stock-Alike Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations and ships.",

--- a/surfacelights/surfacelights-1.7.ckan
+++ b/surfacelights/surfacelights-1.7.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.8.ckan
+++ b/surfacelights/surfacelights-1.8.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",

--- a/surfacelights/surfacelights-1.9.ckan
+++ b/surfacelights/surfacelights-1.9.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "surfacelights",
     "name": "Surface Mounted Lights",
     "abstract": "Small stock-alike lights that sit flush for lighting up your stations, ships, and landing zones.",


### PR DESCRIPTION
Successor to #1850, see #1816.

> This PR changes every `x_ci` to `ci`, `x_preview` to `x_screenshot`, and `x_curse` to `curse` (and adjusts the `spec_version` where needed).
Additionally, one mistyped `respository` resource has been fixed and the `x_textures` property has been removed from `NavBallTextureExport`, since it doesn't have any real use (especially because the bit.ly link has long expired).