### PR TITLE
Update KIS-1.27.ckan

### DIFF
--- a/KIS/KIS-1.27.ckan
+++ b/KIS/KIS-1.27.ckan
@@ -10,7 +10,7 @@
     ],
     "version": "1.27",
     "ksp_version_min": "1.8.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.10.1",
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",

--- a/KIS/KIS-1.27.ckan
+++ b/KIS/KIS-1.27.ckan
@@ -9,8 +9,8 @@
         "Winn75"
     ],
     "version": "1.27",
-    "ksp_version_min": "1.8.0",
-    "ksp_version_max": "1.10.1",
+    "ksp_version_min": "1.11.0",
+    "ksp_version_max": "1.99.99",
     "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149848-kerbal-inventory-system-kis",


### PR DESCRIPTION
As per Ihsoft, when I asked if KIS 1.27 is compatible with KSP 1.10.1, he said "I assume it may not be compatible"

https://forum.kerbalspaceprogram.com/index.php?/topic/149848-minimum-ksp-version-111-kerbal-inventory-system-kis-v128/&do=findComment&comment=3898830