### PR TITLE
Provide unique identifier for the full KSPBurst module

### DIFF
--- a/KSPBurst/KSPBurst-v1.5.0.0.ckan
+++ b/KSPBurst/KSPBurst-v1.5.0.0.ckan
@@ -17,6 +17,9 @@
     "tags": [
         "library"
     ],
+    "provides": [
+        "KSPBurst-Full"
+    ],
     "install": [
         {
             "find": "000_KSPBurst",

--- a/KSPBurst/KSPBurst-v1.5.4.0.ckan
+++ b/KSPBurst/KSPBurst-v1.5.4.0.ckan
@@ -17,6 +17,9 @@
     "tags": [
         "library"
     ],
+    "provides": [
+        "KSPBurst-Full"
+    ],
     "install": [
         {
             "find": "000_KSPBurst",

--- a/KSPBurst/KSPBurst-v1.5.4.1.ckan
+++ b/KSPBurst/KSPBurst-v1.5.4.1.ckan
@@ -17,6 +17,9 @@
     "tags": [
         "library"
     ],
+    "provides": [
+        "KSPBurst-Full"
+    ],
     "install": [
         {
             "find": "000_KSPBurst",

--- a/KSPBurst/KSPBurst-v1.5.5.0.ckan
+++ b/KSPBurst/KSPBurst-v1.5.5.0.ckan
@@ -17,6 +17,9 @@
     "tags": [
         "library"
     ],
+    "provides": [
+        "KSPBurst-Full"
+    ],
     "install": [
         {
             "find": "000_KSPBurst",


### PR DESCRIPTION
Historical component of KSP-CKAN/NetKAN#8706, now `KSPBurst-Full` is provided by all versions of `KSPBurst`.