### PR TITLE
Update USI-LS links after repo move

### DIFF
--- a/USI-LS/USI-LS-0.1.0.ckan
+++ b/USI-LS/USI-LS-0.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.1.0",
     "ksp_version": "1.0",
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.1.0/USILS_0.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.1.0/USILS_0.1.0.zip",
     "download_size": 294880,
     "download_hash": {
         "sha1": "956CA4BF338907795F222414990532D68F096194",

--- a/USI-LS/USI-LS-0.1.2.ckan
+++ b/USI-LS/USI-LS-0.1.2.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.1.2",
     "ksp_version_min": "1.0.0",
@@ -19,7 +19,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.1.2/USILS_0.1.2.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.1.2/USILS_0.1.2.zip",
     "download_size": 1196600,
     "download_hash": {
         "sha1": "3984BF1E542A5A4115401A26D675A80DF38EDD10",

--- a/USI-LS/USI-LS-0.1.4.0.ckan
+++ b/USI-LS/USI-LS-0.1.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.1.4.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.1.4.0/USI-LS_0.1.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.1.4.0/USI-LS_0.1.4.0.zip",
     "download_size": 904989,
     "download_hash": {
         "sha1": "6FCEEE747E2B627F81E2573196CC86BF803DB7B8",

--- a/USI-LS/USI-LS-0.1.5.ckan
+++ b/USI-LS/USI-LS-0.1.5.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.1.5",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.1.5/USILS_0.1.5.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.1.5/USILS_0.1.5.zip",
     "download_size": 874737,
     "download_hash": {
         "sha1": "E8CF8BF4471BEDC3B188A6DEA530B1B8AE79C668",

--- a/USI-LS/USI-LS-0.1.7.0.ckan
+++ b/USI-LS/USI-LS-0.1.7.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.1.7.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.1.7.0/USI-LS_0.1.7.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.1.7.0/USI-LS_0.1.7.0.zip",
     "download_size": 905260,
     "download_hash": {
         "sha1": "F77BF11986A27627E7ED0204B9B65CD866AD033B",

--- a/USI-LS/USI-LS-0.2.0.0.ckan
+++ b/USI-LS/USI-LS-0.2.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.2.0.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.2.0.0/USI-LS_0.2.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.2.0.0/USI-LS_0.2.0.0.zip",
     "download_size": 907680,
     "download_hash": {
         "sha1": "82FF8E14C1F8E35B579E3527590DBDD188DAAED2",

--- a/USI-LS/USI-LS-0.2.1.0.ckan
+++ b/USI-LS/USI-LS-0.2.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.2.1.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.2.1.0/USI-LS_0.2.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.2.1.0/USI-LS_0.2.1.0.zip",
     "download_size": 907682,
     "download_hash": {
         "sha1": "B047BAEE37BE4E9F7C8F4848EC3D89464B650757",

--- a/USI-LS/USI-LS-0.3.0.0.ckan
+++ b/USI-LS/USI-LS-0.3.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.0.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.0.0/USI-LS_0.3.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.0.0/USI-LS_0.3.0.0.zip",
     "download_size": 939834,
     "download_hash": {
         "sha1": "DD367326B0E340EBFB1DE294B3C81323E2E01482",

--- a/USI-LS/USI-LS-0.3.1.0.ckan
+++ b/USI-LS/USI-LS-0.3.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.1.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.1.0/USI-LS_0.3.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.1.0/USI-LS_0.3.1.0.zip",
     "download_size": 997723,
     "download_hash": {
         "sha1": "2E5D88C5537219882AEC0A175E764802233A9EF8",

--- a/USI-LS/USI-LS-0.3.11.0.ckan
+++ b/USI-LS/USI-LS-0.3.11.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.11.0",
     "ksp_version_min": "1.0.0",
@@ -30,7 +30,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.11.0/USI-LS_0.3.11.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.11.0/USI-LS_0.3.11.0.zip",
     "download_size": 981866,
     "download_hash": {
         "sha1": "9B90D6DB6E9AF8D2DF16087E6FD4B814B979CEF6",

--- a/USI-LS/USI-LS-0.3.12.0.ckan
+++ b/USI-LS/USI-LS-0.3.12.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.12.0",
     "ksp_version_min": "1.0.0",
@@ -30,7 +30,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.12.0/USI-LS_0.3.12.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.12.0/USI-LS_0.3.12.0.zip",
     "download_size": 982161,
     "download_hash": {
         "sha1": "2134611E8B31FBA4CC15A73AD586331D72227FB1",

--- a/USI-LS/USI-LS-0.3.13.0.ckan
+++ b/USI-LS/USI-LS-0.3.13.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.13.0",
     "ksp_version_min": "1.0.0",
@@ -30,7 +30,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.13.0/USI-LS_0.3.13.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.13.0/USI-LS_0.3.13.0.zip",
     "download_size": 1011642,
     "download_hash": {
         "sha1": "9D5F697DD95FC3C23387EF2A04F9010F796F1F2A",

--- a/USI-LS/USI-LS-0.3.14.0.ckan
+++ b/USI-LS/USI-LS-0.3.14.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.14.0",
     "ksp_version_min": "1.0.0",
@@ -30,7 +30,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.14.0/USI-LS_0.3.14.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.14.0/USI-LS_0.3.14.0.zip",
     "download_size": 983920,
     "download_hash": {
         "sha1": "A71443C7F52862696987E61DE629575DD3AEE55C",

--- a/USI-LS/USI-LS-0.3.15.0.ckan
+++ b/USI-LS/USI-LS-0.3.15.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.15.0",
     "ksp_version_min": "1.0.0",
@@ -33,7 +33,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.15.0/USI-LS_0.3.15.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.15.0/USI-LS_0.3.15.0.zip",
     "download_size": 983940,
     "download_hash": {
         "sha1": "305D9152A25405D34F2DB97BE587ECF9A16AF2B1",

--- a/USI-LS/USI-LS-0.3.2.0.ckan
+++ b/USI-LS/USI-LS-0.3.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.2.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.2.0/USI-LS_0.3.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.2.0/USI-LS_0.3.2.0.zip",
     "download_size": 998044,
     "download_hash": {
         "sha1": "754A145F3B02E27A2836F0C97961A0DCD7395684",

--- a/USI-LS/USI-LS-0.3.3.0.ckan
+++ b/USI-LS/USI-LS-0.3.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.3.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.3.0/USI-LS_0.3.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.3.0/USI-LS_0.3.3.0.zip",
     "download_size": 1003024,
     "download_hash": {
         "sha1": "AE38E296ADD8188DCAA5035A62DB51666A170965",

--- a/USI-LS/USI-LS-0.3.4.0.ckan
+++ b/USI-LS/USI-LS-0.3.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.4.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.4.0/USI-LS_0.3.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.4.0/USI-LS_0.3.4.0.zip",
     "download_size": 998351,
     "download_hash": {
         "sha1": "A46AA6614DBBB50303C4FD33C61D7EEB15E6B5A7",

--- a/USI-LS/USI-LS-0.3.5.0.ckan
+++ b/USI-LS/USI-LS-0.3.5.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.5.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.5.0/USI-LS_0.3.5.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.5.0/USI-LS_0.3.5.0.zip",
     "download_size": 998943,
     "download_hash": {
         "sha1": "14B29F3E2036136EAF3D17A18EE296AD7D08CCD5",

--- a/USI-LS/USI-LS-0.3.6.0.ckan
+++ b/USI-LS/USI-LS-0.3.6.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.6.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.6.0/USI-LS_0.3.6.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.6.0/USI-LS_0.3.6.0.zip",
     "download_size": 976365,
     "download_hash": {
         "sha1": "CB58EDB72B0A13767A95809A7F87A1A2DF1EB71B",

--- a/USI-LS/USI-LS-0.3.7.0.ckan
+++ b/USI-LS/USI-LS-0.3.7.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.7.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.7.0/USI-LS_0.3.7.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.7.0/USI-LS_0.3.7.0.zip",
     "download_size": 1001729,
     "download_hash": {
         "sha1": "5641C0AF944BFCDF69F24E284D4C03EC5E2FD255",

--- a/USI-LS/USI-LS-0.3.8.0.ckan
+++ b/USI-LS/USI-LS-0.3.8.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/116790",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.3.8.0",
     "ksp_version_min": "1.0.0",
@@ -25,7 +25,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.3.8.0/USI-LS_0.3.8.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.3.8.0/USI-LS_0.3.8.0.zip",
     "download_size": 976970,
     "download_hash": {
         "sha1": "A4F359C2C39616D80B28379ABCA0443ECF5E3DAD",

--- a/USI-LS/USI-LS-0.4.0.0.ckan
+++ b/USI-LS/USI-LS-0.4.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.4.0.0",
     "ksp_version": "1.1.0",
@@ -35,7 +35,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.4.0.0/USI-LS_0.4.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.4.0.0/USI-LS_0.4.0.0.zip",
     "download_size": 1752991,
     "download_hash": {
         "sha1": "B4E891FE1C337917FBCF99E75226916AB919F4B6",

--- a/USI-LS/USI-LS-0.4.1.0.ckan
+++ b/USI-LS/USI-LS-0.4.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.4.1.0",
     "ksp_version": "1.1.0",
@@ -35,7 +35,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.4.1.0/USI-LS_0.4.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.4.1.0/USI-LS_0.4.1.0.zip",
     "download_size": 1768566,
     "download_hash": {
         "sha1": "C2DA57CE9271C0AF27295C6F311502F718A713CE",

--- a/USI-LS/USI-LS-0.4.2.0.ckan
+++ b/USI-LS/USI-LS-0.4.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.4.2.0",
     "ksp_version": "1.1.0",
@@ -38,7 +38,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.4.2.0/USI-LS_0.4.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.4.2.0/USI-LS_0.4.2.0.zip",
     "download_size": 1768038,
     "download_hash": {
         "sha1": "883F7C51B308A9B46EF96DFA78A9412EA51015A2",

--- a/USI-LS/USI-LS-0.4.2.1.ckan
+++ b/USI-LS/USI-LS-0.4.2.1.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.4.2.1",
     "ksp_version_min": "1.1.0",
@@ -39,7 +39,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.4.2.1/USI-LS_0.4.2.1.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.4.2.1/USI-LS_0.4.2.1.zip",
     "download_size": 1840506,
     "download_hash": {
         "sha1": "0C97D29B0034A443378C57B379CDF783235D2D84",

--- a/USI-LS/USI-LS-0.4.3.0.ckan
+++ b/USI-LS/USI-LS-0.4.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.4.3.0",
     "ksp_version_min": "1.1.0",
@@ -39,7 +39,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.4.3.0/USI-LS_0.4.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.4.3.0/USI-LS_0.4.3.0.zip",
     "download_size": 1846468,
     "download_hash": {
         "sha1": "FCB9189736B31370ACF8542E437F20DD9A0EDE54",

--- a/USI-LS/USI-LS-0.4.3.1.ckan
+++ b/USI-LS/USI-LS-0.4.3.1.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.4.3.1",
     "ksp_version_min": "1.1.0",
@@ -39,7 +39,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.4.3.1/USI-LS_0.4.3.1.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.4.3.1/USI-LS_0.4.3.1.zip",
     "download_size": 1795998,
     "download_hash": {
         "sha1": "1FE572EF39C7D097543EFFC782EE31438E4485C4",

--- a/USI-LS/USI-LS-0.4.4.0.ckan
+++ b/USI-LS/USI-LS-0.4.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.4.4.0",
     "ksp_version_min": "1.1.0",
@@ -39,7 +39,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.4.4.0/USI-LS_0.4.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.4.4.0/USI-LS_0.4.4.0.zip",
     "download_size": 2945398,
     "download_hash": {
         "sha1": "8F983EA90409B0EB83EDDDF99B31E94010430E42",

--- a/USI-LS/USI-LS-0.5.0.0.ckan
+++ b/USI-LS/USI-LS-0.5.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.0.0",
     "ksp_version": "1.2.0",
@@ -38,7 +38,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.0.0/USI-LS_0.5.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.0.0/USI-LS_0.5.0.0.zip",
     "download_size": 3756439,
     "download_hash": {
         "sha1": "25928CBF5A6BB61CD35FB2ACE3744F037A6C2C07",

--- a/USI-LS/USI-LS-0.5.10.0.ckan
+++ b/USI-LS/USI-LS-0.5.10.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.10.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.10.0/USI-LS_0.5.10.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.10.0/USI-LS_0.5.10.0.zip",
     "download_size": 4062829,
     "download_hash": {
         "sha1": "0B64B4ADCD784C1001B4976B94E33675DEB628CA",

--- a/USI-LS/USI-LS-0.5.11.0.ckan
+++ b/USI-LS/USI-LS-0.5.11.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.11.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.11.0/USI-LS_0.5.11.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.11.0/USI-LS_0.5.11.0.zip",
     "download_size": 4062971,
     "download_hash": {
         "sha1": "A27F7120FF8A82EAE08ACBAED5EFD16F34E15A56",

--- a/USI-LS/USI-LS-0.5.12.0.ckan
+++ b/USI-LS/USI-LS-0.5.12.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.12.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.12.0/USI-LS_0.5.12.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.12.0/USI-LS_0.5.12.0.zip",
     "download_size": 4063218,
     "download_hash": {
         "sha1": "53C2803EBA40831E8B87B8AA4F59380EB20965FE",

--- a/USI-LS/USI-LS-0.5.13.0.ckan
+++ b/USI-LS/USI-LS-0.5.13.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.13.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.13.0/USI-LS_0.5.13.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.13.0/USI-LS_0.5.13.0.zip",
     "download_size": 4063282,
     "download_hash": {
         "sha1": "2DE404CD3C5A94B7C0936F072174CD43FAE5B2DE",

--- a/USI-LS/USI-LS-0.5.14.0.ckan
+++ b/USI-LS/USI-LS-0.5.14.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.14.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.14.0/USI-LS_0.5.14.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.14.0/USI-LS_0.5.14.0.zip",
     "download_size": 4081112,
     "download_hash": {
         "sha1": "1C7C142313599BB6E5310AA2420F67E80B52AAB2",

--- a/USI-LS/USI-LS-0.5.15.0.ckan
+++ b/USI-LS/USI-LS-0.5.15.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.15.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.15.0/USI-LS_0.5.15.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.15.0/USI-LS_0.5.15.0.zip",
     "download_size": 4139971,
     "download_hash": {
         "sha1": "399F7B79238171E6DBC12D8E5A3F916B889BE9E0",

--- a/USI-LS/USI-LS-0.5.16.0.ckan
+++ b/USI-LS/USI-LS-0.5.16.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.16.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.16.0/USI-LS_0.5.16.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.16.0/USI-LS_0.5.16.0.zip",
     "download_size": 4140719,
     "download_hash": {
         "sha1": "79A7E8CCE0F87970567BD3014A991DF06E93FD75",

--- a/USI-LS/USI-LS-0.5.17.0.ckan
+++ b/USI-LS/USI-LS-0.5.17.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.17.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.17.0/USI-LS_0.5.17.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.17.0/USI-LS_0.5.17.0.zip",
     "download_size": 4243000,
     "download_hash": {
         "sha1": "EE7AE07AF07C4010E720EF0D185C757175041807",

--- a/USI-LS/USI-LS-0.5.18.0.ckan
+++ b/USI-LS/USI-LS-0.5.18.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.18.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.18.0/USI-LS_0.5.18.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.18.0/USI-LS_0.5.18.0.zip",
     "download_size": 4143051,
     "download_hash": {
         "sha1": "E9DFD609E18D406FCE695DE4B89D7608FF39B98A",

--- a/USI-LS/USI-LS-0.5.19.0.ckan
+++ b/USI-LS/USI-LS-0.5.19.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.19.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.19.0/USI-LS_0.5.19.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.19.0/USI-LS_0.5.19.0.zip",
     "download_size": 4143089,
     "download_hash": {
         "sha1": "422276DF4D8F446E1E4047252EB28BFEE2D2372C",

--- a/USI-LS/USI-LS-0.5.2.0.ckan
+++ b/USI-LS/USI-LS-0.5.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.2.0",
     "ksp_version": "1.2.0",
@@ -41,7 +41,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.2.0/USI-LS_0.5.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.2.0/USI-LS_0.5.2.0.zip",
     "download_size": 3772389,
     "download_hash": {
         "sha1": "60F8BEBCD75DE4202B3A2D54513FBC23527F1373",

--- a/USI-LS/USI-LS-0.5.20.0.ckan
+++ b/USI-LS/USI-LS-0.5.20.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.20.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.20.0/USI-LS_0.5.20.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.20.0/USI-LS_0.5.20.0.zip",
     "download_size": 4143207,
     "download_hash": {
         "sha1": "27AF0A2A76D93F0C902F0CC1F8BCC01BB02D9BF9",

--- a/USI-LS/USI-LS-0.5.21.0.ckan
+++ b/USI-LS/USI-LS-0.5.21.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.21.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.21.0/USI-LS_0.5.21.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.21.0/USI-LS_0.5.21.0.zip",
     "download_size": 4161419,
     "download_hash": {
         "sha1": "D29B88C7597615322A6A8A971D3CFE32B468C293",

--- a/USI-LS/USI-LS-0.5.22.0.ckan
+++ b/USI-LS/USI-LS-0.5.22.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.22.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.22.0/USI-LS_0.5.22.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.22.0/USI-LS_0.5.22.0.zip",
     "download_size": 4161542,
     "download_hash": {
         "sha1": "80A3654B173C0E9F59521154F5E7E9782953E6A8",

--- a/USI-LS/USI-LS-0.5.23.0.ckan
+++ b/USI-LS/USI-LS-0.5.23.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.23.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.23.0/USI-LS_0.5.23.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.23.0/USI-LS_0.5.23.0.zip",
     "download_size": 4163247,
     "download_hash": {
         "sha1": "7C7A7EDD239221ADF7A905ADC81E3999E352B738",

--- a/USI-LS/USI-LS-0.5.3.0.ckan
+++ b/USI-LS/USI-LS-0.5.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.3.0",
     "ksp_version": "1.2.0",
@@ -41,7 +41,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.3.0/USI-LS_0.5.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.3.0/USI-LS_0.5.3.0.zip",
     "download_size": 3772538,
     "download_hash": {
         "sha1": "272EC6148064C5248B6B6EA8EB257C2F8A2205BC",

--- a/USI-LS/USI-LS-0.5.4.0.ckan
+++ b/USI-LS/USI-LS-0.5.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.4.0",
     "ksp_version": "1.2.0",
@@ -41,7 +41,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.4.0/USI-LS_0.5.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.4.0/USI-LS_0.5.4.0.zip",
     "download_size": 4037628,
     "download_hash": {
         "sha1": "3FC04D882F5B708D100EB83C86468F10BA510E30",

--- a/USI-LS/USI-LS-0.5.5.0.ckan
+++ b/USI-LS/USI-LS-0.5.5.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.5.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.5.0/USI-LS_0.5.5.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.5.0/USI-LS_0.5.5.0.zip",
     "download_size": 4041395,
     "download_hash": {
         "sha1": "05BBA8F5D43F8F9956F18DC01667A4D8634CCECB",

--- a/USI-LS/USI-LS-0.5.6.0.ckan
+++ b/USI-LS/USI-LS-0.5.6.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.6.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.6.0/USI-LS_0.5.6.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.6.0/USI-LS_0.5.6.0.zip",
     "download_size": 4061262,
     "download_hash": {
         "sha1": "0F569F9CD2ABEFE25E13D335A3998CA421DD137E",

--- a/USI-LS/USI-LS-0.5.7.0.ckan
+++ b/USI-LS/USI-LS-0.5.7.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.7.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.7.0/USI-LS_0.5.7.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.7.0/USI-LS_0.5.7.0.zip",
     "download_size": 4062580,
     "download_hash": {
         "sha1": "CBD716A74F1EA6FB5E5FDECE2BB3C6FF36C5B306",

--- a/USI-LS/USI-LS-0.5.8.0.ckan
+++ b/USI-LS/USI-LS-0.5.8.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.8.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.8.0/USI-LS_0.5.8.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.8.0/USI-LS_0.5.8.0.zip",
     "download_size": 4062716,
     "download_hash": {
         "sha1": "57C6E34BC37320D9A9DAD82507F5373DE8B9B8F0",

--- a/USI-LS/USI-LS-0.5.9.0.ckan
+++ b/USI-LS/USI-LS-0.5.9.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/105202-105",
-        "repository": "https://github.com/BobPalmer/USI-LS"
+        "repository": "https://github.com/UmbraSpaceIndustries/USI-LS"
     },
     "version": "0.5.9.0",
     "ksp_version_min": "1.2.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/USI-LS/releases/download/0.5.9.0/USI-LS_0.5.9.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/USI-LS/releases/download/0.5.9.0/USI-LS_0.5.9.0.zip",
     "download_size": 4062793,
     "download_hash": {
         "sha1": "E0D9616F700FA4CC5C2317DB6F86E2F809E5EE86",


### PR DESCRIPTION
Follow-up of #2507, #2508, #2509, #2510
Updating the repo and download links of USI-LS (USI Life Support)