### PR TITLE
Don't use Linux asset for AFBW-OSX

### DIFF
--- a/AdvancedFlyByWire-OSX/AdvancedFlyByWire-OSX-1.8.3.1.ckan
+++ b/AdvancedFlyByWire-OSX/AdvancedFlyByWire-OSX-1.8.3.1.ckan
@@ -12,6 +12,8 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
         "spacedock": "https://spacedock.info/mod/1878/ABFW%20Revived%20(OSX%20version)",
         "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire",
+        "bugtracker": "https://github.com/linuxgurugamer/ksp-advanced-flybywire/issues",
+        "remote-avc": "http://ksp.spacetux.net/avc/ksp-advanced-flybywire",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/ABFW_Revived_OSX_version/ABFW_Revived_OSX_version-1527782505.4308672.png"
     },
     "tags": [
@@ -48,12 +50,13 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/linuxgurugamer/ksp-advanced-flybywire/releases/download/1.8.3.1/ksp-advanced-flybywire-1.8.0-1.8.3.1-linux.zip",
-    "download_size": 112056,
+    "download": "https://github.com/linuxgurugamer/ksp-advanced-flybywire/releases/download/1.8.3.1/ksp-advanced-flybywire-1.8.0-1.8.3.1-osx.zip",
+    "download_size": 111987,
     "download_hash": {
-        "sha1": "85F8F6C5A608E2B608C32DAB079FD5E37DC52FCD",
-        "sha256": "218A0D449169EF000440B05F2A209B950D904C449B1A8D4D16B9BC4206B36877"
+        "sha1": "527751435EB34FDFF04E93DEFB85E45D309622A8",
+        "sha256": "829C7A7792223B939E9C2D45D08074F4E1E9F9655FA0B634CB04F30430A4D35B"
     },
     "download_content_type": "application/zip",
+    "release_date": "2019-12-21T03:04:59Z",
     "x_generated_by": "netkan"
 }


### PR DESCRIPTION
Historical continuation of part of KSP-CKAN/NetKAN#8341. AFBW-OSX has been using the wrong asset since KSP-CKAN/NetKAN#7729, now all historical versions are fixed.