### PR TITLE
Mark historical SmokeScreen versions as compatible back to KSP 1.5

### DIFF
--- a/SmokeScreen/SmokeScreen-2.8.3.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.8.3.0.ckan
@@ -11,7 +11,7 @@
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.8.3.0",
-    "ksp_version_min": "1.7.0",
+    "ksp_version_min": "1.5.0",
     "ksp_version_max": "1.7.90",
     "install": [
         {

--- a/SmokeScreen/SmokeScreen-2.8.4.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.8.4.0.ckan
@@ -11,7 +11,7 @@
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.8.4.0",
-    "ksp_version_min": "1.7.0",
+    "ksp_version_min": "1.5.0",
     "ksp_version_max": "1.7.90",
     "install": [
         {

--- a/SmokeScreen/SmokeScreen-2.8.5.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.8.5.0.ckan
@@ -11,7 +11,7 @@
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.8.5.0",
-    "ksp_version_min": "1.7.0",
+    "ksp_version_min": "1.5.0",
     "ksp_version_max": "1.7.90",
     "install": [
         {

--- a/SmokeScreen/SmokeScreen-2.8.6.0.ckan
+++ b/SmokeScreen/SmokeScreen-2.8.6.0.ckan
@@ -11,7 +11,7 @@
         "ci": "https://ksp.sarbian.com/jenkins/job/SmokeScreen/"
     },
     "version": "2.8.6.0",
-    "ksp_version_min": "1.7.0",
+    "ksp_version_min": "1.5.0",
     "ksp_version_max": "1.7.90",
     "install": [
         {


### PR DESCRIPTION
## Problem

The [RP-0 installation wiki] for KSP 1.6.1 includes this odd and mysterious tidbit:

> Via CKAN, revert SmokeScreen version to v2.8.1. The version that gets installed automatically doesn't work correctly
>
> ![screenshot](https://cdn.discordapp.com/attachments/512556137380315139/623208783522299914/2019-09-16_20-28-12.jpg)

## Cause

Digging into [the forum thread], it turns out that 2.8.2.0 was buggy and threw exceptions like crazy. 2.8.3.0 through 2.8.6.0 were fix releases that had no new version requirements announced. 2.8.7.0 was announced for KSP 1.8.

However, KSP-CKAN/NetKAN#7312 was merged between 2.8.2.0 and 2.8.3.0 and set the minimum compatibility of the netkan to 1.7, and thus the buggy release ended up being the last one for KSP 1.5 and 1.6.

## Changes

Now these releases are compatible with KSP 1.5 through 1.7, to ensure they will be installed instead of 2.8.2.0.

[RP-0 installation wiki]: https://github.com/KSP-RO/RP-0/wiki/RO-&-RP-1-Installation-for-1.6.1
[the forum thread]: https://forum.kerbalspaceprogram.com/index.php?/topic/64987-18x-19x-smokescreen-2814-extended-fx-plugin-18-april-2020/&do=findComment&comment=3633705