### PR TITLE
Fix historical RSSDateTimeFormatter compatibility

### DIFF
--- a/RSSDateTimeFormatter/RSSDateTimeFormatter-1.4.3.0.ckan
+++ b/RSSDateTimeFormatter/RSSDateTimeFormatter-1.4.3.0.ckan
@@ -12,6 +12,7 @@
         "bugtracker": "https://github.com/KSP-RO/RSSTimeFormatter/issues"
     },
     "version": "1.4.3.0",
+    "ksp_version": "1.4.3",
     "install": [
         {
             "file": "GameData/RSSDateTime",

--- a/RSSDateTimeFormatter/RSSDateTimeFormatter-1.4.5.0.ckan
+++ b/RSSDateTimeFormatter/RSSDateTimeFormatter-1.4.5.0.ckan
@@ -12,6 +12,7 @@
         "bugtracker": "https://github.com/KSP-RO/RSSTimeFormatter/issues"
     },
     "version": "1.4.5.0",
+    "ksp_version": "1.4.5",
     "install": [
         {
             "file": "GameData/RSSDateTime",

--- a/RSSDateTimeFormatter/RSSDateTimeFormatter-1.5.1.0.ckan
+++ b/RSSDateTimeFormatter/RSSDateTimeFormatter-1.5.1.0.ckan
@@ -12,6 +12,7 @@
         "bugtracker": "https://github.com/KSP-RO/RSSTimeFormatter/issues"
     },
     "version": "1.5.1.0",
+    "ksp_version": "1.5.1",
     "install": [
         {
             "file": "GameData/RSSDateTime",


### PR DESCRIPTION
See KSP-RO/RSSTimeFormatter#16, this mod used to have a version file, but it got dropped. Now the compatibility of historical versions is updated to reflect the release announcements.

- https://github.com/KSP-RO/RSSTimeFormatter/releases

The current version is not updated because the bot will just overwrite it until that issue is fixed.