### PR TITLE
Replace bad UniversalStorage links

### DIFF
--- a/UniversalStorage/UniversalStorage-1.3.0.0.ckan
+++ b/UniversalStorage/UniversalStorage-1.3.0.0.ckan
@@ -6,7 +6,7 @@
     "author": "Paul_Kingtiger",
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvs",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/68043-universal-storage/",
         "spacedock": "https://spacedock.info/mod/329/Universal%20Storage",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage/Universal_Storage-1456863749.8985937.jpg"
     },

--- a/UniversalStorage/UniversalStorage-1.4.0.0.ckan
+++ b/UniversalStorage/UniversalStorage-1.4.0.0.ckan
@@ -12,7 +12,7 @@
     "ksp_version_max": "1.4.99",
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvs",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/68043-universal-storage/",
         "spacedock": "https://spacedock.info/mod/329/Universal%20Storage",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage/Universal_Storage-1456863749.8985937.jpg"
     },

--- a/UniversalStorage2/UniversalStorage2-1.3.1.2.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.2.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.3.1.2",

--- a/UniversalStorage2/UniversalStorage2-1.3.1.3.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.3.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.3.1.3",

--- a/UniversalStorage2/UniversalStorage2-1.3.1.4.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.4.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.3.1.4",

--- a/UniversalStorage2/UniversalStorage2-1.3.1.5.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.5.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.3.1.5",

--- a/UniversalStorage2/UniversalStorage2-1.3.1.6.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.6.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.3.1.6",

--- a/UniversalStorage2/UniversalStorage2-1.3.1.7.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.7.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.3.1.7",

--- a/UniversalStorage2/UniversalStorage2-1.3.1.8.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.8.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.3.1.8",

--- a/UniversalStorage2/UniversalStorage2-1.3.1.9.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.3.1.9.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.3.1.9",

--- a/UniversalStorage2/UniversalStorage2-1.4.5.2.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.4.5.2.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.4.5.2",

--- a/UniversalStorage2/UniversalStorage2-1.4.5.3.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.4.5.3.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.4.5.3",

--- a/UniversalStorage2/UniversalStorage2-1.4.5.4.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.4.5.4.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.4.5.4",

--- a/UniversalStorage2/UniversalStorage2-1.5.1.5.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.5.1.5.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.5.1.5",

--- a/UniversalStorage2/UniversalStorage2-1.5.1.6.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.5.1.6.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.5.1.6",

--- a/UniversalStorage2/UniversalStorage2-1.5.1.7.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.5.1.7.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.5.1.7",

--- a/UniversalStorage2/UniversalStorage2-1.5.1.8.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.5.1.8.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.5.1.8",

--- a/UniversalStorage2/UniversalStorage2-1.6.0.9.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.6.0.9.ckan
@@ -10,9 +10,9 @@
     ],
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/wp-content/uploads/2018/08/Universal-Storage-Source-Code.zip",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1545589673.8555577.png"
     },
     "version": "1.6.0.9",

--- a/UniversalStorage2/UniversalStorage2-1.7.0.10.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.7.0.10.ckan
@@ -13,9 +13,9 @@
     "ksp_version_max": "1.7.99",
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/uvsii/",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1555099054.1009135.png"
     },
     "tags": [

--- a/UniversalStorage2/UniversalStorage2-1.9.1.1.ckan
+++ b/UniversalStorage2/UniversalStorage2-1.9.1.1.ckan
@@ -13,9 +13,9 @@
     "ksp_version_max": "1.9.1",
     "license": "restricted",
     "resources": {
-        "homepage": "http://www.kingtiger.online/uvsii/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii/",
         "spacedock": "https://spacedock.info/mod/1933/Universal%20Storage%20II",
-        "repository": "http://www.kingtiger.online/uvsii/",
+        "repository": "https://1drv.ms/f/s!AvmqbLkW8UIH2PsfIYBmSwhNfYG-pw",
         "x_screenshot": "https://spacedock.info/content/Paul_Kingtiger_1707/Universal_Storage_II/Universal_Storage_II-1592889615.2852194.jpg"
     },
     "tags": [


### PR DESCRIPTION
The domain expired and is reportedly redirecting to scam/phishing sites for people without ad- & scriptblocker.
We don't want our users to catch a virus, especially not these days.
I've already replaced the links on the SpaceDock page, now I'm backporting the change to older releases.

The homepage link now goes to the forum thread, the repository link goes to a OneDrive archive of the source code. Yes, 1drv.ms is legit, please ask Microsoft why they thought using a domain looking as shady as this for link shortening would be a good idea.

The UniversalStorage 1 metadata contains a bunch of links to a different domain, www.kingtiger.co.uk, which also seems to be abandoned, but is not leading to any phishing sites so I kept it as is for now.

Fixes https://github.com/KSP-CKAN/NetKAN/issues/8473