### PR TITLE
Set compatibility for historical TelemachusReborn release

### DIFF
--- a/TelemachusReborn/TelemachusReborn-1.7.35.ckan
+++ b/TelemachusReborn/TelemachusReborn-1.7.35.ckan
@@ -5,6 +5,8 @@
     "abstract": "Telemachus is a universal Web Telemetry Mod for Kerbal Space Program. It allows you to access any aspects of game from browser.",
     "author": "DanGSun",
     "version": "1.7.35",
+    "ksp_version_min": "1.6.0",
+    "ksp_version_max": "1.9.9",
     "license": "MIT",
     "release_status": "stable",
     "resources": {


### PR DESCRIPTION
This release had no version file, see TeleIO/Telemachus-1#33, and no `x_netkan_override` to set the compatibility as the previous release did. The next release was created in part to fix this. Now the same compatibility is copied back to 1.7.35.