### PR TITLE
Fix ReStock 1.3.0 min compat

### DIFF
--- a/ReStock/ReStock-1.3.0.ckan
+++ b/ReStock/ReStock-1.3.0.ckan
@@ -5,7 +5,7 @@
     "abstract": "A community-built replacement for KSP's part models and textures. No effects on gameplay",
     "author": "ReStock Team",
     "version": "1.3.0",
-    "ksp_version_min": "1.10.1",
+    "ksp_version_min": "1.11.0",
     "ksp_version_max": "1.11.99",
     "license": "restricted",
     "resources": {


### PR DESCRIPTION
## Problem

![forum](https://i.imgur.com/gB98Uvo.png)

## Cause

The min part of this commit:

https://github.com/PorktoberRevolution/ReStocked/commit/2cceb95dac1c8c90edf50378111ada03ba4f0549#diff-7f788e8a221c9ac1ef7c4ac82021c69b918f6bc0e3b2b6f98ac53bcc77dc9502

Was meant to be done with this commit:

https://github.com/PorktoberRevolution/ReStocked/commit/135a775aab9520cc958b26522975bdd692ac27e5#diff-7f788e8a221c9ac1ef7c4ac82021c69b918f6bc0e3b2b6f98ac53bcc77dc9502

Since a mod version change to 1.3.1 accompanied it, the compatibility of 1.3.0 wasn't updated.

## Changes

Now the min is 1.10.0.