### PR TITLE
Update MissingHistory-1.8.2.ckan

### DIFF
--- a/MissingHistory/MissingHistory-1.3.2.ckan
+++ b/MissingHistory/MissingHistory-1.3.2.ckan
@@ -12,7 +12,8 @@
         "x_screenshot": "https://spacedock.info/content/Snark_166/MissingHistory/MissingHistory-1521005056.5945137.png"
     },
     "version": "1.3.2",
-    "ksp_version": "1.4.4",
+    "ksp_version_min": "1.4.3",
+    "ksp_version_max": "1.4.4",
     "depends": [
         {
             "name": "ModuleManager"

--- a/MissingHistory/MissingHistory-1.3.3.ckan
+++ b/MissingHistory/MissingHistory-1.3.3.ckan
@@ -12,7 +12,8 @@
         "x_screenshot": "https://spacedock.info/content/Snark_166/MissingHistory/MissingHistory-1521005056.5945137.png"
     },
     "version": "1.3.3",
-    "ksp_version": "1.4.5",
+    "ksp_version_min": "1.4.4",
+    "ksp_version_max": "1.4.5",
     "depends": [
         {
             "name": "ModuleManager"

--- a/MissingHistory/MissingHistory-1.3.ckan
+++ b/MissingHistory/MissingHistory-1.3.ckan
@@ -12,7 +12,8 @@
         "x_screenshot": "https://spacedock.info/content/Snark_166/MissingHistory/MissingHistory-1521005056.5945137.png"
     },
     "version": "1.3",
-    "ksp_version": "1.4.3",
+    "ksp_version_min": "1.4.1",
+    "ksp_version_max": "1.4.3",
     "depends": [
         {
             "name": "ModuleManager"

--- a/MissingHistory/MissingHistory-1.4.ckan
+++ b/MissingHistory/MissingHistory-1.4.ckan
@@ -12,7 +12,8 @@
         "x_screenshot": "https://spacedock.info/content/Snark_166/MissingHistory/MissingHistory-1521005056.5945137.png"
     },
     "version": "1.4",
-    "ksp_version": "1.5.1",
+    "ksp_version_min": "1.5.0",
+    "ksp_version_max": "1.5.1",
     "depends": [
         {
             "name": "ModuleManager"

--- a/MissingHistory/MissingHistory-1.7.2.ckan
+++ b/MissingHistory/MissingHistory-1.7.2.ckan
@@ -12,7 +12,8 @@
         "x_screenshot": "https://spacedock.info/content/Snark_166/MissingHistory/MissingHistory-1521005056.5945137.png"
     },
     "version": "1.7.2",
-    "ksp_version": "1.6.1",
+    "ksp_version_min": "1.6.0",
+    "ksp_version_max": "1.6.1",
     "depends": [
         {
             "name": "ModuleManager"

--- a/MissingHistory/MissingHistory-1.7.3.ckan
+++ b/MissingHistory/MissingHistory-1.7.3.ckan
@@ -12,7 +12,8 @@
         "x_screenshot": "https://spacedock.info/content/Snark_166/MissingHistory/MissingHistory-1521005056.5945137.png"
     },
     "version": "1.7.3",
-    "ksp_version": "1.7.3",
+    "ksp_version_min": "1.6.1",
+    "ksp_version_max": "1.7.3",
     "localizations": [
         "en-us"
     ],

--- a/MissingHistory/MissingHistory-1.8.1.ckan
+++ b/MissingHistory/MissingHistory-1.8.1.ckan
@@ -5,7 +5,8 @@
     "abstract": "Handy parts to complement Making History.",
     "author": "Snark",
     "version": "1.8.1",
-    "ksp_version": "1.10.0",
+    "ksp_version_min": "1.8.1",
+    "ksp_version_max": "1.10.0",
     "license": "CC-BY-NC-SA",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/172232-141-missinghistory-v10-handy-parts-to-complement-making-history/",

--- a/MissingHistory/MissingHistory-1.8.2.ckan
+++ b/MissingHistory/MissingHistory-1.8.2.ckan
@@ -5,7 +5,8 @@
     "abstract": "Handy parts to complement Making History.",
     "author": "Snark",
     "version": "1.8.2",
-    "ksp_version": "1.11.0",
+    "ksp_version_min": "1.10.0",
+    "ksp_version_max": "1.10.99",
     "license": "CC-BY-NC-SA",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/172232-141-missinghistory-v10-handy-parts-to-complement-making-history/",

--- a/MissingHistory/MissingHistory-1.8.2.ckan
+++ b/MissingHistory/MissingHistory-1.8.2.ckan
@@ -6,7 +6,7 @@
     "author": "Snark",
     "version": "1.8.2",
     "ksp_version_min": "1.10.0",
-    "ksp_version_max": "1.10.99",
+    "ksp_version_max": "1.11.0",
     "license": "CC-BY-NC-SA",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/172232-141-missinghistory-v10-handy-parts-to-complement-making-history/",

--- a/MissingHistory/MissingHistory-1.8.ckan
+++ b/MissingHistory/MissingHistory-1.8.ckan
@@ -12,7 +12,8 @@
         "x_screenshot": "https://spacedock.info/content/Snark_166/MissingHistory/MissingHistory-1521005056.5945137.png"
     },
     "version": "1.8",
-    "ksp_version": "1.8.1",
+    "ksp_version_min": "1.8.0",
+    "ksp_version_max": "1.8.1",
     "localizations": [
         "en-us"
     ],


### PR DESCRIPTION
MH 1.8.2 was released on July 11th 2020 for KSP 1.10.1 (https://spacedock.info/mod/1743/MissingHistory), yet it's listed as compatible with KSP 1.11.0 only.