### PR TITLE
Update MissingHistory 1.9 compat again

### DIFF
--- a/MissingHistory/MissingHistory-1.9.ckan
+++ b/MissingHistory/MissingHistory-1.9.ckan
@@ -5,8 +5,7 @@
     "abstract": "Handy parts to complement Making History.",
     "author": "Snark",
     "version": "1.9",
-    "ksp_version_min": "1.10.1",
-    "ksp_version_max": "1.11.0",
+    "ksp_version": "1.10",
     "license": "CC-BY-NC-SA",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/172232-141-missinghistory-v10-handy-parts-to-complement-making-history/",


### PR DESCRIPTION
Meant to take care of this in #2246, but got confused by multiple posts saying slightly different things:

![image](https://user-images.githubusercontent.com/1559108/106052498-40f0d380-60af-11eb-9295-968a25b1d593.png)

- 1.9 shouldn't be used on 1.11
- 1.9 is OK for 1.10.0