### PR TITLE
Add InterstellarRedistributable dependency to KSPIE

### DIFF
--- a/KSPInterstellarExtended/KSPInterstellarExtended-1.28.12.ckan
+++ b/KSPInterstellarExtended/KSPInterstellarExtended-1.28.12.ckan
@@ -7,7 +7,7 @@
     "version": "1.28.12",
     "ksp_version_min": "1.8.1",
     "ksp_version_max": "1.12.0",
-    "license": "GPL-3.0",
+    "license": "unknown",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/172026-*",
         "spacedock": "https://spacedock.info/mod/172/KSP%20Interstellar%20Extended",
@@ -33,6 +33,9 @@
         "de-de"
     ],
     "depends": [
+        {
+            "name": "InterstellarRedistributable"
+        },
         {
             "name": "InterstellarFuelSwitch-Core"
         },


### PR DESCRIPTION
Backport of https://github.com/KSP-CKAN/NetKAN/pull/8610, release `1.28.12` was the first one that moved this DLL out of the mod folder to the root of GameData.

ckan compat add 1.12