### PR TITLE
Epoch Kerbulator versions

### DIFF
--- a/Kerbulator/Kerbulator-1-0.4.ckan
+++ b/Kerbulator/Kerbulator-1-0.4.ckan
@@ -9,14 +9,14 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/69406",
         "repository": "https://github.com/wmvanvliet/Kerbulator"
     },
-    "version": "0.41",
+    "version": "1:0.4",
     "ksp_version_min": "1.0.4",
     "ksp_version_max": "1.1.3",
-    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.41/Kerbulator-0.41.zip",
-    "download_size": 537874,
+    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.4/Kerbulator-0.4.zip",
+    "download_size": 537757,
     "download_hash": {
-        "sha1": "DB92D8B517BF96BEC2A8C1A30FA9F4963F63204E",
-        "sha256": "79F19FCFD817EB9D6EF088D6DE670EFCEDC5AA983EFC7D547880EE1D47957095"
+        "sha1": "D3B1B60D60B6197FE4088245DF951593E7849C3D",
+        "sha256": "E2426360950706428BB2936D5BECBC012A0B1C28B69086C561C99A60554FFFCE"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/Kerbulator/Kerbulator-1-0.41.ckan
+++ b/Kerbulator/Kerbulator-1-0.41.ckan
@@ -6,17 +6,17 @@
     "author": "wmvanvliet",
     "license": "GPL-3.0",
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/62988-13-kerbulator-use-your-own-math/",
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/69406",
         "repository": "https://github.com/wmvanvliet/Kerbulator"
     },
-    "version": "0.43",
+    "version": "1:0.41",
     "ksp_version_min": "1.0.4",
     "ksp_version_max": "1.1.3",
-    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.43/Kerbulator-0.43.zip",
-    "download_size": 537732,
+    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.41/Kerbulator-0.41.zip",
+    "download_size": 537874,
     "download_hash": {
-        "sha1": "9E484C29AA1900D435B826D35F67A981397FD4F3",
-        "sha256": "8125D1C3956D24670780B72378EAF00E8BFDDB05E99AAFAF65263A3E481BD5FA"
+        "sha1": "DB92D8B517BF96BEC2A8C1A30FA9F4963F63204E",
+        "sha256": "79F19FCFD817EB9D6EF088D6DE670EFCEDC5AA983EFC7D547880EE1D47957095"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/Kerbulator/Kerbulator-1-0.42.ckan
+++ b/Kerbulator/Kerbulator-1-0.42.ckan
@@ -9,14 +9,14 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/69406",
         "repository": "https://github.com/wmvanvliet/Kerbulator"
     },
-    "version": "0.4",
+    "version": "1:0.42",
     "ksp_version_min": "1.0.4",
     "ksp_version_max": "1.1.3",
-    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.4/Kerbulator-0.4.zip",
-    "download_size": 537757,
+    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.42/Kerbulator-0.42.zip",
+    "download_size": 537832,
     "download_hash": {
-        "sha1": "D3B1B60D60B6197FE4088245DF951593E7849C3D",
-        "sha256": "E2426360950706428BB2936D5BECBC012A0B1C28B69086C561C99A60554FFFCE"
+        "sha1": "9CA5EC9F00997C7A3A7DA60E421A4039A97B19FF",
+        "sha256": "2E71849CF4B8F113F40FB852DC08D39B6BBD7AB22DE8C702D84C191919760A02"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/Kerbulator/Kerbulator-1-0.43.ckan
+++ b/Kerbulator/Kerbulator-1-0.43.ckan
@@ -6,17 +6,17 @@
     "author": "wmvanvliet",
     "license": "GPL-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/69406",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/62988-13-kerbulator-use-your-own-math/",
         "repository": "https://github.com/wmvanvliet/Kerbulator"
     },
-    "version": "0.42",
+    "version": "1:0.43",
     "ksp_version_min": "1.0.4",
     "ksp_version_max": "1.1.3",
