### PR TITLE
Fix compatibility (KSP 1.10.x)

### DIFF
--- a/AT-Utils/AT-Utils-v1.9.5.ckan
+++ b/AT-Utils/AT-Utils-v1.9.5.ckan
@@ -7,7 +7,7 @@
         "allista"
     ],
     "version": "v1.9.5",
-    "ksp_version_min": "1.9.0",
+    "ksp_version_min": "1.10.0",
     "ksp_version_max": "1.10.0",
     "license": "MIT",
     "resources": {


### PR DESCRIPTION
This is #2132 but for AT_Utils. Updating 1.9.5 because it is bundled with CC 2.6.0, so both probably have the same (in)compatibility.