### PR TITLE
Set BluedogDB v1.7.0 min KSP version to 1.8.1

### DIFF
--- a/BluedogDB/BluedogDB-v1.7.0.ckan
+++ b/BluedogDB/BluedogDB-v1.7.0.ckan
@@ -9,7 +9,7 @@
         "Zorg"
     ],
     "version": "v1.7.0",
-    "ksp_version_min": "1.7.3",
+    "ksp_version_min": "1.8.1",
     "ksp_version_max": "1.10.99",
     "license": "CC-BY-NC-SA-4.0",
     "resources": {


### PR DESCRIPTION
See https://github.com/CobaltWolf/Bluedog-Design-Bureau/pull/1040

v1.7.1 got updated via the remote version file ([bot commit here](https://github.com/KSP-CKAN/CKAN-meta/commit/20f6283992fc30effc2df231453727644bbf88db)), the author additionally asked me to change the compatibility of v1.7.0 to min KSP 1.8.1:

![image](https://user-images.githubusercontent.com/28812678/110222949-90a89300-7ed6-11eb-8836-a481a8c39a72.png)
