### PR TITLE
Fix historical CryoEngine licenses

### DIFF
--- a/CryoEngines/CryoEngines-1-0.4.5.ckan
+++ b/CryoEngines/CryoEngines-1-0.4.5.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.4.6.ckan
+++ b/CryoEngines/CryoEngines-1-0.4.6.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.0.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.0.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.1.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.1.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.10.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.10.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.11.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.11.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.2.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.2.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.3.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.3.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.4.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.4.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.5.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.5.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.6.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.6.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.7.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.7.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.8.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.8.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.5.9.ckan
+++ b/CryoEngines/CryoEngines-1-0.5.9.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.6.0.ckan
+++ b/CryoEngines/CryoEngines-1-0.6.0.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.6.1.ckan
+++ b/CryoEngines/CryoEngines-1-0.6.1.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.6.2.ckan
+++ b/CryoEngines/CryoEngines-1-0.6.2.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.6.3.ckan
+++ b/CryoEngines/CryoEngines-1-0.6.3.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.6.4.ckan
+++ b/CryoEngines/CryoEngines-1-0.6.4.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",

--- a/CryoEngines/CryoEngines-1-0.6.5.ckan
+++ b/CryoEngines/CryoEngines-1-0.6.5.ckan
@@ -4,7 +4,7 @@
     "name": "Cryogenic Engines",
     "abstract": "High efficiency chemical engines",
     "author": "Nertea",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/106089-112-cryogenic-engines-high-isp-chemical-rockets-16-may-112-fixes/",
         "spacedock": "https://spacedock.info/mod/709/Cryogenic%20Engines",


### PR DESCRIPTION
## Background

Up to its 0.4.3 release, `CryoEngines` was under the CC-BY-NC-SA-4.0 license, see the `readme.txt`:

https://spacedock.info/mod/709/Cryogenic%20Engines/download/0.4.3

As of the 0.4.5 release, the art assets were All Rights Reserved, again see the `readme.txt`:

https://spacedock.info/mod/709/Cryogenic%20Engines/download/0.4.5

This was specifically announced on the forum as well:

https://forum.kerbalspaceprogram.com/index.php?/topic/106089-112x-cryogenic-engines-liquid-hydrogen-and-methane-rockets-october-25-2021/page/31/&tab=comments#comment-2931998

## Problem

This change was reflected in CKAN about 2 years later, in KSP-CKAN/NetKAN#7157 when the mod was moved to a metanetkan, which has had the license field as `restricted` since it was created. The first version with the new license in the CKAN metadata was 0.6.6, meaning that 0.4.5–0.6.5 have out of date licensing metadata.

The main SpaceDock entry itself also has not been updated, but forum/Discord user Spaceman Spiff is on the case to notify Nertea about the oversight. (I found out about this by being tagged in a Discord discussion about it.)

## Changes

Now versions 0.4.5–0.6.5 are set to the `restricted` license.