### PR TITLE
Install GPPSecondary without GPP

### DIFF
--- a/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.0.ckan
+++ b/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPCloudsHighRes",
     "name": "GPP HighRes clouds",
     "abstract": "High resolution clouds for GPP",
@@ -29,7 +29,14 @@
             "name": "EnvironmentalVisualEnhancements"
         },
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         },
         {
             "name": "ModuleManager"

--- a/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.1.ckan
+++ b/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPCloudsHighRes",
     "name": "GPP HighRes clouds",
     "abstract": "High resolution clouds for GPP",
@@ -28,7 +28,14 @@
             "name": "EnvironmentalVisualEnhancements"
         },
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         },
         {
             "name": "ModuleManager"

--- a/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.2.ckan
+++ b/GPPCloudsHighRes/GPPCloudsHighRes-1.6.4.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPCloudsHighRes",
     "name": "GPP HighRes clouds",
     "abstract": "High resolution clouds for GPP",
@@ -28,7 +28,14 @@
             "name": "EnvironmentalVisualEnhancements"
         },
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         },
         {
             "name": "ModuleManager"

--- a/GPPCloudsHighRes/GPPCloudsHighRes-1.6.5.0.ckan
+++ b/GPPCloudsHighRes/GPPCloudsHighRes-1.6.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPCloudsHighRes",
     "name": "GPP HighRes clouds",
     "abstract": "High resolution clouds for GPP",
@@ -28,7 +28,14 @@
             "name": "EnvironmentalVisualEnhancements"
         },
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         },
         {
             "name": "ModuleManager"

--- a/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.0.ckan
+++ b/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPCloudsLowRes",
     "name": "GPP LowRes clouds",
     "abstract": "Low resolution clouds for GPP",
@@ -29,7 +29,14 @@
             "name": "EnvironmentalVisualEnhancements"
         },
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         },
         {
             "name": "ModuleManager"

--- a/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.1.ckan
+++ b/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPCloudsLowRes",
     "name": "GPP LowRes clouds",
     "abstract": "Low resolution clouds for GPP",
@@ -28,7 +28,14 @@
             "name": "EnvironmentalVisualEnhancements"
         },
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         },
         {
             "name": "ModuleManager"

--- a/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.2.ckan
+++ b/GPPCloudsLowRes/GPPCloudsLowRes-1.6.4.2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPCloudsLowRes",
     "name": "GPP LowRes clouds",
     "abstract": "Low resolution clouds for GPP",
@@ -28,7 +28,14 @@
             "name": "EnvironmentalVisualEnhancements"
         },
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         },
         {
             "name": "ModuleManager"

--- a/GPPCloudsLowRes/GPPCloudsLowRes-1.6.5.0.ckan
+++ b/GPPCloudsLowRes/GPPCloudsLowRes-1.6.5.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPCloudsLowRes",
     "name": "GPP LowRes clouds",
     "abstract": "Low resolution clouds for GPP",
@@ -28,7 +28,14 @@
             "name": "EnvironmentalVisualEnhancements"
         },
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         },
         {
             "name": "ModuleManager"

--- a/GPPSecondary/GPPSecondary-1.5.88.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.88.ckan
@@ -11,7 +11,52 @@
     },
     "version": "1.5.88",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.5.99.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.99.ckan
@@ -11,7 +11,52 @@
     },
     "version": "1.5.99",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.0.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.0.1.ckan
@@ -11,7 +11,52 @@
     },
     "version": "1.6.0.1",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.0.ckan
@@ -11,7 +11,52 @@
     },
     "version": "1.6.0",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.1.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.1.1.ckan
@@ -11,7 +11,52 @@
     },
     "version": "1.6.1.1",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.1.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.1.2.ckan
@@ -11,7 +11,52 @@
     },
     "version": "1.6.1.2",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.2.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.2.0.ckan
@@ -11,7 +11,52 @@
     },
     "version": "1.6.2.0",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.2.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.2.1.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "GPPSecondary",
     "name": "GPP Secondary",
-    "abstract": "GPP secondary puts Galileo's Planet Pack around the stock solar system.",
+    "abstract": "Puts Galileo's Planet Pack around the stock solar system.",
     "author": "Galileo88",
     "license": "CC-BY-NC-ND",
     "resources": {
@@ -11,7 +11,52 @@
     },
     "version": "1.6.2.1",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.2.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.2.2.ckan
