### PR TITLE
Remove MagiCore depends from historical ScrapYard

### DIFF
--- a/ScrapYard/ScrapYard-2.1.1.0.ckan
+++ b/ScrapYard/ScrapYard-2.1.1.0.ckan
@@ -26,9 +26,6 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "MagiCore"
         }
     ],
     "download": "https://spacedock.info/mod/1746/ScrapYard/download/2.1.1.0",


### PR DESCRIPTION
See comments in KSP-CKAN/NetKAN#8764, the MagiCore depends was removed in the release before current. Now the metdata will reflect this.