### PR TITLE
Fix PlanesWithPurposes install stanza

### DIFF
--- a/ContractConfigurator-PlanesWithPurposes/ContractConfigurator-PlanesWithPurposes-1.2.ckan
+++ b/ContractConfigurator-PlanesWithPurposes/ContractConfigurator-PlanesWithPurposes-1.2.ckan
@@ -37,7 +37,7 @@
         {
             "find": "ContractPacks",
             "install_to": "GameData/ContractPacks",
-            "as": "PlanesWithPurposes",
+            "as": "PWP",
             "filter": [
                 ".gitignore",
                 "MiniAVC.dll"

--- a/ContractConfigurator-PlanesWithPurposes/ContractConfigurator-PlanesWithPurposes-1.3.ckan
+++ b/ContractConfigurator-PlanesWithPurposes/ContractConfigurator-PlanesWithPurposes-1.3.ckan
@@ -35,13 +35,8 @@
     ],
     "install": [
         {
-            "find": "ContractPacks",
-            "install_to": "GameData/ContractPacks",
-            "as": "PlanesWithPurposes",
-            "filter": [
-                ".gitignore",
-                "MiniAVC.dll"
-            ]
+            "find": "PWP",
+            "install_to": "GameData/ContractPacks"
         }
     ],
     "download": "https://spacedock.info/mod/2601/Planes%20With%20Purposes/download/1.3",


### PR DESCRIPTION
See https://github.com/KSP-CKAN/NetKAN/pull/8312

1.2 still needs the folder fixup, but the destination folder is now renames to `PWP`.
1.3 comes with its own `PWP` subfolder, and a cleaned zip.