### PR TITLE
Update download links for USI-NuclearRockets after repo move

### DIFF
--- a/USI-Core/USI-Core-0.0.1.0.ckan
+++ b/USI-Core/USI-Core-0.0.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.0.1.0",
     "ksp_version_min": "1.0.0",
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.0.1.0/USICore_0.0.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.0.1.0/USICore_0.0.1.0.zip",
     "download_size": 4587633,
     "download_hash": {
         "sha1": "F1291AE2747518D4F8945920A7AAD367434BA586",

--- a/USI-Core/USI-Core-0.1.1.0.ckan
+++ b/USI-Core/USI-Core-0.1.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.1.1.0",
     "ksp_version_min": "1.0.0",
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.1.1.0/USICore_0.1.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.1.0/USICore_0.1.1.0.zip",
     "download_size": 4602965,
     "download_hash": {
         "sha1": "0C9E5F28C68D1E46477ADFAA18592AA4CB4B6274",

--- a/USI-Core/USI-Core-0.1.2.0.ckan
+++ b/USI-Core/USI-Core-0.1.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.1.2.0",
     "ksp_version_min": "1.0.0",
@@ -33,7 +33,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.1.2.0/USICore_0.1.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.2.0/USICore_0.1.2.0.zip",
     "download_size": 4603186,
     "download_hash": {
         "sha1": "A14FB50B1C0A487AA2D6336A19FE512BC26C36AD",

--- a/USI-Core/USI-Core-0.1.3.0.ckan
+++ b/USI-Core/USI-Core-0.1.3.0.ckan
@@ -30,7 +30,11 @@
     "install": [
         {
             "file": "GameData/UmbraSpaceIndustries",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter": [
+                "FX",
+                "Konstruction"
+            ]
         }
     ],
     "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.3.0/USICore_0.1.3.0.zip",

--- a/USI-Core/USI-Core-0.1.3.0.ckan
+++ b/USI-Core/USI-Core-0.1.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.1.3.0",
     "ksp_version_min": "1.0.0",
@@ -33,7 +33,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.1.3.0/USICore_0.1.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.3.0/USICore_0.1.3.0.zip",
     "download_size": 6613935,
     "download_hash": {
         "sha1": "7A722B248816EFDBF7BD452C57CD517043BD4A6A",

--- a/USI-Core/USI-Core-0.1.4.0.ckan
+++ b/USI-Core/USI-Core-0.1.4.0.ckan
@@ -30,7 +30,11 @@
     "install": [
         {
             "file": "GameData/UmbraSpaceIndustries",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter": [
+                "FX",
+                "Konstruction"
+            ]
         }
     ],
     "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.4.0/USICore_0.1.4.0.zip",

--- a/USI-Core/USI-Core-0.1.4.0.ckan
+++ b/USI-Core/USI-Core-0.1.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.1.4.0",
     "ksp_version_min": "1.0.0",
@@ -33,7 +33,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.1.4.0/USICore_0.1.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.4.0/USICore_0.1.4.0.zip",
     "download_size": 6613874,
     "download_hash": {
         "sha1": "118891EA2A337850ABF304C58A660F78F328E32F",

--- a/USI-Core/USI-Core-0.1.5.0.ckan
+++ b/USI-Core/USI-Core-0.1.5.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.1.5.0",
     "ksp_version_min": "1.0.0",
@@ -33,7 +33,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.1.5.0/USICore_0.1.5.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.5.0/USICore_0.1.5.0.zip",
     "download_size": 6927257,
     "download_hash": {
         "sha1": "37CF38B5ECF51E8EB7F1AC5EF9EC844526CA11F4",

--- a/USI-Core/USI-Core-0.1.5.0.ckan
+++ b/USI-Core/USI-Core-0.1.5.0.ckan
@@ -30,7 +30,11 @@
     "install": [
         {
             "file": "GameData/UmbraSpaceIndustries",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter": [
+                "FX",
+                "Konstruction"
+            ]
         }
     ],
     "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.5.0/USICore_0.1.5.0.zip",

--- a/USI-Core/USI-Core-0.1.6.0.ckan
+++ b/USI-Core/USI-Core-0.1.6.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.1.6.0",
     "ksp_version_min": "1.0.0",
@@ -33,7 +33,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.1.6.0/USICore_0.1.6.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.6.0/USICore_0.1.6.0.zip",
     "download_size": 6963969,
     "download_hash": {
         "sha1": "18B869C574791703ADA19313DB37FA79F1B9EAB8",

--- a/USI-Core/USI-Core-0.1.6.0.ckan
+++ b/USI-Core/USI-Core-0.1.6.0.ckan
@@ -30,7 +30,11 @@
     "install": [
         {
             "file": "GameData/UmbraSpaceIndustries",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter": [
+                "FX",
+                "Konstruction"
+            ]
         }
     ],
     "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.6.0/USICore_0.1.6.0.zip",

--- a/USI-Core/USI-Core-0.1.7.0.ckan
+++ b/USI-Core/USI-Core-0.1.7.0.ckan
@@ -30,7 +30,11 @@
     "install": [
         {
             "file": "GameData/UmbraSpaceIndustries",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter": [
+                "FX",
+                "Konstruction"
+            ]
         }
     ],
     "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.7.0/USICore_0.1.7.0.zip",

--- a/USI-Core/USI-Core-0.1.7.0.ckan
+++ b/USI-Core/USI-Core-0.1.7.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.1.7.0",
     "ksp_version_min": "1.0.0",
@@ -33,7 +33,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.1.7.0/USICore_0.1.7.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.7.0/USICore_0.1.7.0.zip",
     "download_size": 7429427,
     "download_hash": {
         "sha1": "C8239511BDB24191FD19B3CD34E9AABBDCEC2854",

--- a/USI-Core/USI-Core-0.1.8.0.ckan
+++ b/USI-Core/USI-Core-0.1.8.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.1.8.0",
     "ksp_version_min": "1.0.0",
@@ -37,7 +37,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.1.8.0/USICore_0.1.8.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.1.8.0/USICore_0.1.8.0.zip",
     "download_size": 7430125,
     "download_hash": {
         "sha1": "BF585210EC99477263023C6528E27A5BCA570D6F",

--- a/USI-Core/USI-Core-0.2.0.0.ckan
+++ b/USI-Core/USI-Core-0.2.0.0.ckan
@@ -34,7 +34,11 @@
     "install": [
         {
             "file": "GameData/UmbraSpaceIndustries",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter": [
+                "FX",
+                "Konstruction"
+            ]
         }
     ],
     "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.2.0.0/USICore_0.2.0.0.zip",

--- a/USI-Core/USI-Core-0.2.0.0.ckan
+++ b/USI-Core/USI-Core-0.2.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.2.0.0",
     "ksp_version": "1.1.0",
@@ -37,7 +37,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.2.0.0/USICore_0.2.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.2.0.0/USICore_0.2.0.0.zip",
     "download_size": 7422365,
     "download_hash": {
         "sha1": "28D37EFA2D64B6809AE6BA80685C97EF77C9AA52",

--- a/USI-Core/USI-Core-0.2.1.0.ckan
+++ b/USI-Core/USI-Core-0.2.1.0.ckan
@@ -34,7 +34,11 @@
     "install": [
         {
             "file": "GameData/UmbraSpaceIndustries",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter": [
+                "FX",
+                "Konstruction"
+            ]
         }
     ],
     "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.2.1.0/USICore_0.2.1.0.zip",

--- a/USI-Core/USI-Core-0.2.1.0.ckan
+++ b/USI-Core/USI-Core-0.2.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.2.1.0",
     "ksp_version": "1.1.0",
@@ -37,7 +37,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.2.1.0/USICore_0.2.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.2.1.0/USICore_0.2.1.0.zip",
     "download_size": 7442170,
     "download_hash": {
         "sha1": "C20C7A272FF61F8B69B3D6C0CF7C73D474093EAF",

--- a/USI-Core/USI-Core-0.2.2.0.ckan
+++ b/USI-Core/USI-Core-0.2.2.0.ckan
@@ -35,7 +35,11 @@
     "install": [
         {
             "file": "GameData/UmbraSpaceIndustries",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter": [
+                "FX",
+                "Konstruction"
+            ]
         }
     ],
     "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.2.2.0/USICore_0.2.2.0.zip",

--- a/USI-Core/USI-Core-0.2.2.0.ckan
+++ b/USI-Core/USI-Core-0.2.2.0.ckan
@@ -11,8 +11,8 @@
         "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.2.2.0",
-    "ksp_version_min": "1.1.1",
-    "ksp_version_max": "1.1.0",
+    "ksp_version_min": "1.1.0",
+    "ksp_version_max": "1.1.1",
     "depends": [
         {
             "name": "USITools"

--- a/USI-Core/USI-Core-0.2.2.0.ckan
+++ b/USI-Core/USI-Core-0.2.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.2.2.0",
     "ksp_version_min": "1.1.1",
@@ -38,7 +38,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.2.2.0/USICore_0.2.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.2.2.0/USICore_0.2.2.0.zip",
     "download_size": 7642275,
     "download_hash": {
         "sha1": "96CEE422396B8E3120E9FED923C9E7461C166FF5",

--- a/USI-Core/USI-Core-0.2.2.1.ckan
+++ b/USI-Core/USI-Core-0.2.2.1.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.2.2.1",
     "ksp_version_min": "1.1.0",
@@ -38,7 +38,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.2.2.1/USICore_0.2.2.1.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.2.2.1/USICore_0.2.2.1.zip",
     "download_size": 7682869,
     "download_hash": {
         "sha1": "C955F55F02FC2B22B71AA4C470C1262043792C86",

--- a/USI-Core/USI-Core-0.2.2.1.ckan
+++ b/USI-Core/USI-Core-0.2.2.1.ckan
@@ -35,7 +35,11 @@
     "install": [
         {
             "file": "GameData/UmbraSpaceIndustries",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter": [
+                "FX",
+                "Konstruction"
+            ]
         }
     ],
     "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.2.2.1/USICore_0.2.2.1.zip",

--- a/USI-Core/USI-Core-0.2.3.0.ckan
+++ b/USI-Core/USI-Core-0.2.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.2.3.0",
     "ksp_version_min": "1.1.0",
@@ -38,7 +38,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.2.3.0/USICore_0.2.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.2.3.0/USICore_0.2.3.0.zip",
     "download_size": 7682695,
     "download_hash": {
         "sha1": "C4F373435F2FC0DF6A16A7826EC641E4BBABA41B",

--- a/USI-Core/USI-Core-0.2.3.0.ckan
+++ b/USI-Core/USI-Core-0.2.3.0.ckan
@@ -35,7 +35,11 @@
     "install": [
         {
             "file": "GameData/UmbraSpaceIndustries",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter": [
+                "FX",
+                "Konstruction"
+            ]
         }
     ],
     "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.2.3.0/USICore_0.2.3.0.zip",

--- a/USI-Core/USI-Core-0.2.4.0.ckan
+++ b/USI-Core/USI-Core-0.2.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.2.4.0",
     "ksp_version_min": "1.1.0",
@@ -42,7 +42,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.2.4.0/USICore_0.2.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.2.4.0/USICore_0.2.4.0.zip",
     "download_size": 8344712,
     "download_hash": {
         "sha1": "E537B2109F04EE966DB1DAFCF74D67529757226D",

--- a/USI-Core/USI-Core-0.3.0.0.ckan
+++ b/USI-Core/USI-Core-0.3.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.3.0.0",
     "ksp_version": "1.2.0",
@@ -41,7 +41,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.3.0.0/USICore_0.3.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.3.0.0/USICore_0.3.0.0.zip",
     "download_size": 10111143,
     "download_hash": {
         "sha1": "35EF06900C75C9873839B5BC0AA87E919D4A3B2F",

--- a/USI-Core/USI-Core-0.3.1.0.ckan
+++ b/USI-Core/USI-Core-0.3.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.3.1.0",
     "ksp_version": "1.2.0",
@@ -41,7 +41,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.3.1.0/USICore_0.3.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.3.1.0/USICore_0.3.1.0.zip",
     "download_size": 9150490,
     "download_hash": {
         "sha1": "8AF07689AB729644F3183ABE0807A82220908A0F",

--- a/USI-Core/USI-Core-0.3.2.0.ckan
+++ b/USI-Core/USI-Core-0.3.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.3.2.0",
     "ksp_version": "1.2.0",
@@ -41,7 +41,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.3.2.0/USICore_0.3.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.3.2.0/USICore_0.3.2.0.zip",
     "download_size": 9150941,
     "download_hash": {
         "sha1": "83E1452EACCCE301DFB92D34C18C008EA6EBE393",

--- a/USI-Core/USI-Core-0.3.3.0.ckan
+++ b/USI-Core/USI-Core-0.3.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.3.3.0",
     "ksp_version": "1.2.0",
@@ -41,7 +41,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.3.3.0/USICore_0.3.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.3.3.0/USICore_0.3.3.0.zip",
     "download_size": 9152121,
     "download_hash": {
         "sha1": "92E7B6E60D277DC8F8D3BF3D55619EFF335441D0",

--- a/USI-Core/USI-Core-0.3.4.0.ckan
+++ b/USI-Core/USI-Core-0.3.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.3.4.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.3.4.0/USICore_0.3.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.3.4.0/USICore_0.3.4.0.zip",
     "download_size": 9154693,
     "download_hash": {
         "sha1": "8EE265890EE9B69F7C8BBCE5E362609C907EBB93",

--- a/USI-Core/USI-Core-0.3.5.0.ckan
+++ b/USI-Core/USI-Core-0.3.5.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.3.5.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.3.5.0/USICore_0.3.5.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.3.5.0/USICore_0.3.5.0.zip",
     "download_size": 9209081,
     "download_hash": {
         "sha1": "315A63FBC51F06FB15E48E453793D7EF951D8275",

--- a/USI-Core/USI-Core-0.3.6.0.ckan
+++ b/USI-Core/USI-Core-0.3.6.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.3.6.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.3.6.0/USICore_0.3.6.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.3.6.0/USICore_0.3.6.0.zip",
     "download_size": 9210237,
     "download_hash": {
         "sha1": "B246CB7578F5CC0992ED1D99858A2105D62BDC90",

--- a/USI-Core/USI-Core-0.3.7.0.ckan
+++ b/USI-Core/USI-Core-0.3.7.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.3.7.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.3.7.0/USICore_0.3.7.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.3.7.0/USICore_0.3.7.0.zip",
     "download_size": 9214519,
     "download_hash": {
         "sha1": "BFD398A72800188E78153DB84742E988FFA26FE0",

--- a/USI-Core/USI-Core-0.3.8.0.ckan
+++ b/USI-Core/USI-Core-0.3.8.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.3.8.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.3.8.0/USICore_0.3.8.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.3.8.0/USICore_0.3.8.0.zip",
     "download_size": 9225687,
     "download_hash": {
         "sha1": "54E06655DC2944801252C47B7603BACC5C6FD24C",

--- a/USI-Core/USI-Core-0.3.9.0.ckan
+++ b/USI-Core/USI-Core-0.3.9.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/USI_Core"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI_Core"
     },
     "version": "0.3.9.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             ]
         }
     ],
-    "download": "https://github.com/BobPalmer/USI_Core/releases/download/0.3.9.0/USICore_0.3.9.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI_Core/releases/download/0.3.9.0/USICore_0.3.9.0.zip",
     "download_size": 10226406,
     "download_hash": {
         "sha1": "E50AA6A553AE3C7537FBAA4C75DD82CE043A9B70",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.1.2.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.1.2.0.ckan
@@ -27,7 +27,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.1.2.0/Orion_0.1.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.1.2.0/Orion_0.1.2.0.zip",
     "download_size": 6031969,
     "download_hash": {
         "sha1": "21C1D141137DDDD6BCD674E821C63B886487542E",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.1.2.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.1.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.1.2.0",
     "ksp_version_min": "1.0.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.0.0.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.2.0.0/Orion_0.2.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.2.0.0/Orion_0.2.0.0.zip",
     "download_size": 6838013,
     "download_hash": {
         "sha1": "9F0CBA6F188546355500593A0B0CCC78EE6D70C7",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.2.0.0",
     "ksp_version": "1.1.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.1.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.1.0.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.2.1.0/Orion_0.2.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.2.1.0/Orion_0.2.1.0.zip",
     "download_size": 7238293,
     "download_hash": {
         "sha1": "D8788E127BC9F9A7EE6D1EED62BE57EAA6F7E238",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.1.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.2.1.0",
     "ksp_version": "1.1.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.2.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.2.2.0",
     "ksp_version": "1.1.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.2.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.2.0.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.2.2.0/Orion_0.2.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.2.2.0/Orion_0.2.2.0.zip",
     "download_size": 7057930,
     "download_hash": {
         "sha1": "BF61E23AFE191E63186B9A8E9970AB5010E166B5",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.2.1.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.2.1.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.2.2.1",
     "ksp_version_min": "1.1.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.2.1.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.2.1.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.2.2.1/Orion_0.2.2.1.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.2.2.1/Orion_0.2.2.1.zip",
     "download_size": 7069958,
     "download_hash": {
         "sha1": "DDBDDC0274B18713B1E2DD74238A0A32E22B4410",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.3.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.3.0.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.2.3.0/Orion_0.2.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.2.3.0/Orion_0.2.3.0.zip",
     "download_size": 7069689,
     "download_hash": {
         "sha1": "D53CBB583922C0CEB9DCB84096FB50841BFF2070",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.3.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.2.3.0",
     "ksp_version_min": "1.1.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.4.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.2.4.0",
     "ksp_version_min": "1.1.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.2.4.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.2.4.0.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.2.4.0/Orion_0.2.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.2.4.0/Orion_0.2.4.0.zip",
     "download_size": 7745556,
     "download_hash": {
         "sha1": "E3475982AC0BF3380B03B498A89A7E5AEC8281EF",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.3.0.0",
     "ksp_version": "1.2.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.0.0.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.3.0.0/Orion_0.3.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.3.0.0/Orion_0.3.0.0.zip",
     "download_size": 8561822,
     "download_hash": {
         "sha1": "E6BE3CD29495184A15CAEC1A34FC1641DAC765A2",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.1.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.3.1.0",
     "ksp_version": "1.2.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.1.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.1.0.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.3.1.0/Orion_0.3.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.3.1.0/Orion_0.3.1.0.zip",
     "download_size": 8562307,
     "download_hash": {
         "sha1": "46DBCFCB9A8D0C5555B39D9BE6A799708B499BA8",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.2.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.3.2.0",
     "ksp_version": "1.2.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.2.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.2.0.ckan
@@ -31,7 +31,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.3.2.0/Orion_0.3.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.3.2.0/Orion_0.3.2.0.zip",
     "download_size": 8563575,
     "download_hash": {
         "sha1": "96B64D6855FF0876C6FE12467B381EE04027159E",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.3.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.3.3.0",
     "ksp_version_min": "1.2.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.3.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.3.0.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.3.3.0/Orion_0.3.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.3.3.0/Orion_0.3.3.0.zip",
     "download_size": 8601155,
     "download_hash": {
         "sha1": "C45F76EE1C5AD24032BB81353685087FFF1F9454",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.4.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.3.4.0",
     "ksp_version_min": "1.2.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.4.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.4.0.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.3.4.0/Orion_0.3.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.3.4.0/Orion_0.3.4.0.zip",
     "download_size": 8619474,
     "download_hash": {
         "sha1": "E60564067E0593864E9442F727C2908B438DC314",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.5.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.5.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.3.5.0",
     "ksp_version_min": "1.2.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.5.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.5.0.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.3.5.0/Orion_0.3.5.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.3.5.0/Orion_0.3.5.0.zip",
     "download_size": 8633641,
     "download_hash": {
         "sha1": "58D8E3DD0880BB8F85A16EC5E0F0042FC58CC111",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.6.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.6.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.3.6.0",
     "ksp_version_min": "1.2.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.6.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.6.0.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.3.6.0/Orion_0.3.6.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.3.6.0/Orion_0.3.6.0.zip",
     "download_size": 8634772,
     "download_hash": {
         "sha1": "2194A5455DFF92B1CE9CA5F0BF8BC79BA7FA2639",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.7.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.7.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.3.7.0",
     "ksp_version_min": "1.2.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.7.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.7.0.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.3.7.0/Orion_0.3.7.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.3.7.0/Orion_0.3.7.0.zip",
     "download_size": 8639060,
     "download_hash": {
         "sha1": "A5D5D993FA9D23FA918265C82D20876B6E677194",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.8.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.8.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.3.8.0",
     "ksp_version_min": "1.2.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.8.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.8.0.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.3.8.0/Orion_0.3.8.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.3.8.0/Orion_0.3.8.0.zip",
     "download_size": 8639359,
     "download_hash": {
         "sha1": "9DC59C345DAB65CD0253A60FDB52176C3B775C47",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.9.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.9.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/121597-alpha-project-orion-nuclear-pulse-engine/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.3.9.0",
     "ksp_version_min": "1.2.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.3.9.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.3.9.0.ckan
@@ -32,7 +32,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.3.9.0/Orion_0.3.9.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.3.9.0/Orion_0.3.9.0.zip",
     "download_size": 9700737,
     "download_hash": {
         "sha1": "2F7EE317C93C15E3A0854FF366501DE5C58FFBD0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.4.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.4.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.4.0.0",
     "ksp_version_min": "1.2.9",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.4.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.4.0.0.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.4.0.0/Orion_0.4.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.4.0.0/Orion_0.4.0.0.zip",
     "download_size": 9792515,
     "download_hash": {
         "sha1": "83C9B0946F89D649DCFD5FF3892D6A8FC1F90A1A",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.4.1.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.4.1.0.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.4.1.0/Orion_0.4.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.4.1.0/Orion_0.4.1.0.zip",
     "download_size": 9793140,
     "download_hash": {
         "sha1": "453907A92B1DDC31144B83525FEA37D763930578",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.4.1.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.4.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.4.1.0",
     "ksp_version_min": "1.2.9",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.4.2.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.4.2.0.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.4.2.0/Orion_0.4.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.4.2.0/Orion_0.4.2.0.zip",
     "download_size": 9797760,
     "download_hash": {
         "sha1": "41B6DDC42DA46A97DC6E3D16CF450D65D2722C63",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.4.2.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.4.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.4.2.0",
     "ksp_version_min": "1.2.9",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.5.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.5.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.5.0.0",
     "ksp_version_min": "1.3.1",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.5.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.5.0.0.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.5.0.0/Orion_0.5.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.5.0.0/Orion_0.5.0.0.zip",
     "download_size": 9814794,
     "download_hash": {
         "sha1": "D9F5443253065AA2EBFDD604518DEDCE7C61F52B",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.5.1.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.5.1.0.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.5.1.0/Orion_0.5.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.5.1.0/Orion_0.5.1.0.zip",
     "download_size": 9817608,
     "download_hash": {
         "sha1": "7E449627BB048CB8F954543A6EBA5D6DE4C27687",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.5.1.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.5.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.5.1.0",
     "ksp_version_min": "1.3.1",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.6.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.6.0.0.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.6.0.0/Orion_0.6.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.6.0.0/Orion_0.6.0.0.zip",
     "download_size": 9827524,
     "download_hash": {
         "sha1": "E9517D3BD9AE305245848CB600283F1039EEA4D9",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.6.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.6.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.6.0.0",
     "ksp_version_min": "1.4.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.7.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.7.0.0.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/0.7.0.0/Orion_0.7.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/0.7.0.0/Orion_0.7.0.0.zip",
     "download_size": 9831614,
     "download_hash": {
         "sha1": "81AC56F9BCE99D41CF9214B83421B8F1AE2340EE",

--- a/USI-NuclearRockets/USI-NuclearRockets-0.7.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-0.7.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "0.7.0.0",
     "ksp_version_min": "1.4.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-1.1.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-1.1.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "1.1.0.0",
     "ksp_version_min": "1.6.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-1.1.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-1.1.0.0.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/1.1.0.0/Orion_1.1.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/1.1.0.0/Orion_1.1.0.0.zip",
     "download_size": 9850068,
     "download_hash": {
         "sha1": "B6224BB9049DADF7F9131DE5C049D42E8D53C95C",

--- a/USI-NuclearRockets/USI-NuclearRockets-1.2.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-1.2.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets"
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets"
     },
     "version": "1.2.0.0",
     "ksp_version_min": "1.6.0",

--- a/USI-NuclearRockets/USI-NuclearRockets-1.2.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-1.2.0.0.ckan
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/1.2.0.0/Orion_1.2.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/1.2.0.0/Orion_1.2.0.0.zip",
     "download_size": 9815074,
     "download_hash": {
         "sha1": "D7651C929C363CBBEA10BDF5344FCC6BDC99F895",

--- a/USI-NuclearRockets/USI-NuclearRockets-1.3.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-1.3.0.0.ckan
@@ -11,8 +11,8 @@
     "release_status": "development",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/NuclearRockets",
-        "bugtracker": "https://github.com/BobPalmer/NuclearRockets/issues",
+        "repository": "https://github.com/UmbraSpaceIndustries/NuclearRockets",
+        "bugtracker": "https://github.com/UmbraSpaceIndustries/NuclearRockets/issues",
         "metanetkan": "https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-NuclearRockets.netkan"
     },
     "tags": [

--- a/USI-NuclearRockets/USI-NuclearRockets-1.3.0.0.ckan
+++ b/USI-NuclearRockets/USI-NuclearRockets-1.3.0.0.ckan
@@ -39,7 +39,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/NuclearRockets/releases/download/1.3.0.0/Orion_1.3.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/NuclearRockets/releases/download/1.3.0.0/Orion_1.3.0.0.zip",
     "download_size": 9797672,
     "download_hash": {
         "sha1": "F221A5E0A36F8AC0CD56CABBAF30EDEF03889873",


### PR DESCRIPTION
A user reported yet another USI mod suffering from the big repo move in USI land, see https://github.com/KSP-CKAN/CKAN-meta/pull/2369 for a related PR with USITools.

This time it's NuclearRockets, a user just made me aware of the 1.2.0.0 download not working (for some reason CKAN didn't throw an error at all, that's another thing to look into).

There might be more USI mods out there suffering the same fate, I'm going to look through them tomorrow.

In any case, substitutions performed using `sed`:
```bash
sed -i "s/github.com\/BobPalmer\/NuclearRockets/github.com\/UmbraSpaceIndustries\/NuclearRockets/" *.ckan
```

Let's see if all these downloads still work, random samples were successful.