### PR TITLE
Revert Scatterer-sunflare and Scatterer-config dependency on Scatterer

### DIFF
--- a/Scatterer-config/Scatterer-config-3-v0.0723.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0723.ckan
@@ -19,11 +19,6 @@
         "graphics",
         "config"
     ],
-    "depends": [
-        {
-            "name": "Scatterer"
-        }
-    ],
     "conflicts": [
         {
             "name": "Scatterer-config"

--- a/Scatterer-config/Scatterer-config-3-v0.0770.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0770.ckan
@@ -20,11 +20,6 @@
         "graphics",
         "config"
     ],
-    "depends": [
-        {
-            "name": "Scatterer"
-        }
-    ],
     "conflicts": [
         {
             "name": "Scatterer-config"

--- a/Scatterer-config/Scatterer-config-3-v0.0772.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0772.ckan
@@ -20,11 +20,6 @@
         "graphics",
         "config"
     ],
-    "depends": [
-        {
-            "name": "Scatterer"
-        }
-    ],
     "conflicts": [
         {
             "name": "Scatterer-config"

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0723.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0723.ckan
@@ -22,11 +22,6 @@
     "provides": [
         "Scatterer-sunflare-default"
     ],
-    "depends": [
-        {
-            "name": "Scatterer"
-        }
-    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0770.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0770.ckan
@@ -23,11 +23,6 @@
     "provides": [
         "Scatterer-sunflare-default"
     ],
-    "depends": [
-        {
-            "name": "Scatterer"
-        }
-    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0772.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0772.ckan
@@ -23,11 +23,6 @@
     "provides": [
         "Scatterer-sunflare-default"
     ],
-    "depends": [
-        {
-            "name": "Scatterer"
-        }
-    ],
     "conflicts": [
         {
             "name": "Scatterer-sunflare"


### PR DESCRIPTION
Backport of https://github.com/KSP-CKAN/NetKAN/pull/8722 to Scatterer-sunflare and Scatterer-config releases v0.0723, v0.0770 and v0.0772.