### PR TITLE
Rename SpaceTuxLibrary-0.0.0.2.1.ckan to SpaceTuxLibrary-0.0.2.1.ckan

### DIFF
--- a/SpaceTuxLibrary/SpaceTuxLibrary-0.0.2.1.ckan
+++ b/SpaceTuxLibrary/SpaceTuxLibrary-0.0.2.1.ckan
@@ -9,7 +9,7 @@
         "spacedock": "https://spacedock.info/mod/2210/SpaceTux%20Library",
         "repository": "https://github.com/linuxgurugamer/SpaceTuxLibrary"
     },
-    "version": "0.0.0.2.1",
+    "version": "0.0.2.1",
     "ksp_version": "1.8.0",
     "install": [
         {


### PR DESCRIPTION
LGG made us aware of this typoed version number, and asked us to freeze it.
It should have been `0.0.2.1`, but was `0.0.0.2.1`.

I think that just renaming it works just as well to get it into the right sorting order again, without loosing this version completely.
The version on SpaceDock still has the additional zero, but it's not a big deal since the download link stays the same.

It _might_ confuse some user seeing this version on CKAN and trying to find it on SpaceDock (or the other way around), but it would be the first user to take a close look at version numbers.
And it's also not even the most release for this version of KSP (1.8.0), so it's unlikely that anyone would ever try to install it in the future.