### PR TITLE
Move KIS back to Extraplanetary Launchpads's historical recommends list

### DIFF
--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.90.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.90.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KerbalStats"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "KAS"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.92.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.92.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KerbalStats"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "KAS"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.93.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.93.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KerbalStats"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "KAS"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.94.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.94.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KerbalStats"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "KAS"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.5.3.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.5.3.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.6.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.6.0.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.7.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.7.1.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.7.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.7.2.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.8.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.8.0.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.9.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.9.0.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.0.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.0.0.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.1.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.1.0.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.0.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.1.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.2.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.0.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.1.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.2.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.3.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.3.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.4.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.4.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.5.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.5.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.4.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.4.0.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.5.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.5.0.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.5.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.5.1.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.0.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.1.0.ckan
@@ -15,14 +15,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.2.0.ckan
@@ -20,14 +20,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.0.0.ckan
@@ -20,14 +20,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.1.0.ckan
@@ -21,14 +21,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.2.0.ckan
@@ -21,14 +21,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.3.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.3.0.ckan
@@ -24,14 +24,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.0.0.ckan
@@ -24,14 +24,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.1.0.ckan
@@ -24,14 +24,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.2.0.ckan
@@ -24,14 +24,14 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "KIS"
         }
     ],
     "recommends": [
         {
             "name": "KAS"
+        },
+        {
+            "name": "KIS"
         },
         {
             "name": "InfernalRobotics"


### PR DESCRIPTION
Historical version of KSP-CKAN/NetKAN#8313. Author indicated KIS shouldn't be in depends.