### PR TITLE
Don't install Buffalo's Ships folder as part of Pathfinder

### DIFF
--- a/Pathfinder/Pathfinder-v1.35.1.ckan
+++ b/Pathfinder/Pathfinder-v1.35.1.ckan
@@ -70,10 +70,6 @@
             ]
         },
         {
-            "find": "SPH",
-            "install_to": "Ships"
-        },
-        {
             "file": "GameData/WBIPlayMode.cfg",
             "install_to": "GameData"
         }

--- a/Pathfinder/Pathfinder-v1.35.2.ckan
+++ b/Pathfinder/Pathfinder-v1.35.2.ckan
@@ -70,10 +70,6 @@
             ]
         },
         {
-            "find": "SPH",
-            "install_to": "Ships"
-        },
-        {
             "file": "GameData/WBIPlayMode.cfg",
             "install_to": "GameData"
         }

--- a/Pathfinder/Pathfinder-v1.36.0.ckan
+++ b/Pathfinder/Pathfinder-v1.36.0.ckan
@@ -70,10 +70,6 @@
             ]
         },
         {
-            "find": "SPH",
-            "install_to": "Ships"
-        },
-        {
             "file": "GameData/WBIPlayMode.cfg",
             "install_to": "GameData"
         }


### PR DESCRIPTION
Historical counterpart of KSP-CKAN/NetKAN#8254, Pathfinder was installing a folder from a bundled mod. Now it doesn't.