### PR TITLE
Create patched AIES release

### DIFF
--- a/AIESAerospace-Unofficial/AIESAerospace-Unofficial-1.6.1-patched.ckan
+++ b/AIESAerospace-Unofficial/AIESAerospace-Unofficial-1.6.1-patched.ckan
@@ -1,0 +1,32 @@
+{
+    "spec_version": 1,
+    "identifier": "AIESAerospace-Unofficial",
+    "name": "AIES Aerospace",
+    "abstract": "The AIES project is a set pieces to make almost any type of mission, more than 80 pieces so far, engine, fuel tank of any size, Pods, fixed solar panels, SAS, rcs tank, landing legs among others. ",
+    "author": "carmics",
+    "version": "1.6.1-patched",
+    "license": "restricted",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/30974-*"
+    },
+    "tags": [
+        "parts"
+    ],
+    "depends": [
+        { "name": "AIES-Patches" }
+    ],
+    "install": [
+        {
+            "file": "AIES_Aerospace",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://media.forgecdn.net/files/2252/518/AIES_Aerospace161.zip",
+    "download_size": 11162987,
+    "download_hash": {
+        "sha1": "A02640E7F2FF23BE8535B1A67E6C80D43077824F",
+        "sha256": "55E19FB6CD21EE74E4950A228C152EA51FFCE12C18A4595FB67473CAB70FA9DA"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
See KSP-CKAN/CKAN#3000; @linuxgurugamer made an AIES-Patches module to make AIESAerospace-Unofficial work on recent versions, but installation currently requires setting KSP 1.0 as compatible temporarily.

This PR implements the suggested workaround of a special version compatible with all KSP versions but depending on the patches.