### PR TITLE
Fix ROEngines historical licenses

### DIFF
--- a/ROEngines/ROEngines-v1.3.1.0.ckan
+++ b/ROEngines/ROEngines-v1.3.1.0.ckan
@@ -4,7 +4,7 @@
     "name": "RO Engines",
     "abstract": "ROEngines is a mod that takes the best versions of engine models available and uses them as the in-game models for Realism Overhaul parts.",
     "author": "Pap1723",
-    "license": "CC-BY-SA",
+    "license": "CC-BY-NC-ND",
     "release_status": "stable",
     "resources": {
         "repository": "https://github.com/KSP-RO/ROEngines",

--- a/ROEngines/ROEngines-v1.4.0.0.ckan
+++ b/ROEngines/ROEngines-v1.4.0.0.ckan
@@ -7,7 +7,7 @@
     "version": "v1.4.0.0",
     "ksp_version_min": "1.6.1",
     "ksp_version_max": "1.7.3",
-    "license": "CC-BY-SA",
+    "license": "CC-BY-NC-ND",
     "release_status": "stable",
     "resources": {
         "repository": "https://github.com/KSP-RO/ROEngines",

--- a/ROEngines/ROEngines-v1.5.ckan
+++ b/ROEngines/ROEngines-v1.5.ckan
@@ -10,7 +10,7 @@
     "version": "v1.5",
     "ksp_version_min": "1.8.1",
     "ksp_version_max": "1.9.99",
-    "license": "CC-BY-SA-4.0",
+    "license": "CC-BY-NC-ND",
     "release_status": "stable",
     "resources": {
         "homepage": "https://discordapp.com/invite/ZGbR6nv",

--- a/ROEngines/ROEngines-v1.6.ckan
+++ b/ROEngines/ROEngines-v1.6.ckan
@@ -10,7 +10,7 @@
     "version": "v1.6",
     "ksp_version_min": "1.8.1",
     "ksp_version_max": "1.9.99",
-    "license": "CC-BY-SA-4.0",
+    "license": "CC-BY-NC-ND",
     "release_status": "stable",
     "resources": {
         "homepage": "https://discordapp.com/invite/ZGbR6nv",


### PR DESCRIPTION
See KSP-RO/ROEngines#140, this mod always included ND content from @raidernick and should have had the CC-BY-NC-ND license all along.