### PR TITLE
Make FMRSContinued provide and conflict with FMRS

### DIFF
--- a/FMRSContinued/FMRSContinued-1.2.1.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.1.ckan
@@ -14,9 +14,17 @@
     "version": "1.2.1",
     "ksp_version_min": "1.2.0",
     "ksp_version_max": "1.2.99",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.2.1.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.2.1.ckan
@@ -14,9 +14,17 @@
     "version": "1.2.2.1",
     "ksp_version_min": "1.2.2",
     "ksp_version_max": "1.2.98",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.2.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.2.ckan
@@ -14,9 +14,17 @@
     "version": "1.2.2",
     "ksp_version_min": "1.2.0",
     "ksp_version_max": "1.2.99",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.3.1.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.3.1.ckan
@@ -14,9 +14,17 @@
     "version": "1.2.3.1",
     "ksp_version_min": "1.2.2",
     "ksp_version_max": "1.2.98",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.3.8.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.3.8.ckan
@@ -14,12 +14,20 @@
     "version": "1.2.3.8",
     "ksp_version_min": "1.2.2",
     "ksp_version_max": "1.2.98",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
         },
         {
             "name": "RecoveryController"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.3.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.3.ckan
@@ -14,9 +14,17 @@
     "version": "1.2.3",
     "ksp_version_min": "1.2.2",
     "ksp_version_max": "1.2.98",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.4.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.4.ckan
@@ -14,12 +14,20 @@
     "version": "1.2.4",
     "ksp_version_min": "1.2.2",
     "ksp_version_max": "1.2.98",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
         },
         {
             "name": "RecoveryController"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.5.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.5.ckan
@@ -13,12 +13,20 @@
     },
     "version": "1.2.5",
     "ksp_version": "1.3.0",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
         },
         {
             "name": "RecoveryController"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.6.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.6.ckan
@@ -13,12 +13,20 @@
     },
     "version": "1.2.6",
     "ksp_version": "1.3.1",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
         },
         {
             "name": "RecoveryController"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.7.1.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.7.1.ckan
@@ -14,6 +14,9 @@
     "version": "1.2.7.1",
     "ksp_version_min": "1.4.1",
     "ksp_version_max": "1.4.99",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
@@ -26,6 +29,11 @@
         },
         {
             "name": "ClickThroughBlocker"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.7.2.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.7.2.ckan
@@ -14,6 +14,9 @@
     "version": "1.2.7.2",
     "ksp_version_min": "1.4.1",
     "ksp_version_max": "1.4.99",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
@@ -26,6 +29,11 @@
         },
         {
             "name": "ClickThroughBlocker"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.7.3.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.7.3.ckan
@@ -14,6 +14,9 @@
     "version": "1.2.7.3",
     "ksp_version_min": "1.5.1",
     "ksp_version_max": "1.5.99",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
@@ -26,6 +29,11 @@
         },
         {
             "name": "ClickThroughBlocker"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.7.4.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.7.4.ckan
@@ -14,6 +14,9 @@
     "version": "1.2.7.4",
     "ksp_version_min": "1.5.1",
     "ksp_version_max": "1.6.0",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
@@ -26,6 +29,11 @@
         },
         {
             "name": "ClickThroughBlocker"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.8.1.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.8.1.ckan
@@ -14,6 +14,9 @@
     "version": "1.2.8.1",
     "ksp_version_min": "1.5.1",
     "ksp_version_max": "1.7.3",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
@@ -26,6 +29,11 @@
         },
         {
             "name": "ClickThroughBlocker"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.8.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.8.ckan
@@ -14,6 +14,9 @@
     "version": "1.2.8",
     "ksp_version_min": "1.5.1",
     "ksp_version_max": "1.7.2",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
@@ -26,6 +29,11 @@
         },
         {
             "name": "ClickThroughBlocker"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.9.1.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.9.1.ckan
@@ -19,6 +19,9 @@
     "tags": [
         "plugin"
     ],
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
@@ -31,6 +34,11 @@
         },
         {
             "name": "ClickThroughBlocker"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [

--- a/FMRSContinued/FMRSContinued-1.2.9.ckan
+++ b/FMRSContinued/FMRSContinued-1.2.9.ckan
@@ -14,6 +14,9 @@
     "version": "1.2.9",
     "ksp_version_min": "1.8.0",
     "ksp_version_max": "1.8.1",
+    "provides": [
+        "FMRS"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
@@ -26,6 +29,11 @@
         },
         {
             "name": "ClickThroughBlocker"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "FMRS"
         }
     ],
     "install": [


### PR DESCRIPTION
Historical component of https://github.com/KSP-CKAN/NetKAN/commit/20ea93204faa1e9c01a272a54048832c1c241ed5, which I accidentally misclicked into a master commit instead of a PR.

Long and elaborate relationship trees with very permissive compatibility settings can pull in both FMRS and FMRSContinued, resulting in a file overwriting error:

```
Error: 383414 [1] ERROR CKAN.CmdLine.ConsoleUser (null) - Oh no! We tried to overwrite a file owned by another mod!
  Please try a `ckan update` and try again.
  
  If this problem re-occurs, then it maybe a packaging bug.
  Please report it at:
  
  https://github.com/KSP-CKAN/NetKAN/issues/new
  
  Please including the following information in your report:
  
  File           : GameData/FMRS/FMRS_MM.cfg
  Installing Mod : FMRS v1.1.0.1
  Owning Mod     : FMRSContinued
  CKAN Version   : v1.30.5
```

Now they explicitly conflict and FMRSContinued provides FMRS, which will prevent them from both being pulled in as recommendations, at least, as well as allowing old relationships for FMRS to be satisfied by FMRSContinued.

Found while working on KSP-CKAN/NetKAN#8701.