### PR TITLE
Force default sunflare for BeyondHome historical releases

### DIFF
--- a/BeyondHome/BeyondHome-1.2.0.ckan
+++ b/BeyondHome/BeyondHome-1.2.0.ckan
@@ -22,6 +22,9 @@
     "depends": [
         {
             "name": "Kopernicus"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         }
     ],
     "recommends": [

--- a/BeyondHome/BeyondHome-1.3.1.ckan
+++ b/BeyondHome/BeyondHome-1.3.1.ckan
@@ -22,6 +22,9 @@
     "depends": [
         {
             "name": "Kopernicus"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         }
     ],
     "recommends": [

--- a/BeyondHome/BeyondHome-1.4.0.ckan
+++ b/BeyondHome/BeyondHome-1.4.0.ckan
@@ -22,6 +22,9 @@
     "depends": [
         {
             "name": "Kopernicus"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         }
     ],
     "recommends": [

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0245.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0245.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0245",
     "ksp_version": "1.1.2",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0246.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0246.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0246",
     "ksp_version": "1.1.2",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0247.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0247.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0247",
     "ksp_version": "1.1.3",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0256.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0256.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0256",
     "ksp_version": "1.2",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0300.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0300.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0300",
     "ksp_version": "1.2.2",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0320.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0320.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0320",
     "ksp_version": "1.2.2",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0320b.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0320b.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0320b",
     "ksp_version": "1.3",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0324.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0324.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0324",
     "ksp_version": "1.3.1",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0326.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0326.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0326",
     "ksp_version": "1.4.0",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0329_for_1.4.2.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0329_for_1.4.2.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0329_for_1.4.2",
     "ksp_version": "1.4.2",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0331.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0331.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0331",
     "ksp_version": "1.4.2",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0331b.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0331b.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0331b",
     "ksp_version": "1.4.2",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0336.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0336.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0336",
     "ksp_version": "1.5.1",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0520.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0520.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0520",
     "ksp_version": "1.6.1",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0530.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0530.ckan
@@ -14,6 +14,9 @@
     },
     "version": "2:v0.0530",
     "ksp_version": "1.6.1",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0540.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0540.ckan
@@ -15,6 +15,9 @@
     "version": "2:v0.0540",
     "ksp_version_min": "1.6",
     "ksp_version_max": "1.7",
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-2-v0.0541.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-2-v0.0541.ckan
@@ -18,6 +18,9 @@
         "graphics",
         "config"
     ],
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"


### PR DESCRIPTION
This is KSP-CKAN/NetKAN#7794 for historical releases. Now modules for older game versions can depend on `Scatterer-sunflare-default` if they require the default sunflare config to be installed, and older versions of BeyondHome do this.

Needed for KSP-CKAN/NetKAN#7800.