### PR TITLE
Fix Kopernicus -27 release compat

### DIFF
--- a/Kopernicus/Kopernicus-2-release-1.10.1-27.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.10.1-27.ckan
@@ -16,7 +16,7 @@
         "prestja"
     ],
     "version": "2:release-1.10.1-27",
-    "ksp_version": "1.9.1",
+    "ksp_version": "1.10.1",
     "license": "LGPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Kopernicus/Kopernicus-2-release-1.11.1-27.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.11.1-27.ckan
@@ -16,7 +16,7 @@
         "prestja"
     ],
     "version": "2:release-1.11.1-27",
-    "ksp_version": "1.9.1",
+    "ksp_version": "1.11.1",
     "license": "LGPL-3.0",
     "release_status": "development",
     "resources": {


### PR DESCRIPTION
The `release-27` release tag of Kopernicus introduced new assets for KSP 1.10.1 and 1.11.1.
However they included incorrect version files, stating a compatibility with KSP 1.9.1, see https://github.com/Kopernicus/Kopernicus/pull/477

Now we've got a `release-28` which, after a handful of attempts, includes the fixed version files with correct compatibility. It should be updated any minute.
So we're fixing the compatibility of `release-1.10.1-27` and `release-1.11.1-27` here to ensure users don't install or upgrade to an incompatible version.