### PR TITLE
Fix scatterer sunflare install issues

### DIFF
--- a/Spectra/Spectra-v1.2.5.ckan
+++ b/Spectra/Spectra-v1.2.5.ckan
@@ -20,7 +20,7 @@
     ],
     "provides": [
         "PlanetShine-Config",
-        "EnvironmentalVisualEnhancements-Config",
+        "EnvironmentalVisualEnhancements-Config"
     ],
     "depends": [
         {

--- a/Spectra/Spectra-v1.2.5.ckan
+++ b/Spectra/Spectra-v1.2.5.ckan
@@ -21,7 +21,6 @@
     "provides": [
         "PlanetShine-Config",
         "EnvironmentalVisualEnhancements-Config",
-        "Scatterer-sunflare"
     ],
     "depends": [
         {
@@ -34,6 +33,9 @@
         },
         {
             "name": "Scatterer"
+        },
+        {
+            "name": "Scatterer-sunflare"
         },
         {
             "name": "TextureReplacer"
@@ -63,9 +65,6 @@
         },
         {
             "name": "EnvironmentalVisualEnhancements-Config"
-        },
-        {
-            "name": "Scatterer-sunflare"
         },
         {
             "name": "GreenSkullRevived"


### PR DESCRIPTION
People are reporting the Spectra sunflare not working properly because Spectra marks Scatterer-sunflare as incompatible, when in fact it require it to be installed for the custom sunflare to work. I moved Scatterer-sunflare from "conflicts" over to "recommends" to fix this.