### PR TITLE
Make Kerbalism-Config-RO conflict with life support mods

### DIFF
--- a/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.1.ckan
+++ b/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.1.ckan
@@ -8,6 +8,12 @@
     "resources": {
         "repository": "https://github.com/Standecco/ROKerbalism"
     },
+    "tags": [
+        "config",
+        "career",
+        "science",
+        "crewed"
+    ],
     "version": "v0.1.1",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.7.99",
@@ -15,6 +21,9 @@
         "Kerbalism-Config"
     ],
     "depends": [
+        {
+            "name": "ModuleManager"
+        },
         {
             "name": "Kerbalism"
         }

--- a/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.1.ckan
+++ b/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.1.ckan
@@ -32,6 +32,15 @@
     "conflicts": [
         {
             "name": "Kerbalism-Config"
+        },
+        {
+            "name": "TACLS"
+        },
+        {
+            "name": "Snacks"
+        },
+        {
+            "name": "USI-LS"
         }
     ],
     "install": [

--- a/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.2.ckan
+++ b/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.2.ckan
@@ -32,6 +32,15 @@
     "conflicts": [
         {
             "name": "Kerbalism-Config"
+        },
+        {
+            "name": "TACLS"
+        },
+        {
+            "name": "Snacks"
+        },
+        {
+            "name": "USI-LS"
         }
     ],
     "install": [

--- a/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.2.ckan
+++ b/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.2.ckan
@@ -8,6 +8,12 @@
     "resources": {
         "repository": "https://github.com/Standecco/ROKerbalism"
     },
+    "tags": [
+        "config",
+        "career",
+        "science",
+        "crewed"
+    ],
     "version": "v0.1.2",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.7.99",
@@ -15,6 +21,9 @@
         "Kerbalism-Config"
     ],
     "depends": [
+        {
+            "name": "ModuleManager"
+        },
         {
             "name": "Kerbalism"
         }

--- a/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.ckan
+++ b/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.ckan
@@ -8,6 +8,12 @@
     "resources": {
         "repository": "https://github.com/Standecco/ROKerbalism"
     },
+    "tags": [
+        "config",
+        "career",
+        "science",
+        "crewed"
+    ],
     "version": "v0.1",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.7.99",
@@ -15,6 +21,9 @@
         "Kerbalism-Config"
     ],
     "depends": [
+        {
+            "name": "ModuleManager"
+        },
         {
             "name": "Kerbalism"
         }

--- a/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.ckan
+++ b/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.1.ckan
@@ -32,6 +32,15 @@
     "conflicts": [
         {
             "name": "Kerbalism-Config"
+        },
+        {
+            "name": "TACLS"
+        },
+        {
+            "name": "Snacks"
+        },
+        {
+            "name": "USI-LS"
         }
     ],
     "install": [

--- a/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.2.ckan
+++ b/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.2.ckan
@@ -28,6 +28,9 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "Kerbalism"
         }
     ],

--- a/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.2.ckan
+++ b/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.2.ckan
@@ -44,6 +44,15 @@
     "conflicts": [
         {
             "name": "Kerbalism-Config"
+        },
+        {
+            "name": "TACLS"
+        },
+        {
+            "name": "Snacks"
+        },
+        {
+            "name": "USI-LS"
         }
     ],
     "install": [

--- a/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.9.1.ckan
+++ b/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.9.1.ckan
@@ -48,6 +48,15 @@
     "conflicts": [
         {
             "name": "Kerbalism-Config"
+        },
+        {
+            "name": "TACLS"
+        },
+        {
+            "name": "Snacks"
+        },
+        {
+            "name": "USI-LS"
         }
     ],
     "install": [

--- a/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.9.ckan
+++ b/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.9.ckan
@@ -28,6 +28,9 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "Kerbalism"
         }
     ],

--- a/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.9.ckan
+++ b/Kerbalism-Config-RO/Kerbalism-Config-RO-v0.9.ckan
@@ -44,6 +44,15 @@
     "conflicts": [
         {
             "name": "Kerbalism-Config"
+        },
+        {
+            "name": "TACLS"
+        },
+        {
+            "name": "Snacks"
+        },
+        {
+            "name": "USI-LS"
         }
     ],
     "install": [


### PR DESCRIPTION
Historical counterpart to KSP-CKAN/NetKAN#8401, this module should conflict with life support.