### PR TITLE
Cache permissions workaround

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,3 +33,5 @@ jobs:
               with:
                   source: commits
                   pull request body: ${{ github.event.pull_request.body }}
+            - name: Chmod cached files so actions/cache can read them
+              run: sudo chmod -R a+r .cache


### PR DESCRIPTION
See KSP-CKAN/NetKAN#8332, `actions/cache` can't read some of our cached files, so we need to chmod them.