### PR TITLE
Clean up historical resources for Mk2Essentials

### DIFF
--- a/Mk2Essentials/Mk2Essentials-5.ckan
+++ b/Mk2Essentials/Mk2Essentials-5.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "Mk2Essentials",
     "name": "Mk 2 Essentials",
     "abstract": "Some Mk2 parts which I felt were missing from the game",
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/99661-1-0-2-Mk2-Essentials",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
     },
     "version": "5",
     "ksp_version_min": "0.90",
@@ -20,7 +20,7 @@
             "filter": "Thumbs.db"
         }
     ],
-    "download": "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials/files/2239040/download",
+    "download": "https://www.curseforge.com/kerbal/ksp-mods/mk2-essentials/download/2239040/file",
     "download_size": 479219,
     "download_hash": {
         "sha1": "3093C1414E836DF12309FD1B020014A9FDEE7355",

--- a/Mk2Essentials/Mk2Essentials-6.ckan
+++ b/Mk2Essentials/Mk2Essentials-6.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "Mk2Essentials",
     "name": "Mk 2 Essentials",
     "abstract": "Some Mk2 parts which I felt were missing from the game",
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/89875-104",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
     },
     "version": "6",
     "ksp_version_min": "0.90",


### PR DESCRIPTION
Successor to #1851, see #1816.

> This PR changes every `x_ci` to `ci`, `x_preview` to `x_screenshot`, and `x_curse` to `curse` (and adjusts the `spec_version` where needed).
Additionally, one mistyped `respository` resource has been fixed and the `x_textures` property has been removed from `NavBallTextureExport`, since it doesn't have any real use (especially because the bit.ly link has long expired).

This is the last PR of this row. `Mk2Essentials` is Curse-hosted, so the inflation fails. I don't want to freeze these though, since from time to time you are able to download them. Unfortunately they don't have a archive.org fallback since they are restrictively licensed.

Closes #1816