### PR TITLE
Make StandardPropulsionSystems indefinitely compatible

### DIFF
--- a/StandardPropulsionSystems/StandardPropulsionSystems-1.0.5.ckan
+++ b/StandardPropulsionSystems/StandardPropulsionSystems-1.0.5.ckan
@@ -10,6 +10,9 @@
         "spacedock": "https://spacedock.info/mod/226/Standard%20Propulsion%20Systems",
         "x_screenshot": "https://spacedock.info/content/Starbuckminsterfullerton_1223/Standard_Propulsion_Systems/Standard_Propulsion_Systems-1459126034.607687.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "1.0.5",
     "ksp_version_min": "1.2.0",
     "install": [

--- a/StandardPropulsionSystems/StandardPropulsionSystems-1.0.5.ckan
+++ b/StandardPropulsionSystems/StandardPropulsionSystems-1.0.5.ckan
@@ -11,7 +11,7 @@
         "x_screenshot": "https://spacedock.info/content/Starbuckminsterfullerton_1223/Standard_Propulsion_Systems/Standard_Propulsion_Systems-1459126034.607687.png"
     },
     "version": "1.0.5",
-    "ksp_version": "1.2.0",
+    "ksp_version_min": "1.2.0",
     "install": [
         {
             "find": "SPS",


### PR DESCRIPTION
This mod's author intends that it be treated as compatible with all future game versions:

https://forum.kerbalspaceprogram.com/index.php?/topic/200041-110x-111x-moar-station-science-out-of-beta/&do=findComment&comment=3946101

> It's a very simple part mod under the hood, so it should remain compatible with both KSP and other mods pretty much indefinitely.

The netkan was frozen as idle in KSP-CKAN/NetKAN#7513, so if we unfreeze it in the future we'll have to figure out the compatibility anew at that time.