### PR TITLE
Make historical ASETProps compatible with all game versions

### DIFF
--- a/ASETProps/ASETProps-1.3.ckan
+++ b/ASETProps/ASETProps-1.3.ckan
@@ -9,8 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/116430-*"
     },
     "version": "1.3",
-    "ksp_version_min": "1.0.4",
-    "ksp_version_max": "1.1.3",
+    "ksp_version": "any",
     "depends": [
         {
             "name": "RasterPropMonitor-Core",

--- a/ASETProps/ASETProps-1.4.ckan
+++ b/ASETProps/ASETProps-1.4.ckan
@@ -11,8 +11,7 @@
         "x_screenshot": "https://spacedock.info/content/alexustas_3789/ASET_Props/ASET_Props-1486510832.1924078.png"
     },
     "version": "1.4",
-    "ksp_version_min": "1.2",
-    "ksp_version_max": "1.3",
+    "ksp_version": "any",
     "depends": [
         {
             "name": "ASETAgency"


### PR DESCRIPTION
Historical version of KSP-CKAN/NetKAN#7909, these are data files that can be used on any game version where the dependencies are available.