### PR TITLE
Mark Harmony1 bundlers

### DIFF
--- a/AirlockPlus/AirlockPlus-v0.0.10.ckan
+++ b/AirlockPlus/AirlockPlus-v0.0.10.ckan
@@ -12,6 +12,9 @@
     "version": "v0.0.10",
     "ksp_version_min": "1.3.0",
     "ksp_version_max": "1.7.8",
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/AirlockPlus/AirlockPlus-v0.0.9.ckan
+++ b/AirlockPlus/AirlockPlus-v0.0.9.ckan
@@ -12,6 +12,9 @@
     "version": "v0.0.9",
     "ksp_version_min": "1.3.0",
     "ksp_version_max": "1.3.8",
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/Kerbalism/Kerbalism-3.0.1.ckan
+++ b/Kerbalism/Kerbalism-3.0.1.ckan
@@ -17,6 +17,9 @@
     "version": "3.0.1",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.7.99",
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/Kerbalism/Kerbalism-3.0.2.ckan
+++ b/Kerbalism/Kerbalism-3.0.2.ckan
@@ -17,6 +17,9 @@
     "version": "3.0.2",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.7.99",
+    "provides": [
+        "Harmony1"
+    ],
     "localizations": [
         "de-de",
         "ru",

--- a/Kerbalism/Kerbalism-3.0.ckan
+++ b/Kerbalism/Kerbalism-3.0.ckan
@@ -17,6 +17,9 @@
     "version": "3.0",
     "ksp_version_min": "1.4.0",
     "ksp_version_max": "1.7.99",
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/Kerbalism/Kerbalism-3.1.ckan
+++ b/Kerbalism/Kerbalism-3.1.ckan
@@ -20,6 +20,9 @@
         "de-de",
         "pt-br"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/Kerbalism/Kerbalism-3.10.ckan
+++ b/Kerbalism/Kerbalism-3.10.ckan
@@ -28,6 +28,9 @@
         "de-de",
         "pt-br"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "CommunityResourcePack"

--- a/Kerbalism/Kerbalism-3.11.ckan
+++ b/Kerbalism/Kerbalism-3.11.ckan
@@ -28,6 +28,9 @@
         "de-de",
         "pt-br"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "CommunityResourcePack"

--- a/Kerbalism/Kerbalism-3.2.ckan
+++ b/Kerbalism/Kerbalism-3.2.ckan
@@ -26,6 +26,9 @@
         "de-de",
         "pt-br"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/Kerbalism/Kerbalism-3.3.ckan
+++ b/Kerbalism/Kerbalism-3.3.ckan
@@ -22,6 +22,9 @@
     "localizations": [
         "zh-cn"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/Kerbalism/Kerbalism-3.4.ckan
+++ b/Kerbalism/Kerbalism-3.4.ckan
@@ -22,6 +22,9 @@
     "localizations": [
         "zh-cn"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/Kerbalism/Kerbalism-3.5.ckan
+++ b/Kerbalism/Kerbalism-3.5.ckan
@@ -23,6 +23,9 @@
         "zh-cn",
         "de-de"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/Kerbalism/Kerbalism-3.6.ckan
+++ b/Kerbalism/Kerbalism-3.6.ckan
@@ -27,6 +27,9 @@
         "ru",
         "zh-cn"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/Kerbalism/Kerbalism-3.7.ckan
+++ b/Kerbalism/Kerbalism-3.7.ckan
@@ -27,6 +27,9 @@
         "ru",
         "zh-cn"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/Kerbalism/Kerbalism-3.8.ckan
+++ b/Kerbalism/Kerbalism-3.8.ckan
@@ -27,6 +27,9 @@
         "ru",
         "zh-cn"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/Kerbalism/Kerbalism-3.9.ckan
+++ b/Kerbalism/Kerbalism-3.9.ckan
@@ -28,6 +28,9 @@
         "ru",
         "zh-cn"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "CommunityResourcePack"

--- a/LunaMultiplayer/LunaMultiplayer-0.26.0.ckan
+++ b/LunaMultiplayer/LunaMultiplayer-0.26.0.ckan
@@ -16,6 +16,9 @@
     "tags": [
         "plugin"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "download": "https://github.com/LunaMultiplayer/LunaMultiplayer/releases/download/0.26.0/LunaMultiplayer-Release.zip",
     "download_size": 2012726,
     "download_hash": {

--- a/TiltEm/TiltEm-1.2.0.ckan
+++ b/TiltEm/TiltEm-1.2.0.ckan
@@ -15,6 +15,9 @@
         "en-us",
         "es-es"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/TiltEm/TiltEm-1.2.1.ckan
+++ b/TiltEm/TiltEm-1.2.1.ckan
@@ -15,6 +15,9 @@
         "en-us",
         "es-es"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"

--- a/TiltEm/TiltEm-1.2.2.ckan
+++ b/TiltEm/TiltEm-1.2.2.ckan
@@ -20,6 +20,9 @@
         "en-us",
         "es-es"
     ],
+    "provides": [
+        "Harmony1"
+    ],
     "depends": [
         {
             "name": "ModuleManager"


### PR DESCRIPTION
Historical counterpart of KSP-CKAN/NetKAN#8288.
These mods bundle a Harmony 1 DLL. Now they provide the Harmony1 identifier.