@@ -11,7 +11,52 @@
     },
     "version": "1.6.2.2",
     "ksp_version": "1.3.1",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.3.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.3.0.ckan
@@ -12,7 +12,52 @@
     "version": "1.6.3.0",
     "ksp_version_min": "1.3.1",
     "ksp_version_max": "1.4.4",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.3.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.3.1.ckan
@@ -18,7 +18,52 @@
         "config",
         "planet-pack"
     ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.4.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.0.ckan
@@ -23,16 +23,50 @@
     ],
     "depends": [
         {
-            "name": "GPP"
+            "name": "ModuleManager"
         },
         {
             "name": "Kopernicus"
         },
         {
-            "name": "ModuleManager"
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
         }
     ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.4.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.1.ckan
@@ -22,16 +22,50 @@
     ],
     "depends": [
         {
-            "name": "GPP"
+            "name": "ModuleManager"
         },
         {
             "name": "Kopernicus"
         },
         {
-            "name": "ModuleManager"
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
         }
     ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.4.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.2.ckan
@@ -22,16 +22,50 @@
     ],
     "depends": [
         {
-            "name": "GPP"
+            "name": "ModuleManager"
         },
         {
             "name": "Kopernicus"
         },
         {
-            "name": "ModuleManager"
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
         }
     ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPSecondary/GPPSecondary-1.6.5.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.5.0.ckan
@@ -22,16 +22,50 @@
     ],
     "depends": [
         {
-            "name": "GPP"
+            "name": "ModuleManager"
         },
         {
             "name": "Kopernicus"
         },
         {
-            "name": "ModuleManager"
+            "name": "GPPTextures"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "FinalFrontier"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "JNSQ"
+        },
+        {
+            "name": "GrannusExpansionPack-Primary"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "GPP"
+        },
+        {
+            "name": "StockVisualEnhancements"
         }
     ],
     "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "filter": [
+                "Grannus"
+            ],
+            "comment": "This correctly installs Final Frontier for GPP"
+        },
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
             "install_to": "GameData",

--- a/GPPTextures/GPPTextures-3.0.0.ckan
+++ b/GPPTextures/GPPTextures-3.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPTextures",
     "name": "GPP Textures",
     "abstract": "Textures for Galileo's Planet Pack.",
@@ -12,7 +12,14 @@
     "ksp_version": "1.3.1",
     "depends": [
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         }
     ],
     "install": [

--- a/GPPTextures/GPPTextures-4.0.0.ckan
+++ b/GPPTextures/GPPTextures-4.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPTextures",
     "name": "GPP Textures",
     "abstract": "Textures for Galileo's Planet Pack.",
@@ -12,7 +12,14 @@
     "ksp_version": "1.3.1",
     "depends": [
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         }
     ],
     "install": [

--- a/GPPTextures/GPPTextures-4.1.0.ckan
+++ b/GPPTextures/GPPTextures-4.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPTextures",
     "name": "GPP Textures",
     "abstract": "Textures for Galileo's Planet Pack.",
@@ -12,7 +12,14 @@
     "ksp_version": "1.3.1",
     "depends": [
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         }
     ],
     "install": [

--- a/GPPTextures/GPPTextures-4.1.1.ckan
+++ b/GPPTextures/GPPTextures-4.1.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPTextures",
     "name": "GPP Textures",
     "abstract": "Textures for Galileo's Planet Pack.",
@@ -12,7 +12,14 @@
     "ksp_version": "1.3.1",
     "depends": [
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         }
     ],
     "install": [

--- a/GPPTextures/GPPTextures-4.2.0.ckan
+++ b/GPPTextures/GPPTextures-4.2.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "GPPTextures",
     "name": "GPP Textures",
     "abstract": "Textures for Galileo's Planet Pack.",
@@ -12,7 +12,14 @@
     "ksp_version": "1.4.3",
     "depends": [
         {
-            "name": "GPP"
+            "any_of": [
+                {
+                    "name": "GPP"
+                },
+                {
+                    "name": "GPPSecondary"
+                }
+            ]
         }
     ],
     "install": [


### PR DESCRIPTION
Historical counterpart of KSP-CKAN/NetKAN#8804.
Now old versions of GPPSecondary can be installed alongside old versions of mods that conflict with GPP, in case anyone wants to run a retro game instance.