### PR TITLE
Fix GPP mod suite compat and dependencies

### DIFF
--- a/GPP/GPP-1-1.6.4.0.ckan
+++ b/GPP/GPP-1-1.6.4.0.ckan
@@ -5,7 +5,7 @@
     "abstract": "Galileo's Planet Pack is an all new solar system. With high quality planets to explore, and more challeging gameplay than the stock game, GPP will give even the most accomplished KSPer hours of fun. GPP removes the stock planetary system and will corrupt stock system game saves.",
     "author": "Galileo88",
     "version": "1:1.6.4.0",
-    "ksp_version_min": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "ksp_version_max": "1.9.1",
     "license": "CC-BY-NC-ND",
     "resources": {
@@ -67,6 +67,9 @@
         },
         {
             "name": "SigmaReplacements-MenuScenes"
+        },
+        {
+            "name": "Grannus-RibbonPack"
         }
     ],
     "suggests": [
@@ -118,6 +121,9 @@
         {
             "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
             "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
             "comment": "This correctly installs Final Frontier for GPP"
         }
     ],

--- a/GPP/GPP-1-1.6.4.1.ckan
+++ b/GPP/GPP-1-1.6.4.1.ckan
@@ -5,7 +5,7 @@
     "abstract": "Galileo's Planet Pack is an all new solar system. With high quality planets to explore, and more challeging gameplay than the stock game, GPP will give even the most accomplished KSPer hours of fun. GPP removes the stock planetary system and will corrupt stock system game saves.",
     "author": "Galileo88",
     "version": "1:1.6.4.1",
-    "ksp_version": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "license": "CC-BY-NC-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/",
@@ -66,6 +66,9 @@
         },
         {
             "name": "SigmaReplacements-MenuScenes"
+        },
+        {
+            "name": "Grannus-RibbonPack"
         }
     ],
     "suggests": [
@@ -117,6 +120,9 @@
         {
             "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
             "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
             "comment": "This correctly installs Final Frontier for GPP"
         }
     ],

--- a/GPP/GPP-1-1.6.4.2.ckan
+++ b/GPP/GPP-1-1.6.4.2.ckan
@@ -5,7 +5,7 @@
     "abstract": "Galileo's Planet Pack is an all new solar system. With high quality planets to explore, and more challeging gameplay than the stock game, GPP will give even the most accomplished KSPer hours of fun. GPP removes the stock planetary system and will corrupt stock system game saves.",
     "author": "Galileo88",
     "version": "1:1.6.4.2",
-    "ksp_version": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "license": "CC-BY-NC-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/",
@@ -66,6 +66,9 @@
         },
         {
             "name": "SigmaReplacements-MenuScenes"
+        },
+        {
+            "name": "Grannus-RibbonPack"
         }
     ],
     "suggests": [
@@ -117,6 +120,9 @@
         {
             "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
             "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
             "comment": "This correctly installs Final Frontier for GPP"
         }
     ],

--- a/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.0.ckan
+++ b/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.0.ckan
@@ -8,7 +8,7 @@
         "OhioBob"
     ],
     "version": "1.6.4.0",
