### PR TITLE
Fix historical compatibility for SeparatorDestroyer

### DIFF
--- a/SeparatorDestroyer/SeparatorDestroyer-1.0.0.0.ckan
+++ b/SeparatorDestroyer/SeparatorDestroyer-1.0.0.0.ckan
@@ -4,14 +4,24 @@
     "name": "Separator Destroyer",
     "abstract": "Converts stack separators in to explosive bagels. Completely destroys the stack separator when it is decoupled.",
     "author": "Xyphos",
+    "version": "1.0.0.0",
+    "ksp_version_min": "1.2.2",
+    "ksp_version_max": "1.3",
     "license": "public-domain",
     "resources": {
         "homepage": "https://github.com/Xyphos/KSP_SeparatorDestroyer",
         "spacedock": "https://spacedock.info/mod/1379/Separator%20Destroyer",
         "repository": "https://github.com/Xyphos/KSP_SeparatorDestroyer"
     },
-    "version": "1.0.0.0",
-    "ksp_version": "1.2.2",
+    "tags": [
+        "plugin",
+        "convenience"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "install": [
         {
             "find": "XyphosAerospace",

--- a/SeparatorDestroyer/SeparatorDestroyer-1.0.0.1.ckan
+++ b/SeparatorDestroyer/SeparatorDestroyer-1.0.0.1.ckan
@@ -4,14 +4,24 @@
     "name": "Separator Destroyer",
     "abstract": "Adds a GUI menu to stack separators to optionally destroy them when they are decoupled. this feature is disabled by default and will not work with omni-directional decouplers.",
     "author": "Xyphos",
+    "version": "1.0.0.1",
+    "ksp_version_min": "1.3",
+    "ksp_version_max": "1.7",
     "license": "public-domain",
     "resources": {
         "homepage": "https://github.com/Xyphos/KSP_SeparatorDestroyer",
         "spacedock": "https://spacedock.info/mod/1379/Separator%20Destroyer",
         "repository": "https://github.com/Xyphos/KSP_SeparatorDestroyer"
     },
-    "version": "1.0.0.1",
-    "ksp_version": "1.2.2",
+    "tags": [
+        "plugin",
+        "convenience"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
     "install": [
         {
             "find": "XyphosAerospace",


### PR DESCRIPTION
See https://github.com/KSP-CKAN/CKAN-meta/pull/1922 and https://github.com/KSP-CKAN/NetKAN/pull/7921

Fixes the historical compatibility data to how I think it's supposed to be.

Also took the opportunity to backport the tags and the ModuleManager dependency, because why not.