### PR TITLE
Fill in missing author properties

### DIFF
--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
@@ -3,6 +3,7 @@
     "identifier": "AdvancedJetEngine",
     "name": "Advanced Jet Engine (AJE)",
     "abstract": "Realistic jet engines for KSP",
+    "author": "camlost",
     "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {

--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
@@ -3,6 +3,7 @@
     "identifier": "AdvancedJetEngine",
     "name": "Advanced Jet Engine (AJE)",
     "abstract": "Realistic jet engines for KSP",
+    "author": "camlost",
     "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {

--- a/AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
@@ -3,6 +3,7 @@
     "identifier": "AdvancedJetEngine",
     "name": "Advanced Jet Engine (AJE)",
     "abstract": "Realistic jet engines for KSP",
+    "author": "camlost",
     "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {

--- a/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
+++ b/AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
@@ -3,6 +3,7 @@
     "identifier": "AdvancedJetEngine",
     "name": "Advanced Jet Engine (AJE)",
     "abstract": "Realistic jet engines for KSP",
+    "author": "camlost",
     "license": "LGPL-2.0",
     "release_status": "stable",
     "resources": {

--- a/CustomBiomes/CustomBiomes-1.6.8.ckan
+++ b/CustomBiomes/CustomBiomes-1.6.8.ckan
@@ -3,6 +3,7 @@
     "identifier": "CustomBiomes",
     "name": "Custom Biomes",
     "abstract": "Add or replace biomes to any celestial body in KSP",
+    "author": "NathanKell",
     "license": "CC-BY-NC-SA-3.0",
     "release_status": "stable",
     "resources": {

--- a/DynamicBatteryStorage/DynamicBatteryStorage-1.0.0.ckan
+++ b/DynamicBatteryStorage/DynamicBatteryStorage-1.0.0.ckan
@@ -4,6 +4,7 @@
     "identifier": "DynamicBatteryStorage",
     "name": "Dynamic Battery Storage",
     "abstract": "A plugin that works around the problems of stock electricity consumption/generation at high time warp.",
+    "author": "Nertea",
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "repository": "https://github.com/ChrisAdderley/DynamicBatteryStorage"

--- a/EarlyBird/EarlyBird-0.1.5.0.ckan
+++ b/EarlyBird/EarlyBird-0.1.5.0.ckan
@@ -3,6 +3,7 @@
     "identifier": "EarlyBird",
     "name": "EarlyBird",
     "abstract": "Early Bird is a mod for better warp-to-morning functionality. Currently, it modifies the warp-to-morning feature such that warp ends five minutes before sunrise, taking the space center latitude into account (not relevant for stock Kerbin, but relevant for any planet mod that fakes axial tilt",
+    "author": "taniwha",
     "license": "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/162477-*",

--- a/EarlyBird/EarlyBird-0.1.6.0.ckan
+++ b/EarlyBird/EarlyBird-0.1.6.0.ckan
@@ -3,6 +3,7 @@
     "identifier": "EarlyBird",
     "name": "EarlyBird",
     "abstract": "Early Bird is a mod for better warp-to-morning functionality. Currently, it modifies the warp-to-morning feature such that warp ends five minutes before sunrise, taking the space center latitude into account (not relevant for stock Kerbin, but relevant for any planet mod that fakes axial tilt",
+    "author": "taniwha",
     "license": "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/162477-*",

--- a/EarlyBird/EarlyBird-0.1.7.0.ckan
+++ b/EarlyBird/EarlyBird-0.1.7.0.ckan
@@ -3,6 +3,7 @@
     "identifier": "EarlyBird",
     "name": "EarlyBird",
     "abstract": "Early Bird is a mod for better warp-to-morning functionality. Currently, it modifies the warp-to-morning feature such that warp ends five minutes before sunrise, taking the space center latitude into account (not relevant for stock Kerbin, but relevant for any planet mod that fakes axial tilt",
+    "author": "taniwha",
     "version": "0.1.7.0",
     "ksp_version_min": "1.3.1",
     "ksp_version_max": "1.5.99",

--- a/EarlyBird/EarlyBird-0.2.0.0.ckan
+++ b/EarlyBird/EarlyBird-0.2.0.0.ckan
@@ -3,6 +3,7 @@
     "identifier": "EarlyBird",
     "name": "EarlyBird",
     "abstract": "Early Bird is a mod for better warp-to-morning functionality. Currently, it modifies the warp-to-morning feature such that warp ends five minutes before sunrise, taking the space center latitude into account (not relevant for stock Kerbin, but relevant for any planet mod that fakes axial tilt",
+    "author": "taniwha",
     "version": "0.2.0.0",
     "ksp_version_min": "1.8.0",
     "ksp_version_max": "1.9.99",

--- a/PunishTheLazy/PunishTheLazy-0.01.ckan
+++ b/PunishTheLazy/PunishTheLazy-0.01.ckan
@@ -3,6 +3,7 @@
     "identifier": "PunishTheLazy",
     "name": "Punish The Lazy",
     "abstract": "A really simple reputation nibbler.",
+    "author": "Technicalfool",
     "license": "GPL-2.0",
     "release_status": "stable",
     "resources": {

--- a/ResetSAS/ResetSAS-0.01.ckan
+++ b/ResetSAS/ResetSAS-0.01.ckan
@@ -3,6 +3,7 @@
     "identifier": "ResetSAS",
     "name": "ResetSAS",
     "abstract": "Set SAS mode to attitude hold when you turn SAS off and on.",
+    "author": "Technicalfool",
     "license": "MIT",
     "release_status": "stable",
     "resources": {

--- a/SciFiVisualEnhancements/SciFiVisualEnhancements-v1.4.ckan
+++ b/SciFiVisualEnhancements/SciFiVisualEnhancements-v1.4.ckan
@@ -3,6 +3,7 @@
     "identifier": "SciFiVisualEnhancements",
     "name": "Sci-Fi Visual Enhancements",
     "abstract": "High performance alternative to StockVisualEnhancements",
+    "author": "panzer1b",
     "license": "unrestricted",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/151190-*"

--- a/SciFiVisualEnhancements/SciFiVisualEnhancements-v1.5.ckan
+++ b/SciFiVisualEnhancements/SciFiVisualEnhancements-v1.5.ckan
@@ -3,6 +3,7 @@
     "identifier": "SciFiVisualEnhancements",
     "name": "Sci-Fi Visual Enhancements",
     "abstract": "High performance alternative to StockVisualEnhancements",
+    "author": "panzer1b",
     "version": "v1.5",
     "ksp_version": "1.6",
     "license": "unrestricted",

--- a/kOS/kOS-0.14.ckan
+++ b/kOS/kOS-0.14.ckan
@@ -4,6 +4,7 @@
     "name": "kOS - Kerbal OS",
     "abstract": "A programming and automation environment for KSP craft.",
     "license": "GPL-3.0",
+    "author": "erendrake",
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/68089-0-23-kOS-Scriptable-Autopilot-System-v0-11-2-13",


### PR DESCRIPTION
See https://github.com/KSP-CKAN/CKAN/pull/3111, these ckans are missing the author property.
This PR adds it to those that validate successfully,there's another PR for those that fail validation (#2109).
There will also be a PR for some NetKAN files, which I have yet to create, but should be merged first.

`grep -L "author" **/*.ckan`
```
AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
CustomBiomes/CustomBiomes-1.6.8.ckan
DynamicBatteryStorage/DynamicBatteryStorage-1.0.0.ckan
EarlyBird/EarlyBird-0.1.5.0.ckan
EarlyBird/EarlyBird-0.1.6.0.ckan
EarlyBird/EarlyBird-0.1.7.0.ckan
EarlyBird/EarlyBird-0.2.0.0.ckan
kOS/kOS-0.14.ckan
PunishTheLazy/PunishTheLazy-0.01.ckan
ResetSAS/ResetSAS-0.01.ckan
SciFiVisualEnhancements/SciFiVisualEnhancements-v1.4.ckan
SciFiVisualEnhancements/SciFiVisualEnhancements-v1.5.ckan
```