### PR TITLE
Add ContractConfigurator dependency to historical TestFlight versions

### DIFF
--- a/TestFlight/TestFlight-1.10.0.0.ckan
+++ b/TestFlight/TestFlight-1.10.0.0.ckan
@@ -18,6 +18,9 @@
     "ksp_version": "1.6.1",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.11.0.0.ckan
+++ b/TestFlight/TestFlight-1.11.0.0.ckan
@@ -21,6 +21,9 @@
     ],
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.3.1.0.ckan
+++ b/TestFlight/TestFlight-1.3.1.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "0.90",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.5.8"
         }

--- a/TestFlight/TestFlight-1.3.1.0a.ckan
+++ b/TestFlight/TestFlight-1.3.1.0a.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.2",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.3.1.1.ckan
+++ b/TestFlight/TestFlight-1.3.1.1.ckan
@@ -16,6 +16,9 @@
     "ksp_version_max": "1.0.4",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.4.0.2.ckan
+++ b/TestFlight/TestFlight-1.4.0.2.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.5.0.1.ckan
+++ b/TestFlight/TestFlight-1.5.0.1.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.5.1.0.ckan
+++ b/TestFlight/TestFlight-1.5.1.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.5.2.0.ckan
+++ b/TestFlight/TestFlight-1.5.2.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.5.3.0.ckan
+++ b/TestFlight/TestFlight-1.5.3.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.5.4.0.ckan
+++ b/TestFlight/TestFlight-1.5.4.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.5.4.2.ckan
+++ b/TestFlight/TestFlight-1.5.4.2.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.5.4.4.ckan
+++ b/TestFlight/TestFlight-1.5.4.4.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.5.5.0.ckan
+++ b/TestFlight/TestFlight-1.5.5.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.0.5",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.6.0.0.ckan
+++ b/TestFlight/TestFlight-1.6.0.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.2",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.6.0.1.ckan
+++ b/TestFlight/TestFlight-1.6.0.1.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.2",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.6.0.2.ckan
+++ b/TestFlight/TestFlight-1.6.0.2.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.2",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.6.0.3.ckan
+++ b/TestFlight/TestFlight-1.6.0.3.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.2",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.7.0.0.ckan
+++ b/TestFlight/TestFlight-1.7.0.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.3",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.7.0.1.ckan
+++ b/TestFlight/TestFlight-1.7.0.1.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.1.3",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.8.0.0.ckan
+++ b/TestFlight/TestFlight-1.8.0.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.2",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.7.0"
         },

--- a/TestFlight/TestFlight-1.8.0.1.ckan
+++ b/TestFlight/TestFlight-1.8.0.1.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.2.2",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.9.0.0.ckan
+++ b/TestFlight/TestFlight-1.9.0.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.1",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },

--- a/TestFlight/TestFlight-1.9.1.0.ckan
+++ b/TestFlight/TestFlight-1.9.1.0.ckan
@@ -15,6 +15,9 @@
     "ksp_version": "1.3.1",
     "depends": [
         {
+            "name": "ContractConfigurator"
+        },
+        {
             "name": "ModuleManager",
             "min_version": "2.6.1"
         },


### PR DESCRIPTION
See https://github.com/KSP-CKAN/NetKAN/pull/8128
This backports the dependency until version 1.3.1.0, which was the first one containing the TestFlightContracts DLL.