### PR TITLE
Update MiniSampleReturnCapsule-v1.3.ckan 🚀 👁️‍🗨️ 

### DIFF
--- a/MiniSampleReturnCapsule/MiniSampleReturnCapsule-v1.3.ckan
+++ b/MiniSampleReturnCapsule/MiniSampleReturnCapsule-v1.3.ckan
@@ -1,23 +1,24 @@
 {
     "spec_version": "v1.4",
     "identifier": "MiniSampleReturnCapsule",
-    "name": "Mini Sample Return Capsule",
-    "abstract": "2 part 0.625m autonomous return capsule to stuff your experiments in.",
+    "name": "Mini Sample Return Capsule (MSRC)",
+    "abstract": "Two part size zero (0.625m) autonomous return capsule to stuff your experiments in.",
     "author": [
         "CobaltWolf",
-        "AlbertKermin"
+        "AlbertKermin,"
+        "zer0Kerbal"
     ],
-    "license": "restricted",
+    "license": "SimpleBSD + CC BY-NC-SA 4.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/143414-113-mini-sample-return-capsule-bring-your-experiments-home-safe-v1-8jul2016/",
-        "spacedock": "https://spacedock.info/mod/831/Mini%20Sample%20Return%20Capsule",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/204186-*",
+        "spacedock": "https://spacedock.info/mod/831",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Mini_Sample_Return_Capsule/Mini_Sample_Return_Capsule-1468043148.5115068.png"
     },
-    "version": "v1.3",
-    "ksp_version": "1.2.2",
+    "version": "1.4.0.0",
+    "ksp_version": "1.12.1",
     "install": [
         {
-            "find": "SampleReturnCapsule",
+            "find": "MiniSampleReturnCapsule",
             "install_to": "GameData"
         }
     ],


### PR DESCRIPTION
SpaceDock updated - however depends/suggests/recommends/tags, _etc._ updated in readme.md
🐰 
Please and thank you!

any way can remove the v in previous version listings?