### PR TITLE
Update compatibility of Parallax 1.2.3

### DIFF
--- a/Parallax/Parallax-1.2.3.ckan
+++ b/Parallax/Parallax-1.2.3.ckan
@@ -5,7 +5,8 @@
     "abstract": "A PBR tessellation shader for planetary textures",
     "author": "Linx",
     "version": "1.2.3",
-    "ksp_version": "1.11",
+    "ksp_version_min": "1.11",
+    "ksp_version_max": "1.12",
     "license": "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/197024-*",


### PR DESCRIPTION
See https://github.com/KSP-CKAN/NetKAN/pull/8631, the previous release of Parallax, 1.2.3, also works on KSP 1.12, maybe someone wants to stay on this one for the time being for whatever reason. And it's good to have the metadata accurate.