### PR TITLE
Remove max version for CRP 1.3

### DIFF
--- a/CommunityResourcePack/CommunityResourcePack-1.3.0.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-1.3.0.0.ckan
@@ -6,7 +6,6 @@
     "author": "RoverDude",
     "version": "1.3.0.0",
     "ksp_version_min": "1.6.0",
-    "ksp_version_max": "1.8.9",
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {


### PR DESCRIPTION
There was some churn with this release's versioning due to remote version file shenanigans, see BobPalmer/CommunityResourcePack#249.

Now that there's a newer release, we can update the previous one to what was intended.