### PR TITLE
Revert BluedogDB-v1.7.1 compat change

### DIFF
--- a/BluedogDB/BluedogDB-v1.7.1.ckan
+++ b/BluedogDB/BluedogDB-v1.7.1.ckan
@@ -9,7 +9,7 @@
         "Zorg"
     ],
     "version": "v1.7.1",
-    "ksp_version_min": "1.7.3",
+    "ksp_version_min": "1.8.0",
     "ksp_version_max": "1.10.99",
     "license": "CC-BY-NC-SA-4.0",
     "resources": {


### PR DESCRIPTION
This reverts commit 026defc567c50b4801b253ae9ff6ad0082eccdcc.

That commit was the bot picking up on https://github.com/CobaltWolf/Bluedog-Design-Bureau/commit/4f345c1727f6988df9a474b5f8e3ab0eed0bf1bb. Since the `VERSION` is updated for a new release, the compat update from CobaltWolf/Bluedog-Design-Bureau#1040 is no longer available.

This should be merged after KSP-CKAN/NetKAN#8434.