### PR TITLE
Recommend TestLite for historical RP-0 versions

### DIFF
--- a/RP-0/RP-0-v1.3.ckan
+++ b/RP-0/RP-0-v1.3.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "RP-0",
     "name": "Realistic Progression One (RP-1)",
     "abstract": "Realistic Progression One - Career for Realism Overhaul",
@@ -84,10 +84,14 @@
             "name": "RCSBuildAidCont"
         },
         {
-            "name": "RealAntennas"
-        },
-        {
-            "name": "RemoteTech"
+            "any_of": [
+                {
+                    "name": "RealAntennas"
+                },
+                {
+                    "name": "RemoteTech"
+                }
+            ]
         },
         {
             "name": "SCANsat"
@@ -105,7 +109,14 @@
             "name": "TACLS"
         },
         {
-            "name": "TestFlight"
+            "any_of": [
+                {
+                    "name": "TestFlight"
+                },
+                {
+                    "name": "TestLite"
+                }
+            ]
         },
         {
             "name": "TextureReplacer"

--- a/RP-0/RP-0-v1.4.1.ckan
+++ b/RP-0/RP-0-v1.4.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "RP-0",
     "name": "Realistic Progression One (RP-1)",
     "abstract": "Realistic Progression One - Career for Realism Overhaul",
@@ -88,10 +88,14 @@
             "name": "RCSBuildAidCont"
         },
         {
-            "name": "RealAntennas"
-        },
-        {
-            "name": "RemoteTech"
+            "any_of": [
+                {
+                    "name": "RealAntennas"
+                },
+                {
+                    "name": "RemoteTech"
+                }
+            ]
         },
         {
             "name": "SCANsat"
@@ -109,7 +113,14 @@
             "name": "TACLS"
         },
         {
-            "name": "TestFlight"
+            "any_of": [
+                {
+                    "name": "TestFlight"
+                },
+                {
+                    "name": "TestLite"
+                }
+            ]
         },
         {
             "name": "TextureReplacer"

--- a/RP-0/RP-0-v1.4.ckan
+++ b/RP-0/RP-0-v1.4.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "RP-0",
     "name": "Realistic Progression One (RP-1)",
     "abstract": "Realistic Progression One - Career for Realism Overhaul",
@@ -84,10 +84,14 @@
             "name": "RCSBuildAidCont"
         },
         {
-            "name": "RealAntennas"
-        },
-        {
-            "name": "RemoteTech"
+            "any_of": [
+                {
+                    "name": "RealAntennas"
+                },
+                {
+                    "name": "RemoteTech"
+                }
+            ]
         },
         {
             "name": "SCANsat"
@@ -105,7 +109,14 @@
             "name": "TACLS"
         },
         {
-            "name": "TestFlight"
+            "any_of": [
+                {
+                    "name": "TestFlight"
+                },
+                {
+                    "name": "TestLite"
+                }
+            ]
         },
         {
             "name": "TextureReplacer"


### PR DESCRIPTION
Historical version of KSP-RO/RP-0#1303; RP-0 has been recommending conflicting mods, and TestLite has just been indexed.
Now RP-0 versions back to KSP 1.6.1 through 1.7.3 are fixed and updated.