### PR TITLE
Historical ColorCodedCans conflicts with mods that change stock tanks

### DIFF
--- a/ColorCodedCans/ColorCodedCans-0.3.ckan
+++ b/ColorCodedCans/ColorCodedCans-0.3.ckan
@@ -17,6 +17,14 @@
             "min_version": "2.5.6"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-0.3/EEFC7A3A-ColorCodedCans-0.3.zip",
     "download_size": 1691176,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-0.4.ckan
+++ b/ColorCodedCans/ColorCodedCans-0.4.ckan
@@ -17,6 +17,14 @@
             "min_version": "2.5.6"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-0.4/22762023-ColorCodedCans-0.4.zip",
     "download_size": 1989823,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-0.5.ckan
+++ b/ColorCodedCans/ColorCodedCans-0.5.ckan
@@ -17,6 +17,14 @@
             "min_version": "2.5.6"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-0.5/7CC0D359-ColorCodedCans-0.5.zip",
     "download_size": 2096838,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-0.6.ckan
+++ b/ColorCodedCans/ColorCodedCans-0.6.ckan
@@ -17,6 +17,14 @@
             "min_version": "2.5.6"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-0.6/8446D7A7-ColorCodedCans-0.6.zip",
     "download_size": 2185202,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-0.7.ckan
+++ b/ColorCodedCans/ColorCodedCans-0.7.ckan
@@ -17,6 +17,14 @@
             "min_version": "2.5.6"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-0.7/E9289263-ColorCodedCans-0.7.zip",
     "download_size": 2233087,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-0.8.ckan
+++ b/ColorCodedCans/ColorCodedCans-0.8.ckan
@@ -17,6 +17,14 @@
             "min_version": "2.5.6"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-0.8/F469C992-ColorCodedCans-0.8.zip",
     "download_size": 2247944,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-0.9.ckan
+++ b/ColorCodedCans/ColorCodedCans-0.9.ckan
@@ -17,6 +17,14 @@
             "min_version": "2.5.6"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-0.9/41F090BB-ColorCodedCans-0.9.zip",
     "download_size": 2250148,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.0.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.0.ckan
@@ -18,6 +18,14 @@
             "min_version": "2.5.6"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-1.0/12452B76-ColorCodedCans-1.0.zip",
     "download_size": 2108527,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.1.0.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.1.0.ckan
@@ -18,6 +18,14 @@
             "min_version": "2.5.6"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-1.1.0/6393134E-ColorCodedCans-1.1.0.zip",
     "download_size": 2110706,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.1.1.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.1.1.ckan
@@ -19,6 +19,14 @@
             "min_version": "2.5.6"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-1.1.1/BA97780B-ColorCodedCans-1.1.1.zip",
     "download_size": 2110986,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.2.1.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.2.1.ckan
@@ -23,6 +23,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-1.2.1/E7637B84-ColorCodedCans-1.2.1.zip",
     "download_size": 2696273,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.2.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.2.ckan
@@ -23,6 +23,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-1.2/914FD1BA-ColorCodedCans-1.2.zip",
     "download_size": 2696198,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.3.1.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.3.1.ckan
@@ -23,6 +23,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-1.3.1/D5F2DA85-ColorCodedCans-1.3.1.zip",
     "download_size": 2698693,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.3.2.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.3.2.ckan
@@ -23,6 +23,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-1.3.2/DD0777EF-ColorCodedCans-1.3.2.zip",
     "download_size": 2698759,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.3.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.3.ckan
@@ -23,6 +23,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-1.3/45EB3F6D-ColorCodedCans-1.3.zip",
     "download_size": 2698342,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.4.2.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.4.2.ckan
@@ -24,6 +24,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://spacedock.info/mod/91/Color%20Coded%20Canisters/download/1.4.2",
     "download_size": 2698988,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.4.3.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.4.3.ckan
@@ -24,6 +24,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://spacedock.info/mod/91/Color%20Coded%20Canisters/download/1.4.3",
     "download_size": 2699963,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.4.4.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.4.4.ckan
@@ -24,6 +24,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://spacedock.info/mod/91/Color%20Coded%20Canisters/download/1.4.4",
     "download_size": 2700620,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.4.5.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.4.5.ckan
@@ -24,6 +24,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://spacedock.info/mod/91/Color%20Coded%20Canisters/download/1.4.5",
     "download_size": 2700785,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.4.6.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.4.6.ckan
@@ -24,6 +24,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://spacedock.info/mod/91/Color%20Coded%20Canisters/download/1.4.6",
     "download_size": 2701440,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.4.7.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.4.7.ckan
@@ -24,6 +24,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://spacedock.info/mod/91/Color%20Coded%20Canisters/download/1.4.7",
     "download_size": 2701645,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.4.8.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.4.8.ckan
@@ -24,6 +24,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://spacedock.info/mod/91/Color%20Coded%20Canisters/download/1.4.8",
     "download_size": 2701577,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.4.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.4.ckan
@@ -23,6 +23,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://archive.org/download/ColorCodedCans-1.4/8774FEFC-ColorCodedCans-1.4.zip",
     "download_size": 2698926,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.5.1.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.5.1.ckan
@@ -24,6 +24,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://spacedock.info/mod/91/Color%20Coded%20Canisters/download/1.5.1",
     "download_size": 2907990,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-1.5.ckan
+++ b/ColorCodedCans/ColorCodedCans-1.5.ckan
@@ -24,6 +24,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://spacedock.info/mod/91/Color%20Coded%20Canisters/download/1.5",
     "download_size": 2907956,
     "download_hash": {

--- a/ColorCodedCans/ColorCodedCans-2.0.0.ckan
+++ b/ColorCodedCans/ColorCodedCans-2.0.0.ckan
@@ -24,6 +24,14 @@
             "name": "FuelTanksPlus"
         }
     ],
+    "conflicts": [
+        {
+            "name": "ReStock"
+        },
+        {
+            "name": "VenStockRevamp"
+        }
+    ],
     "download": "https://spacedock.info/mod/91/Color%20Coded%20Canisters/download/2.0.0",
     "download_size": 2879572,
     "download_hash": {


### PR DESCRIPTION
Historical version of KSP-CKAN/NetKAN#7836. Now all old versions of CCC conflict with ReStock and Vens.