### PR TITLE
Change Kopernicus_BE repo URI to GitHub generated archive

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -14,7 +14,7 @@
         },
         {
             "name":      "Kopernicus_BE",
-            "uri":       "http://glacialsoftware.net/CKAN/Kopernicus_BE.tar.gz",
+            "uri":       "https://github.com/R-T-B/CKAN-meta-dev-Kopernicus_BE/archive/master.tar.gz",
             "x_mirror":  false,
             "x_comment": "Kopernicus Bleeding Edge beta ckans"
         }


### PR DESCRIPTION
I talked with @R-T-B about moving his CKAN metadata repository for Kopernicus Bleeding Edge to GitHub, so we can use the automatically generated archive tar.gz, and avoid disruptions for CKAN users when his personal internet connection and/or server suffers from an outage.

![discussion](https://user-images.githubusercontent.com/28812678/104496244-05e3a000-55d9-11eb-9baf-0125f31bd544.png)

All the metadata files are now also uploaded to https://github.com/R-T-B/CKAN-meta-dev-Kopernicus_BE, so we can switch over the URL.

IIRC (without checking the code) tthe link won't automatically update for existing users of this custom repo, so they need to remove and add it again. @R-T-B said he is going to keep the old URI up-to-date for the time being, and maybe he can work out a proxy-like setup.