### PR TITLE
InterstellarRedistributable should be compatible with KSP 1.8.1+

### DIFF
--- a/InterstellarRedistributable/InterstellarRedistributable-1.4.ckan
+++ b/InterstellarRedistributable/InterstellarRedistributable-1.4.ckan
@@ -5,7 +5,7 @@
     "abstract": "Redistributable that is used by KSPIE Interstellar and Photon Sailor",
     "author": "FreeThinker",
     "version": "1.4",
-    "ksp_version": "1.8.1",
+    "ksp_version_min": "1.8.1",
     "license": "MIT",
     "resources": {
         "spacedock": "https://spacedock.info/mod/2800/Interstellar%20Redistributable%20",

--- a/InterstellarRedistributable/InterstellarRedistributable-1.4.ckan
+++ b/InterstellarRedistributable/InterstellarRedistributable-1.4.ckan
@@ -5,7 +5,7 @@
     "abstract": "Redistributable that is used by KSPIE Interstellar and Photon Sailor",
     "author": "FreeThinker",
     "version": "1.4",
-    "ksp_version": "1.12.1",
+    "ksp_version": "1.8.1",
     "license": "MIT",
     "resources": {
         "spacedock": "https://spacedock.info/mod/2800/Interstellar%20Redistributable%20",


### PR DESCRIPTION
People with KSP 1.8.1 should be able to install the latest version of KSPIE