-    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.42/Kerbulator-0.42.zip",
-    "download_size": 537832,
+    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.43/Kerbulator-0.43.zip",
+    "download_size": 537732,
     "download_hash": {
-        "sha1": "9CA5EC9F00997C7A3A7DA60E421A4039A97B19FF",
-        "sha256": "2E71849CF4B8F113F40FB852DC08D39B6BBD7AB22DE8C702D84C191919760A02"
+        "sha1": "9E484C29AA1900D435B826D35F67A981397FD4F3",
+        "sha256": "8125D1C3956D24670780B72378EAF00E8BFDDB05E99AAFAF65263A3E481BD5FA"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/Kerbulator/Kerbulator-1-0.44.ckan
+++ b/Kerbulator/Kerbulator-1-0.44.ckan
@@ -4,7 +4,7 @@
     "name": "Kerbulator",
     "abstract": "Calculator plugin for Kerbal Space Program",
     "author": "wmvanvliet",
-    "version": "0.44",
+    "version": "1:0.44",
     "ksp_version": "1.4",
     "license": "GPL-3.0",
     "resources": {

--- a/Kerbulator/Kerbulator-1-0.45.ckan
+++ b/Kerbulator/Kerbulator-1-0.45.ckan
@@ -4,25 +4,23 @@
     "name": "Kerbulator",
     "abstract": "Calculator plugin for Kerbal Space Program",
     "author": "wmvanvliet",
-    "version": "0.46",
+    "version": "1:0.45",
     "ksp_version": "1.9",
     "license": "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/62988-*",
-        "repository": "https://github.com/wmvanvliet/Kerbulator",
-        "bugtracker": "https://github.com/wmvanvliet/Kerbulator/issues"
+        "repository": "https://github.com/wmvanvliet/Kerbulator"
     },
     "tags": [
         "plugin",
         "control"
     ],
-    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.46/Kerbulator-0.46.zip",
-    "download_size": 384501,
+    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.45/Kerbulator-0.45.zip",
+    "download_size": 69386,
     "download_hash": {
-        "sha1": "FD88A0B280BF187EDA16932469C785A44F6D93B9",
-        "sha256": "565BD8A2A1E03E2912DB67036064F12AD2662D6B83DCB64F07AD7E8A7C4A74FC"
+        "sha1": "ED5DFB16E3FD7AC26E57EEC11AE57B4B57E65A27",
+        "sha256": "40F1D8CD25462CAA2A55C82BF5EAC20AD29FC7E3D749628B5A3746F4795C7CB9"
     },
     "download_content_type": "application/zip",
-    "release_date": "2020-03-11T08:28:53Z",
     "x_generated_by": "netkan"
 }

--- a/Kerbulator/Kerbulator-1-0.46.ckan
+++ b/Kerbulator/Kerbulator-1-0.46.ckan
@@ -4,23 +4,25 @@
     "name": "Kerbulator",
     "abstract": "Calculator plugin for Kerbal Space Program",
     "author": "wmvanvliet",
-    "version": "0.45",
+    "version": "1:0.46",
     "ksp_version": "1.9",
     "license": "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/62988-*",
-        "repository": "https://github.com/wmvanvliet/Kerbulator"
+        "repository": "https://github.com/wmvanvliet/Kerbulator",
+        "bugtracker": "https://github.com/wmvanvliet/Kerbulator/issues"
     },
     "tags": [
         "plugin",
         "control"
     ],
-    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.45/Kerbulator-0.45.zip",
-    "download_size": 69386,
+    "download": "https://github.com/wmvanvliet/Kerbulator/releases/download/0.46/Kerbulator-0.46.zip",
+    "download_size": 384501,
     "download_hash": {
-        "sha1": "ED5DFB16E3FD7AC26E57EEC11AE57B4B57E65A27",
-        "sha256": "40F1D8CD25462CAA2A55C82BF5EAC20AD29FC7E3D749628B5A3746F4795C7CB9"
+        "sha1": "FD88A0B280BF187EDA16932469C785A44F6D93B9",
+        "sha256": "565BD8A2A1E03E2912DB67036064F12AD2662D6B83DCB64F07AD7E8A7C4A74FC"
     },
     "download_content_type": "application/zip",
+    "release_date": "2020-03-11T08:28:53Z",
     "x_generated_by": "netkan"
 }


### PR DESCRIPTION
This mod's version system assumes dots are optional, and goes from versions like 0.36 to 0.4 to 0.41, and 0.46 to 0.5
Version 0.4 has been released before our auto-epoching feature and has been missed to epoch manually, so all the 0.4* versions needed an epoch as well.
![Kerbulator versions](https://user-images.githubusercontent.com/28812678/98956030-dc869500-24ff-11eb-887b-aae2938238fa.png)