### PR TITLE
Sunflare fix for GameslinxPlanetOverhaul historical releases

### DIFF
--- a/GPO/GPO-2.4a.ckan
+++ b/GPO/GPO-2.4a.ckan
@@ -36,6 +36,9 @@
             "name": "Scatterer"
         },
         {
+            "name": "Scatterer-sunflare-default"
+        },
+        {
             "name": "TextureReplacer"
         }
     ],

--- a/GPO/GPO-2.5b.ckan
+++ b/GPO/GPO-2.5b.ckan
@@ -34,6 +34,9 @@
         },
         {
             "name": "Scatterer"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         }
     ],
     "recommends": [

--- a/GPO/GPO-3.0.1.ckan
+++ b/GPO/GPO-3.0.1.ckan
@@ -34,6 +34,9 @@
         },
         {
             "name": "Scatterer"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         }
     ],
     "recommends": [

--- a/GPO/GPO-3.0.2.ckan
+++ b/GPO/GPO-3.0.2.ckan
@@ -34,6 +34,9 @@
         },
         {
             "name": "Scatterer"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         }
     ],
     "recommends": [

--- a/GPO/GPO-3.0.ckan
+++ b/GPO/GPO-3.0.ckan
@@ -34,6 +34,9 @@
         },
         {
             "name": "Scatterer"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         }
     ],
     "recommends": [

--- a/GPO/GPO-3.1.ckan
+++ b/GPO/GPO-3.1.ckan
@@ -34,6 +34,9 @@
         },
         {
             "name": "Scatterer"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         }
     ],
     "recommends": [

--- a/GPO/GPO-3.2-HOTFIX.ckan
+++ b/GPO/GPO-3.2-HOTFIX.ckan
@@ -34,6 +34,9 @@
         },
         {
             "name": "Scatterer"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         }
     ],
     "recommends": [

--- a/GPO/GPO-3.2.4.ckan
+++ b/GPO/GPO-3.2.4.ckan
@@ -12,8 +12,7 @@
     "version": "3.2.4",
     "ksp_version": "1.3.1",
     "provides": [
-        "EnvironmentalVisualEnhancements-Config",
-        "Scatterer-sunflare"
+        "EnvironmentalVisualEnhancements-Config"
     ],
     "depends": [
         {
@@ -27,6 +26,9 @@
         },
         {
             "name": "Scatterer-config"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         },
         {
             "name": "INSTANTIATOR"

--- a/GPO/GPO-3.2.5.ckan
+++ b/GPO/GPO-3.2.5.ckan
@@ -12,8 +12,7 @@
     "version": "3.2.5",
     "ksp_version": "1.3.1",
     "provides": [
-        "EnvironmentalVisualEnhancements-Config",
-        "Scatterer-sunflare"
+        "EnvironmentalVisualEnhancements-Config"
     ],
     "depends": [
         {
@@ -27,6 +26,9 @@
         },
         {
             "name": "Scatterer-config"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         },
         {
             "name": "INSTANTIATOR"

--- a/GPO/GPO-3.2.ckan
+++ b/GPO/GPO-3.2.ckan
@@ -34,6 +34,9 @@
         },
         {
             "name": "Scatterer"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         }
     ],
     "recommends": [

--- a/GPO/GPO-3.2d.ckan
+++ b/GPO/GPO-3.2d.ckan
@@ -40,6 +40,9 @@
         },
         {
             "name": "Scatterer"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         }
     ],
     "recommends": [

--- a/GPO/GPO-3.3.1.ckan
+++ b/GPO/GPO-3.3.1.ckan
@@ -12,8 +12,7 @@
     "version": "3.3.1",
     "ksp_version": "1.3.1",
     "provides": [
-        "EnvironmentalVisualEnhancements-Config",
-        "Scatterer-sunflare"
+        "EnvironmentalVisualEnhancements-Config"
     ],
     "depends": [
         {
@@ -27,6 +26,9 @@
         },
         {
             "name": "Scatterer-config"
+        },
+        {
+            "name": "Scatterer-sunflare-default"
         },
         {
             "name": "INSTANTIATOR"


### PR DESCRIPTION
This is KSP-CKAN/NetKAN#7800 for historical releases. Now GPO depends on Scatterer-sunflare-default.