### PR TITLE
Migrate Tantares to NewTantares and TantaresLV to NewTantaresLV

### DIFF
--- a/NewTantares/NewTantares-33.0.ckan
+++ b/NewTantares/NewTantares-33.0.ckan
@@ -1,6 +1,6 @@
 {
     "spec_version": 1,
-    "identifier": "Tantares",
+    "identifier": "NewTantares",
     "name": "Tantares",
     "abstract": "Stockalike Soyuz and MIR",
     "author": "Beale",

--- a/NewTantares/NewTantares-34.0.ckan
+++ b/NewTantares/NewTantares-34.0.ckan
@@ -1,6 +1,6 @@
 {
     "spec_version": 1,
-    "identifier": "Tantares",
+    "identifier": "NewTantares",
     "name": "Tantares",
     "abstract": "Stockalike Soyuz and MIR",
     "author": "Beale",
@@ -11,8 +11,8 @@
         "spacedock": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR",
         "x_screenshot": "https://spacedock.info/content/Beale_838/Tantares_-_Stockalike_Soyuz_and_MIR/Tantares_-_Stockalike_Soyuz_and_MIR-1455884285.234776.png"
     },
-    "version": "34.1",
-    "ksp_version": "1.1.2",
+    "version": "34.0",
+    "ksp_version": "1.1.0",
     "suggests": [
         {
             "name": "CommunityTechTree"
@@ -24,11 +24,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR/download/34.1",
-    "download_size": 22548321,
+    "download": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR/download/34.0",
+    "download_size": 23675569,
     "download_hash": {
-        "sha1": "56DEB201C60C1304C0D44AAFA503158EB15371E3",
-        "sha256": "74883AE946AF3361AA67EE0E347EC824DC1C30158D5265C74BA30A912D0A8B12"
+        "sha1": "13F332ABBCC16F47BC8E0AAD7EB8A06169BF3BA1",
+        "sha256": "296D2E9F08DDBA65D48F725DFB86736419886C851F59EBDCD4C2EB6613300DB3"
     },
     "download_content_type": "application/zip",
     "x_maintained_by": "eagleshift",

--- a/NewTantares/NewTantares-34.1.ckan
+++ b/NewTantares/NewTantares-34.1.ckan
@@ -1,6 +1,6 @@
 {
     "spec_version": 1,
-    "identifier": "Tantares",
+    "identifier": "NewTantares",
     "name": "Tantares",
     "abstract": "Stockalike Soyuz and MIR",
     "author": "Beale",
@@ -11,8 +11,8 @@
         "spacedock": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR",
         "x_screenshot": "https://spacedock.info/content/Beale_838/Tantares_-_Stockalike_Soyuz_and_MIR/Tantares_-_Stockalike_Soyuz_and_MIR-1455884285.234776.png"
     },
-    "version": "34.0",
-    "ksp_version": "1.1.0",
+    "version": "34.1",
+    "ksp_version": "1.1.2",
     "suggests": [
         {
             "name": "CommunityTechTree"
@@ -24,11 +24,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR/download/34.0",
-    "download_size": 23675569,
+    "download": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR/download/34.1",
+    "download_size": 22548321,
     "download_hash": {
-        "sha1": "13F332ABBCC16F47BC8E0AAD7EB8A06169BF3BA1",
-        "sha256": "296D2E9F08DDBA65D48F725DFB86736419886C851F59EBDCD4C2EB6613300DB3"
+        "sha1": "56DEB201C60C1304C0D44AAFA503158EB15371E3",
+        "sha256": "74883AE946AF3361AA67EE0E347EC824DC1C30158D5265C74BA30A912D0A8B12"
     },
     "download_content_type": "application/zip",
     "x_maintained_by": "eagleshift",

--- a/NewTantares/NewTantares-35.0.ckan
+++ b/NewTantares/NewTantares-35.0.ckan
@@ -1,6 +1,6 @@
 {
     "spec_version": 1,
-    "identifier": "Tantares",
+    "identifier": "NewTantares",
     "name": "Tantares",
     "abstract": "Stockalike Soyuz and MIR",
     "author": "Beale",
@@ -11,8 +11,8 @@
         "spacedock": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR",
         "x_screenshot": "https://spacedock.info/content/Beale_838/Tantares_-_Stockalike_Soyuz_and_MIR/Tantares_-_Stockalike_Soyuz_and_MIR-1455884285.234776.png"
     },
-    "version": "36.0",
-    "ksp_version": "1.1.3",
+    "version": "35.0",
+    "ksp_version": "1.1.2",
     "suggests": [
         {
             "name": "CommunityTechTree"
@@ -24,11 +24,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR/download/36.0",
-    "download_size": 21233124,
+    "download": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR/download/35.0",
+    "download_size": 21990336,
     "download_hash": {
-        "sha1": "18A43AC24B8B65520E01490466542C2963B7C750",
-        "sha256": "8A8322AA0B8461283EF2EF3A94E583CE29A3EDF47F907A484501F2363DCA57C5"
+        "sha1": "D855507A37414FA74F8F6D89E26B8C7DA34EEEFB",
+        "sha256": "BD95FAF9E6DE27113B52B6B18853B137D4D3E3B963915BBDDBF24D70008AC031"
     },
     "download_content_type": "application/zip",
     "x_maintained_by": "eagleshift",

--- a/NewTantares/NewTantares-36.0.ckan
+++ b/NewTantares/NewTantares-36.0.ckan
@@ -1,6 +1,6 @@
 {
     "spec_version": 1,
-    "identifier": "Tantares",
+    "identifier": "NewTantares",
     "name": "Tantares",
     "abstract": "Stockalike Soyuz and MIR",
     "author": "Beale",
@@ -11,8 +11,8 @@
         "spacedock": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR",
         "x_screenshot": "https://spacedock.info/content/Beale_838/Tantares_-_Stockalike_Soyuz_and_MIR/Tantares_-_Stockalike_Soyuz_and_MIR-1455884285.234776.png"
     },
-    "version": "35.0",
-    "ksp_version": "1.1.2",
+    "version": "36.0",
+    "ksp_version": "1.1.3",
     "suggests": [
         {
             "name": "CommunityTechTree"
@@ -24,11 +24,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR/download/35.0",
-    "download_size": 21990336,
+    "download": "https://spacedock.info/mod/174/Tantares%20-%20Stockalike%20Soyuz%20and%20MIR/download/36.0",
+    "download_size": 21233124,
     "download_hash": {
-        "sha1": "D855507A37414FA74F8F6D89E26B8C7DA34EEEFB",
-        "sha256": "BD95FAF9E6DE27113B52B6B18853B137D4D3E3B963915BBDDBF24D70008AC031"
+        "sha1": "18A43AC24B8B65520E01490466542C2963B7C750",
+        "sha256": "8A8322AA0B8461283EF2EF3A94E583CE29A3EDF47F907A484501F2363DCA57C5"
     },
     "download_content_type": "application/zip",
     "x_maintained_by": "eagleshift",

--- a/NewTantares/NewTantares-v10.0.ckan
+++ b/NewTantares/NewTantares-v10.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v11.0.ckan
+++ b/NewTantares/NewTantares-v11.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v11.1.ckan
+++ b/NewTantares/NewTantares-v11.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v12.0.ckan
+++ b/NewTantares/NewTantares-v12.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v12.1.ckan
+++ b/NewTantares/NewTantares-v12.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v12.2.ckan
+++ b/NewTantares/NewTantares-v12.2.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v12.3.ckan
+++ b/NewTantares/NewTantares-v12.3.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v13.0.ckan
+++ b/NewTantares/NewTantares-v13.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v14.0.ckan
+++ b/NewTantares/NewTantares-v14.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v14.1.ckan
+++ b/NewTantares/NewTantares-v14.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v14.1.ckan
+++ b/NewTantares/NewTantares-v14.1.ckan
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares",
         "repository": "https://github.com/Tantares/Tantares"
     },
-    "version": "14.1",
+    "version": "v14.1",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.4.2",
     "recommends": [

--- a/NewTantares/NewTantares-v15.0.ckan
+++ b/NewTantares/NewTantares-v15.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v16.0.ckan
+++ b/NewTantares/NewTantares-v16.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v17.0.ckan
+++ b/NewTantares/NewTantares-v17.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v17.1.ckan
+++ b/NewTantares/NewTantares-v17.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v17.2.ckan
+++ b/NewTantares/NewTantares-v17.2.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v18.0.ckan
+++ b/NewTantares/NewTantares-v18.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v18.1.ckan
+++ b/NewTantares/NewTantares-v18.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v19.0.ckan
+++ b/NewTantares/NewTantares-v19.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v2.0.ckan
+++ b/NewTantares/NewTantares-v2.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v20.0.ckan
+++ b/NewTantares/NewTantares-v20.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "version": "v20.0",

--- a/NewTantares/NewTantares-v21.0.ckan
+++ b/NewTantares/NewTantares-v21.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "version": "v21.0",

--- a/NewTantares/NewTantares-v21.1.ckan
+++ b/NewTantares/NewTantares-v21.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "version": "v21.1",

--- a/NewTantares/NewTantares-v21.2.ckan
+++ b/NewTantares/NewTantares-v21.2.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "version": "v21.2",

--- a/NewTantares/NewTantares-v22.0.ckan
+++ b/NewTantares/NewTantares-v22.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "version": "v22.0",

--- a/NewTantares/NewTantares-v22.1.ckan
+++ b/NewTantares/NewTantares-v22.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "version": "v22.1",

--- a/NewTantares/NewTantares-v22.2.ckan
+++ b/NewTantares/NewTantares-v22.2.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "version": "v22.2",

--- a/NewTantares/NewTantares-v23.0.ckan
+++ b/NewTantares/NewTantares-v23.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "version": "v23.0",

--- a/NewTantares/NewTantares-v23.1.ckan
+++ b/NewTantares/NewTantares-v23.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "version": "v23.1",

--- a/NewTantares/NewTantares-v23.2.ckan
+++ b/NewTantares/NewTantares-v23.2.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "version": "v23.2",

--- a/NewTantares/NewTantares-v3.0.ckan
+++ b/NewTantares/NewTantares-v3.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v4.0.ckan
+++ b/NewTantares/NewTantares-v4.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v5.0.ckan
+++ b/NewTantares/NewTantares-v5.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v6.0.ckan
+++ b/NewTantares/NewTantares-v6.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v7.0.ckan
+++ b/NewTantares/NewTantares-v7.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v8.0.ckan
+++ b/NewTantares/NewTantares-v8.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v8.1.ckan
+++ b/NewTantares/NewTantares-v8.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantares/NewTantares-v9.0.ckan
+++ b/NewTantares/NewTantares-v9.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantares",
-    "name": "New Tantares",
+    "name": "Tantares",
     "abstract": "Stockalike Soyuz, LK and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-15.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-15.0.ckan
@@ -1,6 +1,6 @@
 {
     "spec_version": 1,
-    "identifier": "TantaresLV",
+    "identifier": "NewTantaresLV",
     "name": "Tantares LV",
     "abstract": "Stockalike Proton & More",
     "author": "Beale",
@@ -11,8 +11,8 @@
         "spacedock": "https://spacedock.info/mod/176/TantaresLV%20-%20Stockalike%20Launch%20Vehicles",
         "x_screenshot": "https://spacedock.info/content/Beale_838/TantaresLV_-_Stockalike_Launch_Vehicles/TantaresLV_-_Stockalike_Launch_Vehicles-1455884366.676436.png"
     },
-    "version": "17.0",
-    "ksp_version": "1.1.3",
+    "version": "15.0",
+    "ksp_version": "1.0.5",
     "suggests": [
         {
             "name": "Tantares"
@@ -27,11 +27,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/176/TantaresLV%20-%20Stockalike%20Launch%20Vehicles/download/17.0",
-    "download_size": 8462814,
+    "download": "https://spacedock.info/mod/176/TantaresLV%20-%20Stockalike%20Launch%20Vehicles/download/15.0",
+    "download_size": 8962043,
     "download_hash": {
-        "sha1": "24CE21094499DD5B0C81524B67E99D130D1F8A6D",
-        "sha256": "CB113AFB8A1A7BDB57702EB507D70AE9F3EC2FDA79A155D83BD1ECBD9EA4D543"
+        "sha1": "0EF74F57C252ECBA8FB2D5F3E669EEFCD872B6F6",
+        "sha256": "4713785564615CE45677BFE91499A4E2AD4D9C8566A779DD78BF0118A542A587"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/NewTantaresLV/NewTantaresLV-16.1.ckan
+++ b/NewTantaresLV/NewTantaresLV-16.1.ckan
@@ -1,6 +1,6 @@
 {
     "spec_version": 1,
-    "identifier": "TantaresLV",
+    "identifier": "NewTantaresLV",
     "name": "Tantares LV",
     "abstract": "Stockalike Proton & More",
     "author": "Beale",
@@ -11,8 +11,8 @@
         "spacedock": "https://spacedock.info/mod/176/TantaresLV%20-%20Stockalike%20Launch%20Vehicles",
         "x_screenshot": "https://spacedock.info/content/Beale_838/TantaresLV_-_Stockalike_Launch_Vehicles/TantaresLV_-_Stockalike_Launch_Vehicles-1455884366.676436.png"
     },
-    "version": "15.0",
-    "ksp_version": "1.0.5",
+    "version": "16.1",
+    "ksp_version": "1.1.2",
     "suggests": [
         {
             "name": "Tantares"
@@ -27,11 +27,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/176/TantaresLV%20-%20Stockalike%20Launch%20Vehicles/download/15.0",
-    "download_size": 8962043,
+    "download": "https://spacedock.info/mod/176/TantaresLV%20-%20Stockalike%20Launch%20Vehicles/download/16.1",
+    "download_size": 8256931,
     "download_hash": {
-        "sha1": "0EF74F57C252ECBA8FB2D5F3E669EEFCD872B6F6",
-        "sha256": "4713785564615CE45677BFE91499A4E2AD4D9C8566A779DD78BF0118A542A587"
+        "sha1": "9BFA00A2D8D85F1BAE8DC142ACC233CE66D59B6D",
+        "sha256": "F83606125A5FE326EBCE178873F06122E8004252C7A2F42584335BDE251ABCE2"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/NewTantaresLV/NewTantaresLV-17.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-17.0.ckan
@@ -1,6 +1,6 @@
 {
     "spec_version": 1,
-    "identifier": "TantaresLV",
+    "identifier": "NewTantaresLV",
     "name": "Tantares LV",
     "abstract": "Stockalike Proton & More",
     "author": "Beale",
@@ -11,8 +11,8 @@
         "spacedock": "https://spacedock.info/mod/176/TantaresLV%20-%20Stockalike%20Launch%20Vehicles",
         "x_screenshot": "https://spacedock.info/content/Beale_838/TantaresLV_-_Stockalike_Launch_Vehicles/TantaresLV_-_Stockalike_Launch_Vehicles-1455884366.676436.png"
     },
-    "version": "16.1",
-    "ksp_version": "1.1.2",
+    "version": "17.0",
+    "ksp_version": "1.1.3",
     "suggests": [
         {
             "name": "Tantares"
@@ -27,11 +27,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/176/TantaresLV%20-%20Stockalike%20Launch%20Vehicles/download/16.1",
-    "download_size": 8256931,
+    "download": "https://spacedock.info/mod/176/TantaresLV%20-%20Stockalike%20Launch%20Vehicles/download/17.0",
+    "download_size": 8462814,
     "download_hash": {
-        "sha1": "9BFA00A2D8D85F1BAE8DC142ACC233CE66D59B6D",
-        "sha256": "F83606125A5FE326EBCE178873F06122E8004252C7A2F42584335BDE251ABCE2"
+        "sha1": "24CE21094499DD5B0C81524B67E99D130D1F8A6D",
+        "sha256": "CB113AFB8A1A7BDB57702EB507D70AE9F3EC2FDA79A155D83BD1ECBD9EA4D543"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/NewTantaresLV/NewTantaresLV-v10.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-v10.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-v11.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-v11.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-v12.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-v12.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-v12.1.ckan
+++ b/NewTantaresLV/NewTantaresLV-v12.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "version": "v12.1",

--- a/NewTantaresLV/NewTantaresLV-v13.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-v13.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "version": "v13.0",

--- a/NewTantaresLV/NewTantaresLV-v13.1.ckan
+++ b/NewTantaresLV/NewTantaresLV-v13.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "version": "v13.1",

--- a/NewTantaresLV/NewTantaresLV-v2.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-v2.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-v3.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-v3.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-v4.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-v4.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-v5.1.ckan
+++ b/NewTantaresLV/NewTantaresLV-v5.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-v6.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-v6.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-v7.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-v7.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-v8.1.ckan
+++ b/NewTantaresLV/NewTantaresLV-v8.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-v9.0.ckan
+++ b/NewTantaresLV/NewTantaresLV-v9.0.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",

--- a/NewTantaresLV/NewTantaresLV-v9.1.ckan
+++ b/NewTantaresLV/NewTantaresLV-v9.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "NewTantaresLV",
-    "name": "New TantaresLV",
+    "name": "TantaresLV",
     "abstract": "Stockalike N1, Soyuz and more!",
     "author": "Beale",
     "license": "CC-BY-NC-SA-4.0",


### PR DESCRIPTION
Follow-up of https://github.com/KSP-CKAN/NetKAN/pull/8402

The Tantares .ckans are migrated to the NewTantares identifier, and the TantaresLV identifiers are migrated to NewTantaresLV.
After this PR, the GUI should show only one of each of the Tantares mods anymore, and hopefully avoid any confusion on user side.

Version 14.1 of Tantares got a v prefix to sort correctly.

The .kerbalstuff files are left untouched.