### PR TITLE
Make recent DLCs compatible with KSP 1.11.2

### DIFF
--- a/BreakingGround-DLC/BreakingGround-DLC-1.6.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.6.0.ckan
@@ -5,7 +5,8 @@
     "abstract":     "The second expansion pack adds new science-collecting equipment to deploy on your missions, surface features to be investigated scattered across distant planets, and a wealth of new robotic parts for players to test their creativity with",
     "author":       "SQUAD",
     "version":      "1.6.0",
-    "ksp_version":  "1.11.0",
+    "ksp_version_min": "1.11.0",
+    "ksp_version_max": "1.11.2",
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {

--- a/BreakingGround-DLC/BreakingGround-DLC-1.6.1.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.6.1.ckan
@@ -5,7 +5,8 @@
     "abstract":     "The second expansion pack adds new science-collecting equipment to deploy on your missions, surface features to be investigated scattered across distant planets, and a wealth of new robotic parts for players to test their creativity with",
     "author":       "SQUAD",
     "version":      "1.6.1",
-    "ksp_version":  "1.11.1",
+    "ksp_version_min": "1.11.1",
+    "ksp_version_max": "1.11.2",
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {

--- a/MakingHistory-DLC/MakingHistory-DLC-1.11.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.11.0.ckan
@@ -5,7 +5,8 @@
     "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
     "author":       "SQUAD",
     "version":      "1.11.0",
-    "ksp_version":  "1.11.0",
+    "ksp_version_min": "1.11.0",
+    "ksp_version_max": "1.11.2",
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {

--- a/MakingHistory-DLC/MakingHistory-DLC-1.11.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.11.1.ckan
@@ -5,7 +5,8 @@
     "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
     "author":       "SQUAD",
     "version":      "1.11.1",
-    "ksp_version":  "1.11.1",
+    "ksp_version_min": "1.11.1",
+    "ksp_version_max": "1.11.2",
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {


### PR DESCRIPTION
## Motivation

Upstream DLC maintenance has gotten a bit sloppy, see part of KSP-CKAN/CKAN#3243 and KSP-CKAN/CKAN#3302.

In KSP 1.11.1, both DLCs were updated in the changelog but not in the version declared at the top of the readme:

```
$ egrep '^Version|1.11' */readme.txt
MakingHistory/readme.txt:Version 1.11.0
MakingHistory/readme.txt:=================================== v1.11.1 - Requires KSP v1.11.1 ================================
MakingHistory/readme.txt:=================================== v1.11.0 - Requires KSP v1.11.0 ================================
Serenity/readme.txt:Version 1.6.0	
Serenity/readme.txt:====================================== v1.6.1 - Requires KSP v1.11.1 ==============================
Serenity/readme.txt:====================================== v1.6.0 - Requires KSP v1.11.0 ==============================
```

Now in 1.11.2 the DLCs aren't changed at all. Presumably players are OK to use the latest versions.

https://forum.kerbalspaceprogram.com/index.php?/topic/201057-kerbal-space-program-1112-is-live/

## Changes

Now both the actual versions that players have and the versions they falsely claim to be are updated to be compatible with 1.11.2.