### PR TITLE
Fix historical AECS-Motion-Suppressor abstracts

### DIFF
--- a/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.0.ckan
+++ b/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.0.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "AECS-Motion-Suppressor",
     "name": "AECS_Motion_Suppressor (air brake, engine, & control surface)",
-    "abstract": "This﻿ ﻿mod disables and ﻿﻿﻿re﻿-enables﻿ your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. ﻿Also disables engine gimbaling when not running",
+    "abstract": "This mod disables and re-enables your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. Also disables engine gimbaling when not running",
     "author": "linuxgurugamer",
     "license": "MIT",
     "resources": {

--- a/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.1.1.ckan
+++ b/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.1.1.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "AECS-Motion-Suppressor",
     "name": "AECS_Motion_Suppressor (air brake, engine, & control surface)",
-    "abstract": "This﻿ ﻿mod disables and ﻿﻿﻿re﻿-enables﻿ your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. ﻿Also disables engine gimbaling when not running",
+    "abstract": "This mod disables and re-enables your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. Also disables engine gimbaling when not running",
     "author": "linuxgurugamer",
     "license": "MIT",
     "resources": {

--- a/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.1.ckan
+++ b/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.1.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "AECS-Motion-Suppressor",
     "name": "AECS_Motion_Suppressor (air brake, engine, & control surface)",
-    "abstract": "This﻿ ﻿mod disables and ﻿﻿﻿re﻿-enables﻿ your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. ﻿Also disables engine gimbaling when not running",
+    "abstract": "This mod disables and re-enables your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. Also disables engine gimbaling when not running",
     "author": "linuxgurugamer",
     "license": "MIT",
     "resources": {

--- a/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.2.1.ckan
+++ b/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.2.1.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "AECS-Motion-Suppressor",
     "name": "AECS_Motion_Suppressor (air brake, engine, & control surface)",
-    "abstract": "This﻿ ﻿mod disables and ﻿﻿﻿re﻿-enables﻿ your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. ﻿Also disables engine gimbaling when not running",
+    "abstract": "This mod disables and re-enables your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. Also disables engine gimbaling when not running",
     "author": "linuxgurugamer",
     "license": "MIT",
     "resources": {

--- a/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.2.2.ckan
+++ b/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.2.2.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "AECS-Motion-Suppressor",
     "name": "AECS_Motion_Suppressor (air brake, engine, & control surface)",
-    "abstract": "This﻿ ﻿mod disables and ﻿﻿﻿re﻿-enables﻿ your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. ﻿Also disables engine gimbaling when not running",
+    "abstract": "This mod disables and re-enables your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. Also disables engine gimbaling when not running",
     "author": "linuxgurugamer",
     "license": "MIT",
     "resources": {

--- a/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.2.ckan
+++ b/AECS-Motion-Suppressor/AECS-Motion-Suppressor-1.3.2.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "AECS-Motion-Suppressor",
     "name": "AECS_Motion_Suppressor (air brake, engine, & control surface)",
-    "abstract": "This﻿ ﻿mod disables and ﻿﻿﻿re﻿-enables﻿ your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. ﻿Also disables engine gimbaling when not running",
+    "abstract": "This mod disables and re-enables your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. Also disables engine gimbaling when not running",
     "author": "linuxgurugamer",
     "license": "MIT",
     "resources": {


### PR DESCRIPTION
Historical piece of KSP-CKAN/NetKAN#8181. The ZERO WIDTH NO-BREAK SPACE characters originally came from the SpaceDock abstract, so it was already in .ckan files prior to #7729.