### PR TITLE
Restore AVP 4.0.2

### DIFF
--- a/AstronomersVisualPack/AstronomersVisualPack-2-4.0.2.0.ckan
+++ b/AstronomersVisualPack/AstronomersVisualPack-2-4.0.2.0.ckan
@@ -57,11 +57,11 @@
             "name": "EnvironmentalVisualEnhancements-Config"
         }
     ],
-    "download": "https://github.com/themaster402/AstronomersVisualPack/releases/download/v4.03/AVP.v.4.03.zip",
-    "download_size": 50832292,
+    "download": "https://github.com/themaster402/AstronomersVisualPack/releases/download/v4.02/AVP.v.4.02.zip",
+    "download_size": 50830982,
     "download_hash": {
-        "sha1": "B25CDEE81307279B7BC9772969CAA50BF2C30FB2",
-        "sha256": "07F7EFCC78AA129EEE1B342CF68767435F99226244C9717960386294BA2D5714"
+        "sha1": "A0A3AC89BAE36D3578B96B94526C06524102E307",
+        "sha256": "88CB16AD327B6A8754819B54B17EA750929E1FC1A9F75C07F088F7293E2FCF43"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
See KSP-CKAN/NetKAN#7876 and themaster402/AstronomersVisualPack#16, this mod's 4.0.3 release replaced 4.0.2 because its version file wasn't updated. This reverts commit 548803b3c76a0198d12b5dd2b234ccb702710ee5.

ckan compat add 1.8