### PR TITLE
Add modules for DLC

### DIFF
--- a/BreakingGround-DLC/BreakingGround-DLC-1.0.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.0.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "BreakingGround-DLC",
+    "name":         "Breaking Ground",
+    "abstract":     "The second expansion pack adds new science-collecting equipment to deploy on your missions, surface features to be investigated scattered across distant planets, and a wealth of new robotic parts for players to test their creativity with",
+    "author":       "SQUAD",
+    "version":      "1.0.0",
+    "ksp_version":  "1.7.1",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
+        "steamstore": "https://store.steampowered.com/app/982970"
+    }
+}

--- a/BreakingGround-DLC/BreakingGround-DLC-1.1.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.1.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "BreakingGround-DLC",
+    "name":         "Breaking Ground",
+    "abstract":     "The second expansion pack adds new science-collecting equipment to deploy on your missions, surface features to be investigated scattered across distant planets, and a wealth of new robotic parts for players to test their creativity with",
+    "author":       "SQUAD",
+    "version":      "1.1.0",
+    "ksp_version":  "1.7.2",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
+        "steamstore": "https://store.steampowered.com/app/982970"
+    }
+}

--- a/BreakingGround-DLC/BreakingGround-DLC-1.2.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.2.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "BreakingGround-DLC",
+    "name":         "Breaking Ground",
+    "abstract":     "The second expansion pack adds new science-collecting equipment to deploy on your missions, surface features to be investigated scattered across distant planets, and a wealth of new robotic parts for players to test their creativity with",
+    "author":       "SQUAD",
+    "version":      "1.2.0",
+    "ksp_version":  "1.7.3",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
+        "steamstore": "https://store.steampowered.com/app/982970"
+    }
+}

--- a/BreakingGround-DLC/BreakingGround-DLC-1.3.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.3.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "BreakingGround-DLC",
+    "name":         "Breaking Ground",
+    "abstract":     "The second expansion pack adds new science-collecting equipment to deploy on your missions, surface features to be investigated scattered across distant planets, and a wealth of new robotic parts for players to test their creativity with",
+    "author":       "SQUAD",
+    "version":      "1.3.0",
+    "ksp_version":  "1.8.0",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
+        "steamstore": "https://store.steampowered.com/app/982970"
+    }
+}

--- a/BreakingGround-DLC/BreakingGround-DLC-1.3.1.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.3.1.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "BreakingGround-DLC",
+    "name":         "Breaking Ground",
+    "abstract":     "The second expansion pack adds new science-collecting equipment to deploy on your missions, surface features to be investigated scattered across distant planets, and a wealth of new robotic parts for players to test their creativity with",
+    "author":       "SQUAD",
+    "version":      "1.3.1",
+    "ksp_version":  "1.8.1",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
+        "steamstore": "https://store.steampowered.com/app/982970"
+    }
+}

--- a/BreakingGround-DLC/BreakingGround-DLC-1.4.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.4.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "BreakingGround-DLC",
+    "name":         "Breaking Ground",
+    "abstract":     "The second expansion pack adds new science-collecting equipment to deploy on your missions, surface features to be investigated scattered across distant planets, and a wealth of new robotic parts for players to test their creativity with",
+    "author":       "SQUAD",
+    "version":      "1.4.0",
+    "ksp_version":  "1.9.0",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
+        "steamstore": "https://store.steampowered.com/app/982970"
+    }
+}

--- a/BreakingGround-DLC/BreakingGround-DLC-1.4.1.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.4.1.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "BreakingGround-DLC",
+    "name":         "Breaking Ground",
+    "abstract":     "The second expansion pack adds new science-collecting equipment to deploy on your missions, surface features to be investigated scattered across distant planets, and a wealth of new robotic parts for players to test their creativity with",
+    "author":       "SQUAD",
+    "version":      "1.4.1",
+    "ksp_version":  "1.9.1",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
+        "steamstore": "https://store.steampowered.com/app/982970"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.0.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.0.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.0.0",
+    "ksp_version":  "1.4.1",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.1.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.1.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.1.0",
+    "ksp_version":  "1.4.2",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.2.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.2.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.2.0",
+    "ksp_version":  "1.4.3",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.3.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.3.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.3.0",
+    "ksp_version":  "1.4.4",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.4.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.4.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.4.0",
+    "ksp_version":  "1.4.5",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.5.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.5.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.5.0",
+    "ksp_version":  "1.5.0",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.5.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.5.1.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.5.1",
+    "ksp_version":  "1.5.0",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.6.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.6.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.6.0",
+    "ksp_version":  "1.6.0",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.6.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.6.1.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.6.1",
+    "ksp_version":  "1.6.1",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.7.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.7.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.7.0",
+    "ksp_version":  "1.7.0",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.7.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.7.1.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.7.1",
+    "ksp_version":  "1.7.1",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.8.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.8.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.8.0",
+    "ksp_version":  "1.8.0",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.8.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.8.1.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.8.1",
+    "ksp_version":  "1.8.1",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.9.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.9.0.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.9.0",
+    "ksp_version":  "1.9.0",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}

--- a/MakingHistory-DLC/MakingHistory-DLC-1.9.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.9.1.ckan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.28",
+    "identifier":   "MakingHistory-DLC",
+    "name":         "Making History",
+    "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
+    "author":       "SQUAD",
+    "version":      "1.9.1",
+    "ksp_version":  "1.9.1",
+    "kind":         "dlc",
+    "license":      "restricted",
+    "resources": {
+        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
+        "steamstore": "https://store.steampowered.com/app/283740"
+    }
+}


### PR DESCRIPTION
This PR adds a .ckan file for each known version of each DLC, based on the change logs in their `readme.txt` files, following the format created in KSP-CKAN/CKAN#3038.

The spec version is `v1.28`, so it should be safe to merge this without disrupting the existing clients, all of which are on `v1.27` or earlier.