### PR TITLE
Historic SpaceXLaunchVehicles installation fixes

### DIFF
--- a/SpaceXLaunchVehicles-StockSize/SpaceXLaunchVehicles-StockSize-6.1.ckan
+++ b/SpaceXLaunchVehicles-StockSize/SpaceXLaunchVehicles-StockSize-6.1.ckan
@@ -1,7 +1,7 @@
 {
-    "spec_version": "v1.4",
-    "identifier": "SpaceXLaunchVehicles",
-    "name": "SpaceX Launch Vehicles - Real Size",
+    "spec_version": "v1.18",
+    "identifier": "SpaceXLaunchVehicles-StockSize",
+    "name": "SpaceX Launch Vehicles - Stock Size",
     "abstract": "Crew Dragon, Starlink, Falcon 9, Falcon Heavy, Drone Ships to land your boosters on, Raptor engines and much more!",
     "author": "Kartoffelkuchen",
     "version": "6.1",
@@ -14,6 +14,9 @@
     },
     "tags": [
         "parts"
+    ],
+    "provides": [
+        "SpaceXLaunchVehicles"
     ],
     "depends": [
         {
@@ -33,7 +36,7 @@
     ],
     "conflicts": [
         {
-            "name": "SpaceXLaunchVehicles-StockSize"
+            "name": "SpaceXLaunchVehicles"
         }
     ],
     "install": [
@@ -46,7 +49,12 @@
             "install_to": "GameData"
         },
         {
-            "file": "Ships/VAB",
+            "file": "Rescaled/GameData",
+            "install_to": "GameData",
+            "as": "Kartoffelkuchen"
+        },
+        {
+            "file": "Rescaled/Ships/VAB",
             "install_to": "Ships"
         }
     ],

--- a/SpaceXLaunchVehicles/SpaceXLaunchVehicles-6.0.ckan
+++ b/SpaceXLaunchVehicles/SpaceXLaunchVehicles-6.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "SpaceXLaunchVehicles",
-    "name": "SpaceX Launch Vehicles",
+    "name": "SpaceX Launch Vehicles - Real Size",
     "abstract": "Crew Dragon, Starlink, Falcon 9, Falcon Heavy, Drone Ships to land your boosters on, Raptor engines and much more!",
     "author": "Kartoffelkuchen",
     "version": "6.0",
@@ -31,6 +31,11 @@
             "name": "RetractableLiftingSurface"
         }
     ],
+    "conflicts": [
+        {
+            "name": "SpaceXLaunchVehicles-StockSize"
+        }
+    ],
     "install": [
         {
             "find": "Kartoffelkuchen",
@@ -41,7 +46,7 @@
             "install_to": "GameData"
         },
         {
-            "find": "Ships/VAB",
+            "file": "KK_SpaceX_v600/Ships/VAB",
             "install_to": "Ships"
         }
     ],


### PR DESCRIPTION
See https://github.com/KSP-CKAN/NetKAN/pull/7962

This backports the `find`->`file` change until version `6.0`, before there was no `Rescaled/Ships/VAB` folder, so no ambiguity problem.
Also backported the name change and the new conflict with `SpaceXLaunchVehicles-StockSize` along the way.

I also created the `SpaceXLaunchVehicles-StockSize` ckan file for `6.1`.
`6.0` had a different folder structure and is also for 1.9.1, so it's not worth the effort to hand-craft a ckan file just for this.
Before `6.0` there were no files for a stock size version.