### PR TITLE
Make historical ASETAvionics compatible with all game versions

### DIFF
--- a/ASETAvionics/ASETAvionics-1.0.ckan
+++ b/ASETAvionics/ASETAvionics-1.0.ckan
@@ -9,8 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/116479-*"
     },
     "version": "1.0",
-    "ksp_version_min": "1.0.4",
-    "ksp_version_max": "1.1.3",
+    "ksp_version": "any",
     "depends": [
         {
             "name": "ASETProps"

--- a/ASETAvionics/ASETAvionics-2.0.ckan
+++ b/ASETAvionics/ASETAvionics-2.0.ckan
@@ -11,7 +11,7 @@
         "x_screenshot": "https://spacedock.info/content/alexustas_3789/ASET_Avionics/ASET_Avionics-1486632235.7713456.png"
     },
     "version": "2.0",
-    "ksp_version": "1.3.1",
+    "ksp_version": "any",
     "depends": [
         {
             "name": "ASETAgency"


### PR DESCRIPTION
Historical version of KSP-CKAN/NetKAN#7908, these are data files that can be used on any game version where the dependencies are available.