### PR TITLE
ProceduralAirships is not compatible with 1.0 or later

### DIFF
--- a/ProceduralAirships/ProceduralAirships-1.3.ckan
+++ b/ProceduralAirships/ProceduralAirships-1.3.ckan
@@ -34,7 +34,11 @@
             "install_to": "Ships"
         },
         {
-            "file": "saves",
+            "file": "saves/training/airship_flight.sfs",
+            "install_to": "Tutorial"
+        },
+        {
+            "file": "saves/training/airship_flight_far.sfs",
             "install_to": "Tutorial"
         }
     ],

--- a/ProceduralAirships/ProceduralAirships-1.3.ckan
+++ b/ProceduralAirships/ProceduralAirships-1.3.ckan
@@ -8,7 +8,7 @@
         "ItMustBeACamel"
     ],
     "version": "1.3",
-    "ksp_version_min": "0.90.0",
+    "ksp_version": "0.90.0",
     "license": "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/89388-*",


### PR DESCRIPTION
This mod's forum thread has people stating it's broken starting in March of 2015, continuing into this year.

![image](https://user-images.githubusercontent.com/1559108/102169009-e5e48380-3e56-11eb-9e01-31933864653f.png)

![image](https://user-images.githubusercontent.com/1559108/102169088-0dd3e700-3e57-11eb-9457-6fa924b00a17.png)

Noticed while looking for mods that use `"install_to": "Tutorial"` (this is the only one).

Also that install stanza is wrong and is now fixed.
![image](https://user-images.githubusercontent.com/1559108/102171452-27c3f880-3e5c-11eb-99ee-acb7309f0977.png)
Also fake instances didn't have the needed dir until https://github.com/KSP-CKAN/CKAN/commit/042c3f52c4685a42c3b05b2b00568c587fe955e9