### PR TITLE
Update historical Scatterer compat

### DIFF
--- a/Scatterer-config/Scatterer-config-3-v0.0770.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0770.ckan
@@ -5,7 +5,8 @@
     "abstract": "The default configuration files for scatterer",
     "author": "blackrack",
     "version": "3:v0.0770",
-    "ksp_version": "1.11.2",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.11.2",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0770.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0770.ckan
@@ -5,7 +5,8 @@
     "abstract": "The sunflare component of scatterer",
     "author": "blackrack",
     "version": "3:v0.0770",
-    "ksp_version": "1.11.2",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.11.2",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer/Scatterer-3-v0.0770.ckan
+++ b/Scatterer/Scatterer-3-v0.0770.ckan
@@ -5,7 +5,8 @@
     "abstract": "Atmospheric scattering shaders",
     "author": "blackrack",
     "version": "3:v0.0770",
-    "ksp_version": "1.11.2",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.11.2",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {


### PR DESCRIPTION
Historical correlate of KSP-CKAN/NetKAN#8700, Scatterer's min compat still goes back to 1.9, now the previous version reflects this as well.