### PR TITLE
Remove FirespitterCore depends from LithobrakeExplorationTechnologies

### DIFF
--- a/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.2.0.ckan
+++ b/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.2.0.ckan
@@ -15,9 +15,6 @@
     "ksp_version_max": "1.0.5",
     "depends": [
         {
-            "name": "FirespitterCore"
-        },
-        {
             "name": "ModuleManager"
         }
     ],

--- a/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.2.1.ckan
+++ b/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.2.1.ckan
@@ -15,9 +15,6 @@
     "ksp_version_max": "1.0.5",
     "depends": [
         {
-            "name": "FirespitterCore"
-        },
-        {
             "name": "ModuleManager"
         }
     ],

--- a/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.1.ckan
+++ b/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.1.ckan
@@ -14,9 +14,6 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
-            "name": "FirespitterCore"
-        },
-        {
             "name": "ModuleManager"
         }
     ],

--- a/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.2.ckan
+++ b/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.2.ckan
@@ -14,9 +14,6 @@
     "ksp_version": "1.1.0",
     "depends": [
         {
-            "name": "FirespitterCore"
-        },
-        {
             "name": "ModuleManager"
         }
     ],

--- a/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.3.ckan
+++ b/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.3.ckan
@@ -14,9 +14,6 @@
     "ksp_version": "1.1.0",
     "depends": [
         {
-            "name": "FirespitterCore"
-        },
-        {
             "name": "ModuleManager"
         }
     ],

--- a/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.4.ckan
+++ b/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.4.ckan
@@ -14,9 +14,6 @@
     "ksp_version": "1.1.0",
     "depends": [
         {
-            "name": "FirespitterCore"
-        },
-        {
             "name": "ModuleManager"
         }
     ],

--- a/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.5.ckan
+++ b/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.5.ckan
@@ -15,9 +15,6 @@
     "ksp_version_max": "1.1.3",
     "depends": [
         {
-            "name": "FirespitterCore"
-        },
-        {
             "name": "ModuleManager"
         }
     ],

--- a/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.6.ckan
+++ b/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.6.ckan
@@ -15,9 +15,6 @@
     "ksp_version_max": "1.1.3",
     "depends": [
         {
-            "name": "FirespitterCore"
-        },
-        {
             "name": "ModuleManager"
         }
     ],

--- a/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.ckan
+++ b/LithobrakeExplorationTechnologies/LithobrakeExplorationTechnologies-0.3.ckan
@@ -14,9 +14,6 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
-            "name": "FirespitterCore"
-        },
-        {
             "name": "ModuleManager"
         }
     ],


### PR DESCRIPTION
Historical version of KSP-CKAN/NetKAN#7826. Firespitter shouldn't be a dependency for this mod.