### PR TITLE
Backfill Kopernicus 1.8.1 backport

### DIFF
--- a/Kopernicus/Kopernicus-2-release-1.8.1-23.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.8.1-23.ckan
@@ -1,0 +1,68 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Kopernicus",
+    "name": "Kopernicus Planetary System Modifier",
+    "abstract": "Allows users to replace the planetary system used by the game.",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "KillAshley",
+        "Gravitasi",
+        "KCreator",
+        "Sigma88",
+        "R-T-B",
+        "prestja"
+    ],
+    "version": "2:release-1.8.1-23",
+    "ksp_version": "1.8.1",
+    "license": "LGPL-3.0",
+    "release_status": "development",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/194936-*",
+        "repository": "https://github.com/Kopernicus/Kopernicus",
+        "bugtracker": "https://github.com/Kopernicus/Kopernicus/issues",
+        "remote-avc": "https://raw.githubusercontent.com/Kopernicus/Kopernicus/master/build/KSP181/GameData/Kopernicus/Plugins/Kopernicus.version"
+    },
+    "tags": [
+        "plugin",
+        "library"
+    ],
+    "localizations": [
+        "en-us",
+        "it-it",
+        "ru",
+        "zh-cn"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager",
+            "min_version": "2.8.0"
+        },
+        {
+            "name": "ModularFlightIntegrator",
+            "min_version": "1.2.4.0"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
+        }
+    ],
+    "download": "https://github.com/Kopernicus/Kopernicus/releases/download/1.8.1-23/Kopernicus-1.8.1-23.zip",
+    "download_size": 389990,
+    "download_hash": {
+        "sha1": "447C6889A6450BD4D55DBD1F570DFBC7BC6206CB",
+        "sha256": "207A0D47BF1F51C0C2C154DC1EFE9FDB2E55952573D4B5380F6E8696131EC524"
+    },
+    "download_content_type": "application/zip",
+    "release_date": "2021-01-29T02:59:13Z",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
This was uploaded rapidly with dd406ef70784a821fa64cacfa97447c5904ba5c7 and got skipped.
Just a simple `--releases 2` run.