### PR TITLE
Remove UnKerballedStart and ProbesBeforeCrew from TechTreeKompacted 1.4 conflicts

### DIFF
--- a/TechTreeKompacted/TechTreeKompacted-1.4.ckan
+++ b/TechTreeKompacted/TechTreeKompacted-1.4.ckan
@@ -29,12 +29,6 @@
         },
         {
             "name": "KiwiTechTree"
-        },
-        {
-            "name": "UnKerballedStart"
-        },
-        {
-            "name": "ProbesBeforeCrew"
         }
     ],
     "download": "https://spacedock.info/mod/2600/TechTree%20Kompacted/download/1.4",


### PR DESCRIPTION
Backport of https://github.com/KSP-CKAN/NetKAN/pull/8481 to version 1.4 of TechTreeKompacted , which was the first one without these conflicts.