### PR TITLE
Update historical USITools download links after repo switcheroo

### DIFF
--- a/USITools/USITools-0.10.0.0.ckan
+++ b/USITools/USITools-0.10.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.10.0.0",
     "ksp_version_min": "1.3.1",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/0.10.0.0/USITools_0.10.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.10.0.0/USITools_0.10.0.0.zip",
     "download_size": 2734130,
     "download_hash": {
         "sha1": "4559395E8DBC555DAC31ABEE666E9B5C4716F80D",

--- a/USITools/USITools-0.10.1.0.ckan
+++ b/USITools/USITools-0.10.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.10.1.0",
     "ksp_version_min": "1.3.1",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/0.10.1.0/USITools_0.10.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.10.1.0/USITools_0.10.1.0.zip",
     "download_size": 2734159,
     "download_hash": {
         "sha1": "109A62C6BD113D90534308F3EC727686FE948AF6",

--- a/USITools/USITools-0.10.2.0.ckan
+++ b/USITools/USITools-0.10.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.10.2.0",
     "ksp_version_min": "1.3.1",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/0.10.2.0/USITools_0.10.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.10.2.0/USITools_0.10.2.0.zip",
     "download_size": 2736735,
     "download_hash": {
         "sha1": "C4B2A1199B250E2119D91AAA32885EA1E95FB7DF",

--- a/USITools/USITools-0.11.0.0.ckan
+++ b/USITools/USITools-0.11.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.11.0.0",
     "ksp_version_min": "1.4.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/0.11.0.0/USITools_0.11.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.11.0.0/USITools_0.11.0.0.zip",
     "download_size": 2736699,
     "download_hash": {
         "sha1": "CECC46FA21A388261EE41AF77E8F56627F979FD5",

--- a/USITools/USITools-0.11.1.0.ckan
+++ b/USITools/USITools-0.11.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.11.1.0",
     "ksp_version_min": "1.4.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/0.11.1.0/USITools_0.11.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.11.1.0/USITools_0.11.1.0.zip",
     "download_size": 2740266,
     "download_hash": {
         "sha1": "9BCFE32B28C4656DE80100B55BBEF8BFD143ED0D",

--- a/USITools/USITools-0.12.0.0.ckan
+++ b/USITools/USITools-0.12.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.12.0.0",
     "ksp_version_min": "1.4.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/0.12.0.0/USITools_0.12.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.12.0.0/USITools_0.12.0.0.zip",
     "download_size": 2740278,
     "download_hash": {
         "sha1": "6F66B77C43B1D524B2482F73CE928BCEBEDA9AA3",

--- a/USITools/USITools-0.7.4.0.ckan
+++ b/USITools/USITools-0.7.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.7.4.0",
     "ksp_version_min": "1.0.0",
@@ -35,7 +35,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.7.4.0/USITools_0.7.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.7.4.0/USITools_0.7.4.0.zip",
     "download_size": 2054796,
     "download_hash": {
         "sha1": "ECC9F47B44F0197F1E475740E5BFD24DC82EFA5B",

--- a/USITools/USITools-0.8.0.0.ckan
+++ b/USITools/USITools-0.8.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.0.0",
     "ksp_version": "1.2.0",
@@ -30,7 +30,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.0.0/USITools_0.8.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.0.0/USITools_0.8.0.0.zip",
     "download_size": 2666883,
     "download_hash": {
         "sha1": "00B6B6976453CA17902165722B930370288CDF4F",

--- a/USITools/USITools-0.8.1.0.ckan
+++ b/USITools/USITools-0.8.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.1.0",
     "ksp_version": "1.2.0",
@@ -30,7 +30,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.1.0/USITools_0.8.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.1.0/USITools_0.8.1.0.zip",
     "download_size": 2666464,
     "download_hash": {
         "sha1": "5B3D3D347EA6FF103755782E2877C86274F2E5D9",

--- a/USITools/USITools-0.8.10.0.ckan
+++ b/USITools/USITools-0.8.10.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.10.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.10.0/USITools_0.8.10.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.10.0/USITools_0.8.10.0.zip",
     "download_size": 2707512,
     "download_hash": {
         "sha1": "06E71557CBF7A52A8E669541C893C5B5CCBD5067",

--- a/USITools/USITools-0.8.11.0.ckan
+++ b/USITools/USITools-0.8.11.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.11.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.11.0/USITools_0.8.11.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.11.0/USITools_0.8.11.0.zip",
     "download_size": 2707168,
     "download_hash": {
         "sha1": "F77328CD389756129486F283C0ACAB4DBF49E3BA",

--- a/USITools/USITools-0.8.12.0.ckan
+++ b/USITools/USITools-0.8.12.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.12.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.12.0/USITools_0.8.12.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.12.0/USITools_0.8.12.0.zip",
     "download_size": 2707793,
     "download_hash": {
         "sha1": "AAEC3AFE28CB9D5668DDC8521D3B0B47A4D52322",

--- a/USITools/USITools-0.8.13.0.ckan
+++ b/USITools/USITools-0.8.13.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.13.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.13.0/USITools_0.8.13.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.13.0/USITools_0.8.13.0.zip",
     "download_size": 2707740,
     "download_hash": {
         "sha1": "134E61F16884EA4F855B902D9E0B1AB209438400",

--- a/USITools/USITools-0.8.14.0.ckan
+++ b/USITools/USITools-0.8.14.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.14.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.14.0/USITools_0.8.14.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.14.0/USITools_0.8.14.0.zip",
     "download_size": 2707907,
     "download_hash": {
         "sha1": "7D8795EA4664B9A8D7E47FC77AA997B92535C0F5",

--- a/USITools/USITools-0.8.15.0.ckan
+++ b/USITools/USITools-0.8.15.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.15.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.15.0/USITools_0.8.15.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.15.0/USITools_0.8.15.0.zip",
     "download_size": 2707985,
     "download_hash": {
         "sha1": "5E7F3956E95791545DB62BD9641DE5D07558352A",

--- a/USITools/USITools-0.8.16.0.ckan
+++ b/USITools/USITools-0.8.16.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.16.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.16.0/USITools_0.8.16.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.16.0/USITools_0.8.16.0.zip",
     "download_size": 2708817,
     "download_hash": {
         "sha1": "6F49A6963BD223E59FD9264F043EE7CAF0E84AAC",

--- a/USITools/USITools-0.8.17.0.ckan
+++ b/USITools/USITools-0.8.17.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.17.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.17.0/USITools_0.8.17.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.17.0/USITools_0.8.17.0.zip",
     "download_size": 2709400,
     "download_hash": {
         "sha1": "6F6589F5288EBEE11C67AF5BEC6D241D18C67421",

--- a/USITools/USITools-0.8.18.0.ckan
+++ b/USITools/USITools-0.8.18.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.18.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/0.8.18.0/USITools_0.8.18.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.18.0/USITools_0.8.18.0.zip",
     "download_size": 2709481,
     "download_hash": {
         "sha1": "58761473DE492EE6A44397E75CF2394807078000",

--- a/USITools/USITools-0.8.2.0.ckan
+++ b/USITools/USITools-0.8.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.2.0",
     "ksp_version": "1.2.0",
@@ -30,7 +30,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.2.0/USITools_0.8.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.2.0/USITools_0.8.2.0.zip",
     "download_size": 2666606,
     "download_hash": {
         "sha1": "71DE9D3CF182667BC5BF3BE380A792C34046B27A",

--- a/USITools/USITools-0.8.3.0.ckan
+++ b/USITools/USITools-0.8.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.3.0",
     "ksp_version": "1.2.0",
@@ -30,7 +30,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.3.0/USITools_0.8.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.3.0/USITools_0.8.3.0.zip",
     "download_size": 2667526,
     "download_hash": {
         "sha1": "92092D84AC3D394CBF1A3B56510E1C95C06B3ABC",

--- a/USITools/USITools-0.8.4.0.ckan
+++ b/USITools/USITools-0.8.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.4.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.4.0/USITools_0.8.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.4.0/USITools_0.8.4.0.zip",
     "download_size": 2670614,
     "download_hash": {
         "sha1": "37BF3E03EC4916FD73951488E67AF576E3DE3C5C",

--- a/USITools/USITools-0.8.5.0.ckan
+++ b/USITools/USITools-0.8.5.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.5.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.5.0/USITools_0.8.5.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.5.0/USITools_0.8.5.0.zip",
     "download_size": 2688916,
     "download_hash": {
         "sha1": "6DCC698016BB90679A7E32291139A8908ED7307C",

--- a/USITools/USITools-0.8.6.0.ckan
+++ b/USITools/USITools-0.8.6.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.6.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.6.0/USITools_0.8.6.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.6.0/USITools_0.8.6.0.zip",
     "download_size": 2690132,
     "download_hash": {
         "sha1": "BC1E65D1A97703D5A8158AD5A622E5DBB0D15E3B",

--- a/USITools/USITools-0.8.7.0.ckan
+++ b/USITools/USITools-0.8.7.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.7.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.7.0/USITools_0.8.7.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.7.0/USITools_0.8.7.0.zip",
     "download_size": 2702849,
     "download_hash": {
         "sha1": "BBECFAD8B3E003864DBD8A8D90DE6406CC64F3B7",

--- a/USITools/USITools-0.8.8.0.ckan
+++ b/USITools/USITools-0.8.8.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.8.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.8.0/USITools_0.8.8.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.8.0/USITools_0.8.8.0.zip",
     "download_size": 2703386,
     "download_hash": {
         "sha1": "DEE0C90A9418C731A14EBB5E0687D51837182DB3",

--- a/USITools/USITools-0.8.9.0.ckan
+++ b/USITools/USITools-0.8.9.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.8.9.0",
     "ksp_version_min": "1.2.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/UmbraSpaceIndustries/releases/download/0.8.9.0/USITools_0.8.9.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.8.9.0/USITools_0.8.9.0.zip",
     "download_size": 2703393,
     "download_hash": {
         "sha1": "63C91EA8098F8DF87D979A617A0AAFF601ED4E96",

--- a/USITools/USITools-0.9.0.0.ckan
+++ b/USITools/USITools-0.9.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.9.0.0",
     "ksp_version_min": "1.2.9",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/0.9.0.0/USITools_0.9.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.9.0.0/USITools_0.9.0.0.zip",
     "download_size": 2714275,
     "download_hash": {
         "sha1": "C7335F460FC69E11D9E779190F7F599501F6AE2C",

--- a/USITools/USITools-0.9.1.0.ckan
+++ b/USITools/USITools-0.9.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.9.1.0",
     "ksp_version_min": "1.2.9",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/0.9.1.0/USITools_0.9.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.9.1.0/USITools_0.9.1.0.zip",
     "download_size": 2714295,
     "download_hash": {
         "sha1": "E800FD51F2CD0F08D3913886B04F2B9737AF1158",

--- a/USITools/USITools-0.9.2.0.ckan
+++ b/USITools/USITools-0.9.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.9.2.0",
     "ksp_version_min": "1.2.9",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/0.9.2.0/USITools_0.9.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.9.2.0/USITools_0.9.2.0.zip",
     "download_size": 2714193,
     "download_hash": {
         "sha1": "D6C4CA9DAA4E6E8477CE6B22D6E144FAFD90244C",

--- a/USITools/USITools-0.9.3.0.ckan
+++ b/USITools/USITools-0.9.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "0.9.3.0",
     "ksp_version_min": "1.2.9",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/0.9.3.0/USITools_0.9.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/0.9.3.0/USITools_0.9.3.0.zip",
     "download_size": 2718882,
     "download_hash": {
         "sha1": "5CE1158CCA4ACB7F8BD6D2356ABA964568BA4A44",

--- a/USITools/USITools-1.1.0.0.ckan
+++ b/USITools/USITools-1.1.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "1.1.0.0",
     "ksp_version_min": "1.6.0",
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/1.1.0.0/USITools_1.1.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/1.1.0.0/USITools_1.1.0.0.zip",
     "download_size": 2742922,
     "download_hash": {
         "sha1": "958E879019470E582ECAD7A7A59FBBD271ADC9B4",

--- a/USITools/USITools-1.2.0.0.ckan
+++ b/USITools/USITools-1.2.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries"
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools"
     },
     "version": "1.2.0.0",
     "ksp_version_min": "1.6.0",
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/1.2.0.0/USITools_1.2.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/1.2.0.0/USITools_1.2.0.0.zip",
     "download_size": 2743386,
     "download_hash": {
         "sha1": "D16A9537D59C8C96B28B20877BD2A9783394326C",

--- a/USITools/USITools-1.3.0.0.ckan
+++ b/USITools/USITools-1.3.0.0.ckan
@@ -11,8 +11,8 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries",
-        "bugtracker": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/issues",
+        "repository": "https://github.com/UmbraSpaceIndustries/USITools",
+        "bugtracker": "https://github.com/UmbraSpaceIndustries/USITools/issues",
         "metanetkan": "https://raw.githubusercontent.com/BobPalmer/CKAN/master/USITools.netkan"
     },
     "tags": [
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/releases/download/1.3.0.0/USITools_1.3.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USITools/releases/download/1.3.0.0/USITools_1.3.0.0.zip",
     "download_size": 2726646,
     "download_hash": {
         "sha1": "6608860595FA81B31D2877D6A4FB25090F349310",


### PR DESCRIPTION
The USITools repo made quite a journey by now. It started at https://github.com/BobPalmer/UmbraSpaceIndustries, moved to https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries on 2017-04-26 ([bot commit](https://github.com/KSP-CKAN/CKAN-meta/commit/20fb9b5d3138763ba066a531befc678c0c6b6203)),
then moved to https://github.com/UmbraSpaceIndustries/USITools just recently ([bot commit](https://github.com/KSP-CKAN/CKAN-meta/commit/3c63a72469e88c8772c6dab1217be03a1806e5cc)).

Per se not a problem, GitHub thankfully redirects old repo names to the new ones. However in this case, a different repository has taken the place of https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries now (previously at https://github.com/BobPalmer/Constellation I suspect), so the automatic redirects no longer work, and downloads fail with a 404.

USITools versions since 0.7.1.0 are "restricted", so there are no archive.org fallbacks, versions below 0.7.4.0 are no longer available in the GitHub repo so they rely on the archive.org fallback (0.7.1.0, 0.7.2.0, 0.7.2.1 have been frozen in #1540, 0.7.3.0 doesn't exist).

This updates the old references to point to the current repository, of all releases since 0.7.4.0 (i.e. non-frozen restricted).

Fixes https://github.com/KSP-CKAN/NetKAN/issues/8585

```bash
for C in *.ckan; do
    jq --indent 4 'if ( .license == "restricted" and .download and (.download | contains("github.com/UmbraSpaceIndustries/UmbraSpaceIndustries") or contains("github.com/BobPalmer/UmbraSpaceIndustries"))) then (.download |= sub("github\\.com/(UmbraSpaceIndustries|BobPalmer)/UmbraSpaceIndustries"; "github.com/UmbraSpaceIndustries/USITools")) else . end' $C | sponge $C;
done

for C in *.ckan; do
    jq --indent 4 'if ( .license == "restricted" and .resources.repository and (.resources.repository | contains("github.com/UmbraSpaceIndustries/UmbraSpaceIndustries") or contains("github.com/BobPalmer/UmbraSpaceIndustries"))) then (.resources.repository |= sub("github\\.com/(UmbraSpaceIndustries|BobPalmer)/UmbraSpaceIndustries"; "github.com/UmbraSpaceIndustries/USITools")) else . end' $C | sponge $C;
done

for C in *.ckan; do
    jq --indent 4 'if ( .license == "restricted" and .resources.bugtracker and (.resources.bugtracker | contains("github.com/UmbraSpaceIndustries/UmbraSpaceIndustries") or contains("github.com/BobPalmer/UmbraSpaceIndustries"))) then (.resources.bugtracker |= sub("github\\.com/(UmbraSpaceIndustries|BobPalmer)/UmbraSpaceIndustries"; "github.com/UmbraSpaceIndustries/USITools")) else . end' $C | sponge $C;
done