### PR TITLE
Manually index SCANsat v20.0

### DIFF
--- a/SCANsat/SCANsat-v20.0.ckan
+++ b/SCANsat/SCANsat-v20.0.ckan
@@ -1,0 +1,63 @@
+{
+    "spec_version": 1,
+    "identifier": "SCANsat",
+    "name": "SCANsat",
+    "abstract": "SCANsat: Real Scanning, Real Science, Warp Speed!",
+    "author": "DMagic",
+    "version": "v20.0",
+    "ksp_version_min": "1.8.1",
+    "ksp_version_max": "1.9.8",
+    "license": "restricted",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72679-1",
+        "spacedock": "https://spacedock.info/mod/129/SCANsat",
+        "repository": "https://github.com/S-C-A-N/SCANsat",
+        "license": "https://github.com/S-C-A-N/SCANsat/blob/release/SCANsat/LICENSE.txt",
+        "x_screenshot": "https://spacedock.info/content/DMagic_247/SCANsat/SCANsat-1455816692.2400143.png"
+    },
+    "tags": [
+        "plugin",
+        "information",
+        "resources"
+    ],
+    "localizations": [
+        "de-de",
+        "en-us",
+        "es-es",
+        "fr-fr",
+        "pt-br",
+        "ru",
+        "zh-cn"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "Toolbar"
+        },
+        {
+            "name": "ContractConfigurator"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "RasterPropMonitor"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "ContractConfigurator-ScanSatLite"
+        }
+    ],
+    "download": "https://spacedock.info/mod/129/SCANsat/download/v20.0",
+    "download_size": 20178080,
+    "download_hash": {
+        "sha1": "36BFB651BF6E823B89AFBBAB66FEA1BFB9BB52EC",
+        "sha256": "0BC17D00F56E1F2D748698718684C0FFFA0B62F9238763BB76B69E6961D5174F"
+    },
+    "download_content_type": "application/zip",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
See S-C-A-N/SCANsat#371, this version of SCANsat has a syntax error in its version file, so it has been erroring out in the bot and hasn't been indexed.

![image](https://user-images.githubusercontent.com/1559108/84921457-0a33f300-b0b4-11ea-8f95-b45e7a9022e3.png)

A fix version hasn't come out yet, and people continue to ask about it despite repeated announcements on the forum and Discord, so we might as well work around the issue.

Process for generating this file:

1. Temporarily remove the vref from a local copy of the netkan
2. `netkan.exe NetKAN/SCANsat.netkan`
3. Edit `SCANsat-v20.0.ckan` to add the version compatibility that it's supposed to have
4. Move to `CKAN-meta/SCANsat`