### PR TITLE
Try to enforce Scatterer compatibility for GPP and GEP

### DIFF
--- a/GPP/GPP-1-1.6.1.1.ckan
+++ b/GPP/GPP-1-1.6.1.1.ckan
@@ -92,6 +92,12 @@
             "name": "Rescale-10625"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "find": "GPP",

--- a/GPP/GPP-1-1.6.1.1.ckan
+++ b/GPP/GPP-1-1.6.1.1.ckan
@@ -95,7 +95,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.1.2.ckan
+++ b/GPP/GPP-1-1.6.1.2.ckan
@@ -92,6 +92,12 @@
             "name": "Rescale-10625"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "find": "GPP",

--- a/GPP/GPP-1-1.6.1.2.ckan
+++ b/GPP/GPP-1-1.6.1.2.ckan
@@ -95,7 +95,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.2.1.ckan
+++ b/GPP/GPP-1-1.6.2.1.ckan
@@ -95,7 +95,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.2.1.ckan
+++ b/GPP/GPP-1-1.6.2.1.ckan
@@ -92,6 +92,10 @@
     "conflicts": [
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.2.2.ckan
+++ b/GPP/GPP-1-1.6.2.2.ckan
@@ -95,7 +95,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.2.2.ckan
+++ b/GPP/GPP-1-1.6.2.2.ckan
@@ -92,6 +92,10 @@
     "conflicts": [
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.3.0.ckan
+++ b/GPP/GPP-1-1.6.3.0.ckan
@@ -93,6 +93,10 @@
     "conflicts": [
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.3.0.ckan
+++ b/GPP/GPP-1-1.6.3.0.ckan
@@ -96,7 +96,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.3.1.ckan
+++ b/GPP/GPP-1-1.6.3.1.ckan
@@ -110,7 +110,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.3.1.ckan
+++ b/GPP/GPP-1-1.6.3.1.ckan
@@ -107,6 +107,10 @@
     "conflicts": [
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.4.0.ckan
+++ b/GPP/GPP-1-1.6.4.0.ckan
@@ -110,6 +110,10 @@
     "conflicts": [
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.4.0.ckan
+++ b/GPP/GPP-1-1.6.4.0.ckan
@@ -113,7 +113,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.4.1.ckan
+++ b/GPP/GPP-1-1.6.4.1.ckan
@@ -112,7 +112,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.4.1.ckan
+++ b/GPP/GPP-1-1.6.4.1.ckan
@@ -109,6 +109,10 @@
     "conflicts": [
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.4.2.ckan
+++ b/GPP/GPP-1-1.6.4.2.ckan
@@ -112,7 +112,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.4.2.ckan
+++ b/GPP/GPP-1-1.6.4.2.ckan
@@ -109,6 +109,10 @@
     "conflicts": [
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.5.0.ckan
+++ b/GPP/GPP-1-1.6.5.0.ckan
@@ -112,7 +112,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.5.0.ckan
+++ b/GPP/GPP-1-1.6.5.0.ckan
@@ -109,6 +109,10 @@
     "conflicts": [
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.6.0.ckan
+++ b/GPP/GPP-1-1.6.6.0.ckan
@@ -110,6 +110,10 @@
     "conflicts": [
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.6.0.ckan
+++ b/GPP/GPP-1-1.6.6.0.ckan
@@ -113,7 +113,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.7.0.ckan
+++ b/GPP/GPP-1-1.6.7.0.ckan
@@ -110,6 +110,10 @@
     "conflicts": [
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1-1.6.7.0.ckan
+++ b/GPP/GPP-1-1.6.7.0.ckan
@@ -113,7 +113,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1.5.1.ckan
+++ b/GPP/GPP-1.5.1.ckan
@@ -61,7 +61,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1.5.1.ckan
+++ b/GPP/GPP-1.5.1.ckan
@@ -58,6 +58,10 @@
     "conflicts": [
         {
             "name": "LoadingScreenManager"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1.5.2.ckan
+++ b/GPP/GPP-1.5.2.ckan
@@ -61,7 +61,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1.5.2.ckan
+++ b/GPP/GPP-1.5.2.ckan
@@ -58,6 +58,10 @@
     "conflicts": [
         {
             "name": "LoadingScreenManager"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1.5.3.ckan
+++ b/GPP/GPP-1.5.3.ckan
@@ -76,6 +76,10 @@
     "conflicts": [
         {
             "name": "LoadingScreenManager"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1.5.3.ckan
+++ b/GPP/GPP-1.5.3.ckan
@@ -79,7 +79,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1.5.88.ckan
+++ b/GPP/GPP-1.5.88.ckan
@@ -92,7 +92,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1.5.88.ckan
+++ b/GPP/GPP-1.5.88.ckan
@@ -89,6 +89,12 @@
             "name": "Rescale-10625"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "find": "GPP",

--- a/GPP/GPP-1.5.99.ckan
+++ b/GPP/GPP-1.5.99.ckan
@@ -92,6 +92,12 @@
             "name": "Rescale-10625"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "find": "GPP",

--- a/GPP/GPP-1.5.99.ckan
+++ b/GPP/GPP-1.5.99.ckan
@@ -95,7 +95,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1.6.0.1.ckan
+++ b/GPP/GPP-1.6.0.1.ckan
@@ -92,6 +92,12 @@
             "name": "Rescale-10625"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "find": "GPP",

--- a/GPP/GPP-1.6.0.1.ckan
+++ b/GPP/GPP-1.6.0.1.ckan
@@ -95,7 +95,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1.6.0.ckan
+++ b/GPP/GPP-1.6.0.ckan
@@ -92,6 +92,12 @@
             "name": "Rescale-10625"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "find": "GPP",

--- a/GPP/GPP-1.6.0.ckan
+++ b/GPP/GPP-1.6.0.ckan
@@ -95,7 +95,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPP/GPP-1.6.1.0.ckan
+++ b/GPP/GPP-1.6.1.0.ckan
@@ -92,6 +92,12 @@
             "name": "Rescale-10625"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "find": "GPP",

--- a/GPP/GPP-1.6.1.0.ckan
+++ b/GPP/GPP-1.6.1.0.ckan
@@ -95,7 +95,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPCloudsHighRes/GPPCloudsHighRes-1.5.2.ckan
+++ b/GPPCloudsHighRes/GPPCloudsHighRes-1.5.2.ckan
@@ -32,10 +32,10 @@
         }
     ],
     "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.5.2/Galileos.Planet.Pack.1.5.2.zip",
-    "download_size": 254573508,
+    "download_size": 254555780,
     "download_hash": {
-        "sha1": "C79BC6EEFA5BD4418E6D5C121E71BB42201EE7AC",
-        "sha256": "C08DAC7C5882C27D5E590A442CBDC58FB5966FAE7F00B6EC78EFAF96B12476CA"
+        "sha1": "497A4CCBEC4CC1A640F3EAD09299CC7DE907199B",
+        "sha256": "CAB15ADC84CB06C23D594D7A32557396251C5E0A69C113229C0F7E20EF571B35"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/GPPCloudsLowRes/GPPCloudsLowRes-1.5.2.ckan
+++ b/GPPCloudsLowRes/GPPCloudsLowRes-1.5.2.ckan
@@ -32,10 +32,10 @@
         }
     ],
     "download": "https://github.com/Galileo88/Galileos-Planet-Pack/releases/download/1.5.2/Galileos.Planet.Pack.1.5.2.zip",
-    "download_size": 254573508,
+    "download_size": 254555780,
     "download_hash": {
-        "sha1": "C79BC6EEFA5BD4418E6D5C121E71BB42201EE7AC",
-        "sha256": "C08DAC7C5882C27D5E590A442CBDC58FB5966FAE7F00B6EC78EFAF96B12476CA"
+        "sha1": "497A4CCBEC4CC1A640F3EAD09299CC7DE907199B",
+        "sha256": "CAB15ADC84CB06C23D594D7A32557396251C5E0A69C113229C0F7E20EF571B35"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/GPPSecondary/GPPSecondary-1.5.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.1.ckan
@@ -11,6 +11,12 @@
     },
     "version": "1.5.1",
     "ksp_version": "1.3.0",
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",

--- a/GPPSecondary/GPPSecondary-1.5.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.1.ckan
@@ -14,7 +14,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.5.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.2.ckan
@@ -14,7 +14,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.5.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.2.ckan
@@ -11,6 +11,12 @@
     },
     "version": "1.5.2",
     "ksp_version": "1.3.0",
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",

--- a/GPPSecondary/GPPSecondary-1.5.3.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.3.ckan
@@ -11,6 +11,12 @@
     },
     "version": "1.5.3",
     "ksp_version": "1.3.1",
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",

--- a/GPPSecondary/GPPSecondary-1.5.3.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.3.ckan
@@ -14,7 +14,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.5.88.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.88.ckan
@@ -44,7 +44,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.5.88.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.88.ckan
@@ -41,6 +41,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.5.99.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.99.ckan
@@ -44,7 +44,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.5.99.ckan
+++ b/GPPSecondary/GPPSecondary-1.5.99.ckan
@@ -41,6 +41,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.0.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.0.1.ckan
@@ -44,7 +44,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.0.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.0.1.ckan
@@ -41,6 +41,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.0.ckan
@@ -44,7 +44,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.0.ckan
@@ -41,6 +41,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.1.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.1.1.ckan
@@ -44,7 +44,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.1.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.1.1.ckan
@@ -41,6 +41,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.1.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.1.2.ckan
@@ -44,7 +44,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.1.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.1.2.ckan
@@ -41,6 +41,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.2.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.2.0.ckan
@@ -44,7 +44,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.2.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.2.0.ckan
@@ -41,6 +41,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.2.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.2.1.ckan
@@ -44,7 +44,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.2.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.2.1.ckan
@@ -41,6 +41,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.2.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.2.2.ckan
@@ -44,7 +44,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.2.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.2.2.ckan
@@ -41,6 +41,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.3.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.3.0.ckan
@@ -45,7 +45,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.3.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.3.0.ckan
@@ -42,6 +42,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.3.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.3.1.ckan
@@ -51,7 +51,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.3.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.3.1.ckan
@@ -48,6 +48,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.4.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.0.ckan
@@ -51,6 +51,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.4.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.0.ckan
@@ -54,7 +54,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.4.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.1.ckan
@@ -50,6 +50,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.4.1.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.1.ckan
@@ -53,7 +53,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.4.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.2.ckan
@@ -50,6 +50,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.4.2.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.4.2.ckan
@@ -53,7 +53,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.5.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.5.0.ckan
@@ -50,6 +50,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.5.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.5.0.ckan
@@ -53,7 +53,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.6.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.6.0.ckan
@@ -59,6 +59,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.6.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.6.0.ckan
@@ -62,7 +62,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.7.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.7.0.ckan
@@ -59,6 +59,10 @@
         },
         {
             "name": "StockVisualEnhancements"
+        },
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GPPSecondary/GPPSecondary-1.6.7.0.ckan
+++ b/GPPSecondary/GPPSecondary-1.6.7.0.ckan
@@ -62,7 +62,7 @@
         },
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.1.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.1.ckan
@@ -68,7 +68,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.1.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.1.ckan
@@ -65,6 +65,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.2.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.2.ckan
@@ -68,7 +68,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.2.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.2.ckan
@@ -65,6 +65,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.3.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.3.ckan
@@ -68,7 +68,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.3.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.3.ckan
@@ -65,6 +65,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.4.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.4.ckan
@@ -68,7 +68,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.4.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.4.ckan
@@ -65,6 +65,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.5.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.5.ckan
@@ -69,7 +69,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.5.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.5.ckan
@@ -66,6 +66,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.6.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.6.ckan
@@ -69,7 +69,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.1.6.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.1.6.ckan
@@ -66,6 +66,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.0.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.0.ckan
@@ -69,7 +69,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.0.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.0.ckan
@@ -66,6 +66,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.1.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.1.ckan
@@ -70,6 +70,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.1.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.1.ckan
@@ -73,7 +73,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.2.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.2.ckan
@@ -70,6 +70,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.2.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.2.ckan
@@ -73,7 +73,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.3.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.3.ckan
@@ -70,6 +70,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.3.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.3.ckan
@@ -73,7 +73,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.4.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.4.ckan
@@ -74,7 +74,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.4.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.4.ckan
@@ -71,6 +71,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.5.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.5.ckan
@@ -74,7 +74,7 @@
     "conflicts": [
         {
             "name": "Scatterer",
-            "version_min": "3:v0.0825b"
+            "min_version": "3:v0.0825b"
         }
     ],
     "install": [

--- a/GrannusExpansionPack/GrannusExpansionPack-1.2.5.ckan
+++ b/GrannusExpansionPack/GrannusExpansionPack-1.2.5.ckan
@@ -71,6 +71,12 @@
             "name": "GrannusExpansionPack-CommNet"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer",
+            "version_min": "3:v0.0825b"
+        }
+    ],
     "install": [
         {
             "file": "GameData/GEP",


### PR DESCRIPTION
Historical component of KSP-CKAN/NetKAN#8880 and KSP-CKAN/NetKAN#8881; now all versions of GPP, GPPSecondary, and GEP conflict with Scatterer 0.0825b and later.