### PR TITLE
Backport Parallax-Textures to Parallax 1.1.1

### DIFF
--- a/Parallax-StockTextures/Parallax-StockTextures-1.1.1.ckan
+++ b/Parallax-StockTextures/Parallax-StockTextures-1.1.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
-    "identifier": "Parallax",
-    "name": "Parallax",
+    "identifier": "Parallax-StockTextures",
+    "name": "Parallax - Stock Planet Textures",
     "abstract": "A PBR terrain shader for planet surfaces",
     "author": "Gameslinx",
     "version": "1.1.1",
@@ -14,26 +14,28 @@
         "x_screenshot": "https://spacedock.info/content/Gameslinx_10298/Parallax/Parallax-1600947558.1891763.png"
     },
     "tags": [
-        "plugin",
-        "library",
+        "config",
         "graphics"
+    ],
+    "provides": [
+        "Parallax-Textures"
     ],
     "depends": [
         {
-            "name": "Kopernicus"
+            "name": "ModuleManager"
         },
+        {
+            "name": "Parallax"
+        }
+    ],
+    "conflicts": [
         {
             "name": "Parallax-Textures"
         }
     ],
-    "recommends": [
-        {
-            "name": "Scatterer"
-        }
-    ],
     "install": [
         {
-            "find": "Parallax",
+            "find": "Parallax_StockTextures",
             "install_to": "GameData"
         }
     ],


### PR DESCRIPTION
Continuation of #2172 
This adds the `Parallax-StockTextures-1.1.1.ckan`, and updates Parallax 1.1.1 to depend on Parallax-Textures (and Kopernicus).

ckan compat add 1.9