### PR TITLE
Backfill Kopernicus 1.8.1-24 and fix Kopernicus 1.8.1-23 download

### DIFF
--- a/Kopernicus/Kopernicus-2-release-1.8.1-24.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.8.1-24.ckan
@@ -15,7 +15,7 @@
         "R-T-B",
         "prestja"
     ],
-    "version": "2:release-1.8.1-23",
+    "version": "2:release-1.8.1-24",
     "ksp_version": "1.8.1",
     "license": "LGPL-3.0",
     "release_status": "development",
@@ -56,13 +56,13 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/Kopernicus/Kopernicus/releases/download/release-1.8.1-23/Kopernicus-1.8.1-23.zip",
-    "download_size": 389990,
+    "download": "https://github.com/Kopernicus/Kopernicus/releases/download/release-1.8.1-24/Kopernicus-1.8.1-24.zip",
+    "download_size": 384828,
     "download_hash": {
-        "sha1": "447C6889A6450BD4D55DBD1F570DFBC7BC6206CB",
-        "sha256": "207A0D47BF1F51C0C2C154DC1EFE9FDB2E55952573D4B5380F6E8696131EC524"
+        "sha1": "81A4F188088704B95E40F3866E754F0371136F02",
+        "sha256": "E48B50F7B5173BD0EAD3677F3C192B98B54163FCB3C926267FFDE86EF1DF434A"
     },
     "download_content_type": "application/zip",
-    "release_date": "2021-01-29T02:59:13Z",
+    "release_date": "2021-01-29T20:27:02Z",
     "x_generated_by": "netkan"
 }


### PR DESCRIPTION
Version `1.8.1-24` got uploaded shortly before `1.9.1-24` and thus has been missed;
Version `1.8.1-23` has been deleted and recreated with a slightly different tag name.