### PR TITLE
Fix historical ThrottleControlledAvionics compatibility

### DIFF
--- a/ThrottleControlledAvionics/ThrottleControlledAvionics-v3.7.1.ckan
+++ b/ThrottleControlledAvionics/ThrottleControlledAvionics-v3.7.1.ckan
@@ -7,7 +7,7 @@
         "allista"
     ],
     "version": "v3.7.1",
-    "ksp_version_min": "1.9.0",
+    "ksp_version_min": "1.10.0",
     "ksp_version_max": "1.10.0",
     "license": "CC-BY-SA-4.0",
     "resources": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/92968739-3371de80-f46b-11ea-9c5e-a8c052b78268.png)

Now this is reflected in the CKAN metadata for the non-current versions.

This is part of the fix for KSP-CKAN/NetKAN#8140, along with allista/ThrottleControlledAvionics#102.