### PR TITLE
Remove dead repos from defaults list

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -6,40 +6,11 @@
             "x_mirror":  true,
             "x_comment": "The well-known default CKAN metadata repository"
         },
-
-        {
-            "name":      "dev",
-            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/master.tar.gz",
-            "x_mirror":  false,
-            "x_comment": "Development ckans"
-        },
-
         {
             "name":      "MechJeb2-dev",
             "uri":       "https://ksp.sarbian.com/ckan/MechJeb2-ci.tar.gz",
             "x_mirror":  false,
             "x_comment": "MechJeb2 Development (prerelease and Jenkins) ckans"
-        },
-
-        {
-            "name":      "RemoteTech-pre",
-            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/RemoteTech-pre.tar.gz",
-            "x_mirror":  false,
-            "x_comment": "RemoteTech Development (prerelease and Jenkins) ckans"
-        },
-
-        {
-            "name":      "SCANsat-pre",
-            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/SCANsat-pre.tar.gz",
-            "x_mirror":  false,
-            "x_comment": "SCANsat Development (prerelease and Jenkins) ckans"
-        },
-
-        {
-            "name":      "Trajectories-pre",
-            "uri":       "https://github.com/KSP-CKAN/CKAN-meta-dev/archive/Trajectories-pre.tar.gz",
-            "x_mirror":  false,
-            "x_comment": "Trajectories Development (prerelease and Jenkins) ckans"
         }
     ]
 }


### PR DESCRIPTION
## Background

See KSP-CKAN/NetKAN-Infra#155; the dev, RemoteTech, SCANsat, and Trajectories options in this list are 5 years out of date:

![screenshot](https://user-images.githubusercontent.com/1559108/76819357-d240b980-67ff-11ea-87f5-c44e37050f7b.png)

Even if you install a version of KSP from 5 years ago, these options would *still* not be useful, since they were pre-releases and there would long since have been normal releases of these mods with the relevant changes in the meantime.

## Changes

Now the outdated options are removed. default and MechJeb2-dev remain because they are still actively updated.

(KSP-CKAN/NetKAN-Infra#155 still needs some documentation added to the repos to be closed.)