-    "ksp_version_min": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "ksp_version_max": "1.9.1",
     "license": "CC-BY-NC-ND",
     "resources": {
@@ -27,6 +27,12 @@
     "depends": [
         {
             "name": "EnvironmentalVisualEnhancements"
+        },
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "conflicts": [

--- a/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.1.ckan
+++ b/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.1.ckan
@@ -8,7 +8,7 @@
         "OhioBob"
     ],
     "version": "1.6.4.1",
-    "ksp_version": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "license": "CC-BY-NC-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/",
@@ -26,6 +26,12 @@
     "depends": [
         {
             "name": "EnvironmentalVisualEnhancements"
+        },
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "conflicts": [

--- a/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.2.ckan
+++ b/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.2.ckan
@@ -8,7 +8,7 @@
         "OhioBob"
     ],
     "version": "1.6.4.2",
-    "ksp_version": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "license": "CC-BY-NC-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/",
@@ -26,6 +26,12 @@
     "depends": [
         {
             "name": "EnvironmentalVisualEnhancements"
+        },
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "conflicts": [

--- a/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.0.ckan
+++ b/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.0.ckan
@@ -8,7 +8,7 @@
         "OhioBob"
     ],
     "version": "1.6.4.0",
-    "ksp_version_min": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "ksp_version_max": "1.9.1",
     "license": "CC-BY-NC-ND",
     "resources": {
@@ -27,6 +27,12 @@
     "depends": [
         {
             "name": "EnvironmentalVisualEnhancements"
+        },
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "conflicts": [

--- a/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.1.ckan
+++ b/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.1.ckan
@@ -8,7 +8,7 @@
         "OhioBob"
     ],
     "version": "1.6.4.1",
-    "ksp_version": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "license": "CC-BY-NC-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/",
@@ -26,6 +26,12 @@
     "depends": [
         {
             "name": "EnvironmentalVisualEnhancements"
+        },
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "conflicts": [

--- a/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.2.ckan
+++ b/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.2.ckan
@@ -8,7 +8,7 @@
         "OhioBob"
     ],
     "version": "1.6.4.2",
-    "ksp_version": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "license": "CC-BY-NC-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/",
@@ -26,6 +26,12 @@
     "depends": [
         {
             "name": "EnvironmentalVisualEnhancements"
+        },
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "conflicts": [

--- a/GPPSecondary/GPPSecondary-1.6.4.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.0.ckan
@@ -8,7 +8,7 @@
         "OhioBob"
     ],
     "version": "1.6.4.0",
-    "ksp_version_min": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "ksp_version_max": "1.9.1",
     "license": "CC-BY-NC-ND",
     "resources": {
@@ -23,7 +23,13 @@
     ],
     "depends": [
         {
+            "name": "GPP"
+        },
+        {
             "name": "Kopernicus"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.4.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.1.ckan
@@ -8,7 +8,7 @@
         "OhioBob"
     ],
     "version": "1.6.4.1",
-    "ksp_version": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "license": "CC-BY-NC-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/",
@@ -22,7 +22,13 @@
     ],
     "depends": [
         {
+            "name": "GPP"
+        },
+        {
             "name": "Kopernicus"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.4.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.2.ckan
@@ -8,7 +8,7 @@
         "OhioBob"
     ],
     "version": "1.6.4.2",
-    "ksp_version": "1.4.5",
+    "ksp_version_min": "1.8.1",
     "license": "CC-BY-NC-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/",
@@ -22,7 +22,13 @@
     ],
     "depends": [
         {
+            "name": "GPP"
+        },
+        {
             "name": "Kopernicus"
+        },
+        {
+            "name": "ModuleManager"
         }
     ],
     "install": [

--- a/GPPTextures/GPPTextures-3.0.0.ckan
+++ b/GPPTextures/GPPTextures-3.0.0.ckan
@@ -10,6 +10,11 @@
     },
     "version": "3.0.0",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "GPP"
+        }
+    ],
     "install": [
         {
             "find": "GPP",

--- a/GPPTextures/GPPTextures-4.0.0.ckan
+++ b/GPPTextures/GPPTextures-4.0.0.ckan
@@ -10,6 +10,11 @@
     },
     "version": "4.0.0",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "GPP"
+        }
+    ],
     "install": [
         {
             "find": "GPP",

--- a/GPPTextures/GPPTextures-4.1.0.ckan
+++ b/GPPTextures/GPPTextures-4.1.0.ckan
@@ -10,6 +10,11 @@
     },
     "version": "4.1.0",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "GPP"
+        }
+    ],
     "install": [
         {
             "find": "GPP",

--- a/GPPTextures/GPPTextures-4.1.1.ckan
+++ b/GPPTextures/GPPTextures-4.1.1.ckan
@@ -10,6 +10,11 @@
     },
     "version": "4.1.1",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "GPP"
+        }
+    ],
     "install": [
         {
             "find": "GPP",

--- a/GPPTextures/GPPTextures-4.2.0.ckan
+++ b/GPPTextures/GPPTextures-4.2.0.ckan
@@ -10,6 +10,11 @@
     },
     "version": "4.2.0",
     "ksp_version": "1.4.3",
+    "depends": [
+        {
+            "name": "GPP"
+        }
+    ],
     "install": [
         {
             "find": "GPP",


### PR DESCRIPTION
Historical backport of https://github.com/KSP-CKAN/NetKAN/pull/8644

Compatibility is taken from the version file, the embedded file matched the remote file at all times (https://github.com/Galileo88/Galileos-Planet-Pack/commits/master/GameData/GPP/Version/GalileosPlanetPack.version).

The Grannus-RibbonPack filter is also put on the right isntall stanza, another NetKAN PR will follow to correct it for the netkan file.