### PR TITLE
Historical SerialIO min compat

### DIFF
--- a/SerialIO/SerialIO-v0.19.2.ckan
+++ b/SerialIO/SerialIO-v0.19.2.ckan
@@ -5,7 +5,8 @@
     "abstract": "This plugin sends/receives data packets over the serial port, which should make it much easier for people wanting to build hardware for KSP",
     "author": "zitron",
     "version": "v0.19.2",
-    "ksp_version": "1.12.2",
+    "ksp_version_min": "1.9",
+    "ksp_version_max": "1.12",
     "license": "CC-BY",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/60281-hardware-plugin-arduino-based-physical-display-serial-port-io-tutorial-12-oct/",


### PR DESCRIPTION
This mod had two changes in rapid succession, a change to the compatibility and then a new release. If not for the new release, we would have had to use `x_netkan_override` to pin the minimum compatibility, but now we can just update the .ckan file directly based on its original compatibility.