### PR TITLE
Fix compatibility of frozen mods

### DIFF
--- a/GPO/GPO-3.3.1.ckan
+++ b/GPO/GPO-3.3.1.ckan
@@ -10,7 +10,7 @@
         "repository": "https://github.com/Gameslinx/Gameslinx-Planet-Overhaul"
     },
     "version": "3.3.1",
-    "ksp_version": "1.3.1",
+    "ksp_version": "1.4.2",
     "provides": [
         "EnvironmentalVisualEnhancements-Config"
     ],

--- a/GPO/GPO-3.4.0.ckan
+++ b/GPO/GPO-3.4.0.ckan
@@ -5,7 +5,7 @@
     "abstract": "A large planet mod which comes with its own suite of visuals for your enjoyment. This mod adds 28 new worlds to explore.",
     "author": "Gameslinx",
     "version": "3.4.0",
-    "ksp_version": "1.3.1",
+    "ksp_version": "1.4.3",
     "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/155740-*",

--- a/SemioticStandard/SemioticStandard-1.1.1.ckan
+++ b/SemioticStandard/SemioticStandard-1.1.1.ckan
@@ -5,7 +5,8 @@
     "abstract": "Icon decals from science fiction",
     "author": "drewcassidy",
     "version": "1.1.1",
-    "ksp_version": "1.6.1",
+    "ksp_version_min": "1.4",
+    "ksp_version_max": "1.7",
     "license": "BSD-2-clause",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/174095-14x-semiotic-standard-for-kerbal-vessels/",


### PR DESCRIPTION
These mods have been frozen in https://github.com/KSP-CKAN/NetKAN/pull/8390, however the compatibility data of their latest releases isn't 100% correct. Now that they're frozen it#s quite easy to fix.
Probably not very useful, but why not give those mods with correct data as a last salute, someone doing a nostalgic KSP run might benefit from this after all.

## SemioticStandard
Originally released for KSP 1.4:
https://github.com/KSP-CKAN/CKAN-meta/commit/9d50c38fcc73f3d70f658da03a569ae7937859d4#diff-cd74631dc015e2a6949fee3d295520286016b7bc19dc66a28b0e35166d3de1a2
![SemioticStandard-min](https://user-images.githubusercontent.com/28812678/109993632-cdc12980-7d0c-11eb-81bd-428f4344d58e.png)

But according to the forum thread compatible with up to KSP 1.7:
![SemioticStandard-max](https://user-images.githubusercontent.com/28812678/109993437-9488b980-7d0c-11eb-867f-b774c036513e.png)

## GPO
This one is caused by incorrect .version files included in the download.
![GPO-3.3.1](https://user-images.githubusercontent.com/28812678/109993909-111b9800-7d0d-11eb-857f-d9df75d0c966.png)

![GPO-3.4.0](https://user-images.githubusercontent.com/28812678/109993813-f6492380-7d0c-11eb-8761-098473305a97.png)
