### PR TITLE
Edit SSTO Project 1.3.x to be installable with 1.9.x

### DIFF
--- a/SSTOProject/SSTOProject-1.3.1.ckan
+++ b/SSTOProject/SSTOProject-1.3.1.ckan
@@ -5,7 +5,8 @@
     "abstract": "SSTO project add wide range of high-performance spacecraft parts",
     "author": "Monniasza",
     "version": "1.3.1",
-    "ksp_version": "1.8.1",
+    "ksp_version_min": "1.8.0",
+    "ksp_version_max": "1.9.1",
     "license": "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/195058-ssto-project-ksp-181/",

--- a/SSTOProject/SSTOProject-1.3.2.ckan
+++ b/SSTOProject/SSTOProject-1.3.2.ckan
@@ -5,7 +5,8 @@
     "abstract": "SSTO project add wide range of high-performance spacecraft parts",
     "author": "Monniasza",
     "version": "1.3.2",
-    "ksp_version": "1.8.1",
+    "ksp_version_min": "1.8.0",
+    "ksp_version_max": "1.9.1",
     "license": "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/195058-ssto-project-ksp-181/",

--- a/SSTOProject/SSTOProject-1.3.3.ckan
+++ b/SSTOProject/SSTOProject-1.3.3.ckan
@@ -5,7 +5,8 @@
     "abstract": "SSTO project add wide range of high-performance spacecraft parts",
     "author": "Monniasza",
     "version": "1.3.3",
-    "ksp_version": "1.8.1",
+    "ksp_version_min": "1.8.0",
+    "ksp_version_max": "1.9.1",
     "license": "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/195058-ssto-project-ksp-181/",

--- a/SSTOProject/SSTOProject-1.3.ckan
+++ b/SSTOProject/SSTOProject-1.3.ckan
@@ -5,7 +5,8 @@
     "abstract": "SSTO project add wide range of high-performance spacecraft parts",
     "author": "Monniasza",
     "version": "1.3",
-    "ksp_version": "1.8.1",
+    "ksp_version_min": "1.8.0",
+    "ksp_version_max": "1.9.1",
     "license": "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/195058-ssto-project-ksp-181/",


### PR DESCRIPTION
I've tested SSTO Project to work with both KSP 1.8.1 and 1.9.1. No updates were pushed, but SpaceDock description were updated with:
> Works with KSP 1.9.x too