### PR TITLE
Update more historical Scatterer compat

### DIFF
--- a/Scatterer-config/Scatterer-config-3-v0.0600.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0600.ckan
@@ -5,7 +5,8 @@
     "abstract": "The default configuration files for scatterer",
     "author": "blackrack",
     "version": "3:v0.0600",
-    "ksp_version": "1.9.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.9.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-config/Scatterer-config-3-v0.0610.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0610.ckan
@@ -5,7 +5,8 @@
     "abstract": "The default configuration files for scatterer",
     "author": "blackrack",
     "version": "3:v0.0610",
-    "ksp_version": "1.9.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.9.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-config/Scatterer-config-3-v0.0621b.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0621b.ckan
@@ -5,7 +5,8 @@
     "abstract": "The default configuration files for scatterer",
     "author": "blackrack",
     "version": "3:v0.0621b",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-config/Scatterer-config-3-v0.0621c.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0621c.ckan
@@ -5,7 +5,8 @@
     "abstract": "The default configuration files for scatterer",
     "author": "blackrack",
     "version": "3:v0.0621c",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-config/Scatterer-config-3-v0.0630.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0630.ckan
@@ -5,7 +5,8 @@
     "abstract": "The default configuration files for scatterer",
     "author": "blackrack",
     "version": "3:v0.0630",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-config/Scatterer-config-3-v0.0632.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0632.ckan
@@ -5,7 +5,8 @@
     "abstract": "The default configuration files for scatterer",
     "author": "blackrack",
     "version": "3:v0.0632",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-config/Scatterer-config-3-v0.0722.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0722.ckan
@@ -5,7 +5,8 @@
     "abstract": "The default configuration files for scatterer",
     "author": "blackrack",
     "version": "3:v0.0722",
-    "ksp_version": "1.11.0",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.11.0",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0600.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0600.ckan
@@ -5,7 +5,8 @@
     "abstract": "The sunflare component of scatterer",
     "author": "blackrack",
     "version": "3:v0.0600",
-    "ksp_version": "1.9.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.9.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0610.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0610.ckan
@@ -5,7 +5,8 @@
     "abstract": "The sunflare component of scatterer",
     "author": "blackrack",
     "version": "3:v0.0610",
-    "ksp_version": "1.9.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.9.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0621b.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0621b.ckan
@@ -5,7 +5,8 @@
     "abstract": "The sunflare component of scatterer",
     "author": "blackrack",
     "version": "3:v0.0621b",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0621c.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0621c.ckan
@@ -5,7 +5,8 @@
     "abstract": "The sunflare component of scatterer",
     "author": "blackrack",
     "version": "3:v0.0621c",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0630.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0630.ckan
@@ -5,7 +5,8 @@
     "abstract": "The sunflare component of scatterer",
     "author": "blackrack",
     "version": "3:v0.0630",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0632.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0632.ckan
@@ -5,7 +5,8 @@
     "abstract": "The sunflare component of scatterer",
     "author": "blackrack",
     "version": "3:v0.0632",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0722.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0722.ckan
@@ -5,7 +5,8 @@
     "abstract": "The sunflare component of scatterer",
     "author": "blackrack",
     "version": "3:v0.0722",
-    "ksp_version": "1.11.0",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.11.0",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer/Scatterer-3-v0.0600.ckan
+++ b/Scatterer/Scatterer-3-v0.0600.ckan
@@ -5,7 +5,8 @@
     "abstract": "Atmospheric scattering shaders",
     "author": "blackrack",
     "version": "3:v0.0600",
-    "ksp_version": "1.9.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.9.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer/Scatterer-3-v0.0610.ckan
+++ b/Scatterer/Scatterer-3-v0.0610.ckan
@@ -5,7 +5,8 @@
     "abstract": "Atmospheric scattering shaders",
     "author": "blackrack",
     "version": "3:v0.0610",
-    "ksp_version": "1.9.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.9.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer/Scatterer-3-v0.0621b.ckan
+++ b/Scatterer/Scatterer-3-v0.0621b.ckan
@@ -5,7 +5,8 @@
     "abstract": "Atmospheric scattering shaders",
     "author": "blackrack",
     "version": "3:v0.0621b",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer/Scatterer-3-v0.0621c.ckan
+++ b/Scatterer/Scatterer-3-v0.0621c.ckan
@@ -5,7 +5,8 @@
     "abstract": "Atmospheric scattering shaders",
     "author": "blackrack",
     "version": "3:v0.0621c",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer/Scatterer-3-v0.0630.ckan
+++ b/Scatterer/Scatterer-3-v0.0630.ckan
@@ -5,7 +5,8 @@
     "abstract": "Atmospheric scattering shaders",
     "author": "blackrack",
     "version": "3:v0.0630",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer/Scatterer-3-v0.0632.ckan
+++ b/Scatterer/Scatterer-3-v0.0632.ckan
@@ -5,7 +5,8 @@
     "abstract": "Atmospheric scattering shaders",
     "author": "blackrack",
     "version": "3:v0.0632",
-    "ksp_version": "1.10.1",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.10.1",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {

--- a/Scatterer/Scatterer-3-v0.0722.ckan
+++ b/Scatterer/Scatterer-3-v0.0722.ckan
@@ -5,7 +5,8 @@
     "abstract": "Atmospheric scattering shaders",
     "author": "blackrack",
     "version": "3:v0.0722",
-    "ksp_version": "1.11.0",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.11.0",
     "license": "GPL-3.0",
     "release_status": "development",
     "resources": {


### PR DESCRIPTION
I should have looked at the new version/compat table in #2427, it's very unlikely that the true min compat version went forwards to 1.11.0 and then backwards to 1.9:

![image](https://user-images.githubusercontent.com/1559108/128620778-f3d6dd21-1347-4e1e-8184-2664905b5416.png)

Now all of the versions that have compatibility beyond 1.9, also have min compat of 1.9.