### PR TITLE
Revert historical PilotAssistant compatibility

### DIFF
--- a/PilotAssistant/PilotAssistant-v1.13.4.ckan
+++ b/PilotAssistant/PilotAssistant-v1.13.4.ckan
@@ -8,7 +8,7 @@
         "zolotiyeruki"
     ],
     "version": "v1.13.4",
-    "ksp_version": "1.9",
+    "ksp_version": "1.8",
     "license": "CC-BY-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/184277-*",

--- a/PilotAssistant/PilotAssistant-v1.13.4.ckan
+++ b/PilotAssistant/PilotAssistant-v1.13.4.ckan
@@ -8,7 +8,8 @@
         "zolotiyeruki"
     ],
     "version": "v1.13.4",
-    "ksp_version": "1.8",
+    "ksp_version_min": "1.7",
+    "ksp_version_max": "1.8",
     "license": "CC-BY-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/184277-*",


### PR DESCRIPTION
The author updated the version file which unintentionally affected the previous release because the version number wasn't truly updated. Now it's back as it was.

![image](https://user-images.githubusercontent.com/1559108/77990104-fcba6880-730f-11ea-8c5b-0e3eccb02ec4.png)
