### PR TITLE
ModularLaunchPads historical dependencies

### DIFF
--- a/ModularLaunchPads/ModularLaunchPads-1.01.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.01.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.01",
     "ksp_version": "1.4.1",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.01",
     "download_size": 7166546,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.1.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.1.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.1",
     "ksp_version": "1.4.2",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.1",
     "download_size": 8192443,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.2.1.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.2.1.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.2.1",
     "ksp_version": "1.4.2",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.2.1",
     "download_size": 8887635,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.2.2.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.2.2.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.2.2",
     "ksp_version": "1.4.3",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.2.2",
     "download_size": 8936999,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.2.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.2.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.2",
     "ksp_version": "1.4.2",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.2",
     "download_size": 8888181,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.3.0.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.3.0.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.3.0",
     "ksp_version": "1.4.3",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.3.0",
     "download_size": 17647173,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.3.1.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.3.1.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.3.1",
     "ksp_version": "1.4.3",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.3.1",
     "download_size": 13631209,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.3.2.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.3.2.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.3.2",
     "ksp_version": "1.4.3",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.3.2",
     "download_size": 13679716,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.3.3.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.3.3.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.3.3",
     "ksp_version": "1.4.4",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.3.3",
     "download_size": 13680143,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.3.4.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.3.4.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.3.4",
     "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.3.4",
     "download_size": 13691934,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.3.5.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.3.5.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.3.5",
     "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.3.5",
     "download_size": 13698970,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.3.6.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.3.6.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.3.6",
     "ksp_version": "1.4.5",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.3.6",
     "download_size": 13703251,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.3.7.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.3.7.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.3.7",
     "ksp_version": "1.5.1",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.3.7",
     "download_size": 13703591,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-1.3.8.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-1.3.8.ckan
@@ -12,6 +12,22 @@
     },
     "version": "1.3.8",
     "ksp_version": "1.7.2",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/1.3.8",
     "download_size": 13703803,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-2.0.0.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-2.0.0.ckan
@@ -12,6 +12,22 @@
     },
     "version": "2.0.0",
     "ksp_version": "1.7.3",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/2.0.0",
     "download_size": 42464892,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-2.0.1.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-2.0.1.ckan
@@ -12,6 +12,22 @@
     },
     "version": "2.0.1",
     "ksp_version": "1.7.3",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/2.0.1",
     "download_size": 42483544,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-2.0.2.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-2.0.2.ckan
@@ -12,6 +12,22 @@
     },
     "version": "2.0.2",
     "ksp_version": "1.7.3",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/2.0.2",
     "download_size": 42438733,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-2.0.3.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-2.0.3.ckan
@@ -12,6 +12,22 @@
     },
     "version": "2.0.3",
     "ksp_version": "1.7.3",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/2.0.3",
     "download_size": 42766646,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-2.0.4.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-2.0.4.ckan
@@ -12,6 +12,22 @@
     },
     "version": "2.0.4",
     "ksp_version": "1.7.3",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/2.0.4",
     "download_size": 42817072,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-2.0.5.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-2.0.5.ckan
@@ -12,6 +12,22 @@
     },
     "version": "2.0.5",
     "ksp_version": "1.8.1",
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/2.0.5",
     "download_size": 42071809,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-2.0.6.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-2.0.6.ckan
@@ -15,6 +15,22 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/2.0.6",
     "download_size": 42074742,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-2.0.7.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-2.0.7.ckan
@@ -15,6 +15,22 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/2.0.7",
     "download_size": 42177275,
     "download_hash": {

--- a/ModularLaunchPads/ModularLaunchPads-2.0.7b.ckan
+++ b/ModularLaunchPads/ModularLaunchPads-2.0.7b.ckan
@@ -15,6 +15,22 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        {
+            "name": "B9PartSwitch"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "AnimatedDecouplers"
+        },
+        {
+            "name": "CommunityCategoryKit"
+        },
+        {
+            "name": "KSCExtended"
+        }
+    ],
     "download": "https://spacedock.info/mod/1767/AlphaMensae%27s%20Modular%20Launch%20Pads/download/2.0.7b",
     "download_size": 42176763,
     "download_hash": {


### PR DESCRIPTION
Historical version of KSP-CKAN/NetKAN#7865.

Apparently these dependencies go all the way back, as they're bundled as ZIPs-within-a-ZIP in even the earliest versions.

ckan compat add 1.7.3