### PR TITLE
Fix compatibility (KSP 1.10.x)

### DIFF
--- a/ConfigurableContainers/ConfigurableContainers-2.6.0.ckan
+++ b/ConfigurableContainers/ConfigurableContainers-2.6.0.ckan
@@ -7,7 +7,7 @@
         "allista"
     ],
     "version": "2.6.0",
-    "ksp_version_min": "1.9.0",
+    "ksp_version_min": "1.10.0",
     "ksp_version_max": "1.10.0",
     "license": "MIT",
     "resources": {


### PR DESCRIPTION
See KSP-CKAN/NetKAN#8085, the PRs submitted to fix that will only affect the current release. This PR fixes CC 2.6.0.