### PR TITLE
Update PersistentThrust hashes

### DIFF
--- a/PersistentThrust/PersistentThrust-1-1.2.1.ckan
+++ b/PersistentThrust/PersistentThrust-1-1.2.1.ckan
@@ -38,10 +38,10 @@
         }
     ],
     "download": "https://spacedock.info/mod/2450/Persistent%20Thrust/download/1.2.1",
-    "download_size": 68703,
+    "download_size": 68700,
     "download_hash": {
-        "sha1": "F7FF8A51363145DA1A9C4B037A28170C2CD1883C",
-        "sha256": "8C21F8A095EC62FD3C8AEC947F60182A8069B93E528454D36D3562246EC2F9C7"
+        "sha1": "4B93917263144A158AFB1C6885FF9ABF0934B53A",
+        "sha256": "4FA2F2930F14F26EF491B8015703357002BF8DF61EE7CA1E7EC60F689FD1070F"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/PersistentThrust/PersistentThrust-1-1.4.5.ckan
+++ b/PersistentThrust/PersistentThrust-1-1.4.5.ckan
@@ -41,10 +41,10 @@
         }
     ],
     "download": "https://spacedock.info/mod/2450/Persistent%20Thrust/download/1.4.5",
-    "download_size": 73267,
+    "download_size": 73268,
     "download_hash": {
-        "sha1": "0413799F7497D1F5B0B2F41F107A506EDBF57AC6",
-        "sha256": "0964EBE969D63A2B523094CD839D632B82937DF8DF5E87FA71589E93D405BEB3"
+        "sha1": "B7FD6990212DCFBCE4944FA9FA2120CE49CAE281",
+        "sha256": "28DB3A374889C8C79AF4DA50B56F885DE43103C977BC28371D09B55614987E5F"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
Users are complaining about hash mismatches on this thread; some versions must have been replaced after indexing. I ran `netkan.exe --releases 15`.

https://forum.kerbalspaceprogram.com/index.php?/topic/194707-171181191-persistent-thrust-extended-145/