### PR TITLE
Update TheWorldBeyond license and compatibility

### DIFF
--- a/TheWorldBeyond/TheWorldBeyond-v1.1.1.ckan
+++ b/TheWorldBeyond/TheWorldBeyond-v1.1.1.ckan
@@ -6,8 +6,8 @@
     "author": "TheProtagonists",
     "version": "v1.1.1",
     "ksp_version_min": "1.3.1",
-    "ksp_version_max": "1.5.1",
-    "license": "CC-BY-NC-ND-4.0",
+    "ksp_version_max": "1.6.1",
+    "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175432-*",
         "repository": "https://github.com/TheProtagonists/TheWorldBeyond",


### PR DESCRIPTION
See https://github.com/KSP-CKAN/NetKAN/pull/8580, this mod has been discontinued, and to allow adoption by another author the license has been changed to CC-BY-NC-SA-4.0.
The compatibility is updated as well, to reflect the latest state of the forum thread:
![image](https://user-images.githubusercontent.com/28812678/122769535-ec8c0180-d2a4-11eb-976c-00a57406bd10.png)
