### PR TITLE
Don't provide Scatterer-sunflare and Scatterer-config with BeyondHome

### DIFF
--- a/BeyondHome/BeyondHome-1.2.0.ckan
+++ b/BeyondHome/BeyondHome-1.2.0.ckan
@@ -17,8 +17,6 @@
         "graphics"
     ],
     "provides": [
-        "Scatterer-config",
-        "Scatterer-sunflare",
         "EnvironmentalVisualEnhancements-Config"
     ],
     "depends": [


### PR DESCRIPTION
This is the historical counterpart for https://github.com/KSP-CKAN/NetKAN/pull/7741.
There's only one old version so far, luckily ;)