### PR TITLE
Purge rogue tag

### DIFF
--- a/Notes2Log/Notes2Log-0.0.1.ckan
+++ b/Notes2Log/Notes2Log-0.0.1.ckan
@@ -15,8 +15,7 @@
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/Notes2Log/Notes2Log-1608076541.778403.png"
     },
     "tags": [
-        "plugin",
-        "utility"
+        "plugin"
     ],
     "depends": [
         {

--- a/Notes2Log/Notes2Log-0.0.2.ckan
+++ b/Notes2Log/Notes2Log-0.0.2.ckan
@@ -15,8 +15,7 @@
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/Notes2Log/Notes2Log-1608076541.778403.png"
     },
     "tags": [
-        "plugin",
-        "utility"
+        "plugin"
     ],
     "depends": [
         {


### PR DESCRIPTION
`utility` slipped through without discussion in KSP-CKAN/NetKAN#8261, so it's currently the dreaded single-mod tag.
Already removed from the netkan in https://github.com/KSP-CKAN/NetKAN/commit/445257e4e225937d476a2b6dad10167c136c81a7