### PR TITLE
Fix install_to capitalization of Scatterer config and sunflare

### DIFF
--- a/Scatterer-config/Scatterer-config-3-v0.0824.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0824.ckan
@@ -27,8 +27,8 @@
     ],
     "install": [
         {
-            "find": "scatterer/config",
-            "install_to": "GameData/scatterer",
+            "find": "Scatterer/config",
+            "install_to": "GameData/Scatterer",
             "filter": "Sunflares"
         }
     ],

--- a/Scatterer-config/Scatterer-config-3-v0.0825.ckan
+++ b/Scatterer-config/Scatterer-config-3-v0.0825.ckan
@@ -27,8 +27,8 @@
     ],
     "install": [
         {
-            "find": "scatterer/config",
-            "install_to": "GameData/scatterer",
+            "find": "Scatterer/config",
+            "install_to": "GameData/Scatterer",
             "filter": "Sunflares"
         }
     ],

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0824.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0824.ckan
@@ -31,7 +31,7 @@
     "install": [
         {
             "find": "Sunflares",
-            "install_to": "GameData/scatterer/config"
+            "install_to": "GameData/Scatterer/config"
         }
     ],
     "download": "https://spacedock.info/mod/141/scatterer/download/0.0824",

--- a/Scatterer-sunflare/Scatterer-sunflare-3-v0.0825.ckan
+++ b/Scatterer-sunflare/Scatterer-sunflare-3-v0.0825.ckan
@@ -31,7 +31,7 @@
     "install": [
         {
             "find": "Sunflares",
-            "install_to": "GameData/scatterer/config"
+            "install_to": "GameData/Scatterer/config"
         }
     ],
     "download": "https://spacedock.info/mod/141/scatterer/download/0.0825",

--- a/Scatterer/Scatterer-3-v0.0824.ckan
+++ b/Scatterer/Scatterer-3-v0.0824.ckan
@@ -34,7 +34,7 @@
     ],
     "install": [
         {
-            "find": "scatterer",
+            "find": "Scatterer",
             "install_to": "GameData",
             "filter_regexp": "config\\/.*"
         }

--- a/Scatterer/Scatterer-3-v0.0825.ckan
+++ b/Scatterer/Scatterer-3-v0.0825.ckan
@@ -34,7 +34,7 @@
     ],
     "install": [
         {
-            "find": "scatterer",
+            "find": "Scatterer",
             "install_to": "GameData",
             "filter_regexp": "config\\/.*"
         }


### PR DESCRIPTION
Backport of https://github.com/KSP-CKAN/NetKAN/pull/8862 to releases `v0.0825` and `v0.0824`, which have been deleted from SpaceDock but are still downloadable from our archive.org fallback.

I've confirmed that both versions already had the capitalized directory name.