### PR TITLE
Set ksp_version_max for CommunityDeltaVMaps

### DIFF
--- a/CommunityDeltaVMaps/CommunityDeltaVMaps-v2.6.0.ckan
+++ b/CommunityDeltaVMaps/CommunityDeltaVMaps-v2.6.0.ckan
@@ -15,6 +15,7 @@
     ],
     "version": "v2.6.0",
     "ksp_version_min": "1.3",
+    "ksp_version_max": "1.7",
     "install": [
         {
             "find_regexp": "Delta-V Map.*\\.ksp",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/87559441-ebf3ef80-c67f-11ea-9d74-37000a93ca82.png)

Fixes KSP-CKAN/NetKAN#8045.

No point in updating the netkan because it doesn't inflate, the latest release doesn't have the KSPedia files.