### PR TITLE
Update CommunityResourcePack links after repo move

### DIFF
--- a/CommunityResourcePack/CommunityResourcePack-0.10.0.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.10.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.10.0.0",
     "ksp_version_min": "1.4.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.10.0.0/CRP_0.10.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.10.0.0/CRP_0.10.0.0.zip",
     "download_size": 44905,
     "download_hash": {
         "sha1": "6C19F4F0BF3AE9C4E61B5CAD9CB6E1206C3813CB",

--- a/CommunityResourcePack/CommunityResourcePack-0.2.2.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.2.2.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.2.2",
     "ksp_version": "0.25",
@@ -22,7 +22,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.2.2/CRP_0.2.2.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.2.2/CRP_0.2.2.zip",
     "download_size": 16349520,
     "download_hash": {
         "sha1": "E9E5A60144A69E267CE2DAD4FEA6EF1797E1F969",

--- a/CommunityResourcePack/CommunityResourcePack-0.2.3.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.2.3.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.2.3",
     "ksp_version": "0.25",
@@ -22,7 +22,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.2.3/CRP_0.2.3.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.2.3/CRP_0.2.3.zip",
     "download_size": 16354356,
     "download_hash": {
         "sha1": "EFDDCFED2B1764ADCCFC3FAF101F34DB0F537C0B",

--- a/CommunityResourcePack/CommunityResourcePack-0.3.1.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.3.1.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.3.1",
     "ksp_version": "0.90",
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.3.1/CRP_0.3.1.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.3.1/CRP_0.3.1.zip",
     "download_size": 14402,
     "download_hash": {
         "sha1": "012138172377E8D6E0D42A58D047D11C720899EE",

--- a/CommunityResourcePack/CommunityResourcePack-0.3.2.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.3.2.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.3.2",
     "ksp_version": "0.90",
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.3.2/CRP_0.3.2.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.3.2/CRP_0.3.2.zip",
     "download_size": 13838,
     "download_hash": {
         "sha1": "B35CCF1D7991B984F10D0522071FB5FF2FEC0A1E",

--- a/CommunityResourcePack/CommunityResourcePack-0.3.3.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.3.3.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.3.3",
     "ksp_version": "0.90",
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.3.3/CRP_0.3.3.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.3.3/CRP_0.3.3.zip",
     "download_size": 13892,
     "download_hash": {
         "sha1": "2F133125091B35195C33EB659A836CAFA440D7A6",

--- a/CommunityResourcePack/CommunityResourcePack-0.4.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.4.0",
     "ksp_version": "1.0",
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.4.0/CRP_0.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.4.0/CRP_0.4.0.zip",
     "download_size": 15469,
     "download_hash": {
         "sha1": "6C5EDD080D975D7AE01787B33DA7F13AF4AF9C18",

--- a/CommunityResourcePack/CommunityResourcePack-0.4.1.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.4.1.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.4.1",
     "ksp_version": "1.0",
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.4.1/CRP_0.4.1.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.4.1/CRP_0.4.1.zip",
     "download_size": 15532,
     "download_hash": {
         "sha1": "665D381BC1BB65E0239CA28EA4A4BB8A35D1099E",

--- a/CommunityResourcePack/CommunityResourcePack-0.4.2.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.4.2.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.4.2",
     "ksp_version": "1.0",
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.4.2/CRP_0.4.2.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.4.2/CRP_0.4.2.zip",
     "download_size": 16166,
     "download_hash": {
         "sha1": "B44FCA63B0A0C2AD5E7192EA358E28C3C87874D1",

--- a/CommunityResourcePack/CommunityResourcePack-0.4.3.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.4.3.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.4.3",
     "ksp_version": "1.0",
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.4.3/CRP_0.4.3.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.4.3/CRP_0.4.3.zip",
     "download_size": 17658,
     "download_hash": {
         "sha1": "08BE818714939851B101978C93530427D7D276E9",

--- a/CommunityResourcePack/CommunityResourcePack-0.4.4.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.4.4.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.4.4",
     "ksp_version": "1.0",
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.4.4/CRP_0.4.4.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.4.4/CRP_0.4.4.zip",
     "download_size": 17695,
     "download_hash": {
         "sha1": "7BB637603415ABC553B5598D40D87E948E78837B",

--- a/CommunityResourcePack/CommunityResourcePack-0.4.5.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.4.5.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.4.5.0",
     "ksp_version_min": "1.0.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.4.5.0/CRP_0.4.5.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.4.5.0/CRP_0.4.5.0.zip",
     "download_size": 16788,
     "download_hash": {
         "sha1": "C74E975348B8462BDC2B600B9A1551AC011E6AF4",

--- a/CommunityResourcePack/CommunityResourcePack-0.4.7.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.4.7.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.4.7.0",
     "ksp_version_min": "1.0.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.4.7.0/CRP_0.4.7.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.4.7.0/CRP_0.4.7.0.zip",
     "download_size": 17694,
     "download_hash": {
         "sha1": "9F650DD795EF5F5C913FDBF7C23F3F1D491DCAE7",

--- a/CommunityResourcePack/CommunityResourcePack-0.4.8.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.4.8.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/91998",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.4.8.0",
     "ksp_version_min": "1.0.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.4.8.0/CRP_0.4.8.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.4.8.0/CRP_0.4.8.0.zip",
     "download_size": 18457,
     "download_hash": {
         "sha1": "0B5C4EF4D0775FD454BC9BB4336BFAB5F773726F",

--- a/CommunityResourcePack/CommunityResourcePack-0.5.1.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.5.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.5.1.0",
     "ksp_version_min": "1.0.0",
@@ -24,7 +24,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.5.1.0/CRP_0.5.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.5.1.0/CRP_0.5.1.0.zip",
     "download_size": 16098,
     "download_hash": {
         "sha1": "D2025581F3B76999364DC31065EAFF0BC1F1E602",

--- a/CommunityResourcePack/CommunityResourcePack-0.5.1.1.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.5.1.1.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.5.1.1",
     "ksp_version_min": "1.0.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.5.1.1/CRP_0.5.1.1.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.5.1.1/CRP_0.5.1.1.zip",
     "download_size": 22649,
     "download_hash": {
         "sha1": "224C5FAEA11EAF514D9ABFA17AA2F218B775973C",

--- a/CommunityResourcePack/CommunityResourcePack-0.5.2.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.5.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.5.2.0",
     "ksp_version_min": "1.0.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.5.2.0/CRP_0.5.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.5.2.0/CRP_0.5.2.0.zip",
     "download_size": 22761,
     "download_hash": {
         "sha1": "DD11FC30AFD7C7AFDA48A00600C54164655289B2",

--- a/CommunityResourcePack/CommunityResourcePack-0.5.4.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.5.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.5.4.0",
     "ksp_version_min": "1.0.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.5.4.0/CRP_0.5.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.5.4.0/CRP_0.5.4.0.zip",
     "download_size": 23706,
     "download_hash": {
         "sha1": "F9BB72380B4047EFBF4A391D158DD9CCCF77DE0B",

--- a/CommunityResourcePack/CommunityResourcePack-0.6.0.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.6.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.6.0.0",
     "ksp_version_min": "1.1.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.6.0.0/CRP_0.6.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.6.0.0/CRP_0.6.0.0.zip",
     "download_size": 27175,
     "download_hash": {
         "sha1": "40F28BF39230E3CE3A706FAF50DB011C6FCF00BC",

--- a/CommunityResourcePack/CommunityResourcePack-0.6.1.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.6.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.6.1.0",
     "ksp_version_min": "1.1.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.6.1.0/CRP_0.6.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.6.1.0/CRP_0.6.1.0.zip",
     "download_size": 27574,
     "download_hash": {
         "sha1": "DF374AF6CD67E22FD486B812819A8895F174883C",

--- a/CommunityResourcePack/CommunityResourcePack-0.6.2.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.6.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.6.2.0",
     "ksp_version_min": "1.1.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.6.2.0/CRP_0.6.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.6.2.0/CRP_0.6.2.0.zip",
     "download_size": 27498,
     "download_hash": {
         "sha1": "6A8EA8A2A117C0A40261435F1D2E1ADCAAAE2EE8",

--- a/CommunityResourcePack/CommunityResourcePack-0.6.3.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.6.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.6.3.0",
     "ksp_version_min": "1.1.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.6.3.0/CRP_0.6.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.6.3.0/CRP_0.6.3.0.zip",
     "download_size": 27530,
     "download_hash": {
         "sha1": "E8BC07546422819A9C8F0139A1836C6444A7FF7D",

--- a/CommunityResourcePack/CommunityResourcePack-0.6.4.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.6.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.6.4.0",
     "ksp_version_min": "1.1.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.6.4.0/CRP_0.6.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.6.4.0/CRP_0.6.4.0.zip",
     "download_size": 27569,
     "download_hash": {
         "sha1": "2F388E5F159A3522DB64B487B8DA15BD7A4F8325",

--- a/CommunityResourcePack/CommunityResourcePack-0.6.5.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.6.5.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.6.5.0",
     "ksp_version_min": "1.1.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.6.5.0/CRP_0.6.5.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.6.5.0/CRP_0.6.5.0.zip",
     "download_size": 27895,
     "download_hash": {
         "sha1": "9DB7425E59AE95CA4F1F02F84B7A383270B031E4",

--- a/CommunityResourcePack/CommunityResourcePack-0.6.6.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.6.6.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.6.6.0",
     "ksp_version_min": "1.1.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.6.6.0/CRP_0.6.6.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.6.6.0/CRP_0.6.6.0.zip",
     "download_size": 28117,
     "download_hash": {
         "sha1": "C7B534675822694AE13A228AD4B5A1EB9819344A",

--- a/CommunityResourcePack/CommunityResourcePack-0.7.0.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.7.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.7.0.0",
     "ksp_version_min": "1.2.9",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.7.0.0/CRP_0.7.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.7.0.0/CRP_0.7.0.0.zip",
     "download_size": 29018,
     "download_hash": {
         "sha1": "660CABEA2F7454E341EED425BD41E4500650A752",

--- a/CommunityResourcePack/CommunityResourcePack-0.7.1.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.7.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.7.1.0",
     "ksp_version_min": "1.2.9",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.7.1.0/CRP_0.7.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.7.1.0/CRP_0.7.1.0.zip",
     "download_size": 29488,
     "download_hash": {
         "sha1": "9F9BDBD1E39899ED0FF0295CEE6704B74C0ECB88",

--- a/CommunityResourcePack/CommunityResourcePack-0.7.2.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.7.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.7.2.0",
     "ksp_version_min": "1.2.9",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.7.2.0/CRP_0.7.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.7.2.0/CRP_0.7.2.0.zip",
     "download_size": 39633,
     "download_hash": {
         "sha1": "61D5ADD4E7B6BD9CF0CD4F249DE9CF3241B409CE",

--- a/CommunityResourcePack/CommunityResourcePack-0.8.0.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.8.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.8.0.0",
     "ksp_version_min": "1.3.1",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.8.0.0/CRP_0.8.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.8.0.0/CRP_0.8.0.0.zip",
     "download_size": 42710,
     "download_hash": {
         "sha1": "247679110D666B6B1A33FE8C0EA4D8CAAF8D490D",

--- a/CommunityResourcePack/CommunityResourcePack-0.8.1.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.8.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.8.1.0",
     "ksp_version_min": "1.3.1",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.8.1.0/CRP_0.8.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.8.1.0/CRP_0.8.1.0.zip",
     "download_size": 44874,
     "download_hash": {
         "sha1": "FCA4AE93083E8291ABCE85433053AA4C85F1D137",

--- a/CommunityResourcePack/CommunityResourcePack-0.9.0.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-0.9.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "0.9.0.0",
     "ksp_version_min": "1.4.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.9.0.0/CRP_0.9.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/0.9.0.0/CRP_0.9.0.0.zip",
     "download_size": 44890,
     "download_hash": {
         "sha1": "70AF7AD988C45E81280B0BE4EBD7FB3F2A2325F5",

--- a/CommunityResourcePack/CommunityResourcePack-1.0.0.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-1.0.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "1.0.0.0",
     "ksp_version_min": "1.5.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/1.0.0.0/CRP_1.0.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/1.0.0.0/CRP_1.0.0.0.zip",
     "download_size": 49951,
     "download_hash": {
         "sha1": "E2DBD7A723DC7345984BA89A2E2532A6947F5B98",

--- a/CommunityResourcePack/CommunityResourcePack-1.1.0.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-1.1.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "1.1.0.0",
     "ksp_version_min": "1.6.0",
@@ -28,7 +28,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/1.1.0.0/CRP_1.1.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/1.1.0.0/CRP_1.1.0.0.zip",
     "download_size": 52498,
     "download_hash": {
         "sha1": "0179690553031581CC551E277A455BAD5D15F081",

--- a/CommunityResourcePack/CommunityResourcePack-1.2.0.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-1.2.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack"
     },
     "version": "1.2.0.0",
     "ksp_version_min": "1.6.0",
@@ -29,7 +29,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/1.2.0.0/CRP_1.2.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/1.2.0.0/CRP_1.2.0.0.zip",
     "download_size": 55066,
     "download_hash": {
         "sha1": "E0691F7DA4595E9765B0DF520789CEE881FD8674",

--- a/CommunityResourcePack/CommunityResourcePack-1.3.0.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-1.3.0.0.ckan
@@ -10,8 +10,8 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack",
-        "bugtracker": "https://github.com/BobPalmer/CommunityResourcePack/issues",
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack",
+        "bugtracker": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/issues",
         "metanetkan": "https://raw.githubusercontent.com/BobPalmer/CKAN/master/CommunityResourcePack.netkan"
     },
     "tags": [
@@ -35,7 +35,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/1.3.0.0/CRP_1.3.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/1.3.0.0/CRP_1.3.0.0.zip",
     "download_size": 55072,
     "download_hash": {
         "sha1": "0994D462628C8E613F075A9AD938F52DF398D140",

--- a/CommunityResourcePack/CommunityResourcePack-1.4.1.0.ckan
+++ b/CommunityResourcePack/CommunityResourcePack-1.4.1.0.ckan
@@ -11,8 +11,8 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/CommunityResourcePack",
-        "bugtracker": "https://github.com/BobPalmer/CommunityResourcePack/issues",
+        "repository": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack",
+        "bugtracker": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/issues",
         "metanetkan": "https://raw.githubusercontent.com/BobPalmer/CKAN/master/CommunityResourcePack.netkan"
     },
     "tags": [
@@ -36,7 +36,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/1.4.1.0/CRP_1.4.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/CommunityResourcePack/releases/download/1.4.1.0/CRP_1.4.1.0.zip",
     "download_size": 55087,
     "download_hash": {
         "sha1": "8215DFA69A7CD37F8B8E60946C443676B7BA6CDA",


### PR DESCRIPTION
Follow-up of https://github.com/KSP-CKAN/CKAN-meta/pull/2507, updating the repo and download links of `CommunityResourcePack`

Edit: decided to do only one mod per PR, so I don't have to fight with and wait for CI so much.