### PR TITLE
Conflicts between MinorPlanetsExpansionRevived and MinorPlanetsExpansion

### DIFF
--- a/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.1.ckan
+++ b/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.1.ckan
@@ -29,6 +29,11 @@
             "name": "OuterPlanetsMod"
         }
     ],
+    "conflicts": [
+        {
+            "name": "MinorPlanetsExpansion"
+        }
+    ],
     "install": [
         {
             "find": "MPE",

--- a/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.2.ckan
+++ b/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.2.ckan
@@ -29,6 +29,11 @@
             "name": "OuterPlanetsMod"
         }
     ],
+    "conflicts": [
+        {
+            "name": "MinorPlanetsExpansion"
+        }
+    ],
     "install": [
         {
             "find": "MPE",

--- a/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.3.ckan
+++ b/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.3.ckan
@@ -29,6 +29,11 @@
             "name": "OuterPlanetsMod"
         }
     ],
+    "conflicts": [
+        {
+            "name": "MinorPlanetsExpansion"
+        }
+    ],
     "install": [
         {
             "find": "MPE",

--- a/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.4.ckan
+++ b/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.4.ckan
@@ -29,6 +29,11 @@
             "name": "OuterPlanetsMod"
         }
     ],
+    "conflicts": [
+        {
+            "name": "MinorPlanetsExpansion"
+        }
+    ],
     "install": [
         {
             "find": "MPE",

--- a/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.5.ckan
+++ b/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.5.ckan
@@ -29,6 +29,11 @@
             "name": "OuterPlanetsMod"
         }
     ],
+    "conflicts": [
+        {
+            "name": "MinorPlanetsExpansion"
+        }
+    ],
     "install": [
         {
             "find": "MPE",

--- a/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.6.ckan
+++ b/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.1.6.ckan
@@ -29,6 +29,11 @@
             "name": "OuterPlanetsMod"
         }
     ],
+    "conflicts": [
+        {
+            "name": "MinorPlanetsExpansion"
+        }
+    ],
     "install": [
         {
             "find": "MPE",

--- a/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.2.0.ckan
+++ b/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.2.0.ckan
@@ -29,6 +29,11 @@
             "name": "OuterPlanetsMod"
         }
     ],
+    "conflicts": [
+        {
+            "name": "MinorPlanetsExpansion"
+        }
+    ],
     "install": [
         {
             "find": "MPE",

--- a/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.2.1.ckan
+++ b/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.2.1.ckan
@@ -29,6 +29,11 @@
             "name": "OuterPlanetsMod"
         }
     ],
+    "conflicts": [
+        {
+            "name": "MinorPlanetsExpansion"
+        }
+    ],
     "install": [
         {
             "find": "MPE",

--- a/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.2.2.ckan
+++ b/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.2.2.ckan
@@ -29,6 +29,11 @@
             "name": "OuterPlanetsMod"
         }
     ],
+    "conflicts": [
+        {
+            "name": "MinorPlanetsExpansion"
+        }
+    ],
     "install": [
         {
             "find": "MPE",

--- a/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.3.0.ckan
+++ b/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.3.0.ckan
@@ -29,6 +29,11 @@
             "name": "OuterPlanetsMod"
         }
     ],
+    "conflicts": [
+        {
+            "name": "MinorPlanetsExpansion"
+        }
+    ],
     "install": [
         {
             "find": "MPE",

--- a/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.3.1.ckan
+++ b/MinorPlanetsExpansionRevived/MinorPlanetsExpansionRevived-1.3.1.ckan
@@ -29,6 +29,11 @@
             "name": "OuterPlanetsMod"
         }
     ],
+    "conflicts": [
+        {
+            "name": "MinorPlanetsExpansion"
+        }
+    ],
     "install": [
         {
             "find": "MPE",


### PR DESCRIPTION
Historical component of KSP-CKAN/NetKAN#8860.
Now all versions of MPER conflict with MPE, so the relationship resolver won't try to install old releases to get around the conflict.

___

ckan compat add 1.11