### PR TITLE
Update MalemuteRover links after repo move

### DIFF
--- a/MalemuteRover/MalemuteRover-0.1.4.0.ckan
+++ b/MalemuteRover/MalemuteRover-0.1.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139668-112",
-        "repository": "https://github.com/BobPalmer/Malemute"
+        "repository": "https://github.com/UmbraSpaceIndustries/Malemute"
     },
     "version": "0.1.4.0",
     "ksp_version_min": "1.1.0",
@@ -35,7 +35,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Malemute/releases/download/0.1.4.0/Malemute_0.1.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Malemute/releases/download/0.1.4.0/Malemute_0.1.4.0.zip",
     "download_size": 26355212,
     "download_hash": {
         "sha1": "23CE0F954C1CA19F9DDB8848845033E4DCD8CA0B",

--- a/MalemuteRover/MalemuteRover-0.2.0.0.ckan
+++ b/MalemuteRover/MalemuteRover-0.2.0.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139668-112",
-        "repository": "https://github.com/BobPalmer/Malemute"
+        "repository": "https://github.com/UmbraSpaceIndustries/Malemute"
     },
     "version": "0.2.0.0",
     "ksp_version": "1.2.0",
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Malemute/releases/download/0.2.0.0/Malemute_0.2.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Malemute/releases/download/0.2.0.0/Malemute_0.2.0.0.zip",
     "download_size": 7096881,
     "download_hash": {
         "sha1": "7B739F849E295E346F05330952BC3814FB0008D5",

--- a/MalemuteRover/MalemuteRover-0.2.1.0.ckan
+++ b/MalemuteRover/MalemuteRover-0.2.1.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139668-112",
-        "repository": "https://github.com/BobPalmer/Malemute"
+        "repository": "https://github.com/UmbraSpaceIndustries/Malemute"
     },
     "version": "0.2.1.0",
     "ksp_version": "1.2.0",
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Malemute/releases/download/0.2.1.0/Malemute_0.2.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Malemute/releases/download/0.2.1.0/Malemute_0.2.1.0.zip",
     "download_size": 7097177,
     "download_hash": {
         "sha1": "AACCEA33D4B18F8F951C4492BFCA8C7D2A4C1689",

--- a/MalemuteRover/MalemuteRover-0.2.2.0.ckan
+++ b/MalemuteRover/MalemuteRover-0.2.2.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139668-112",
-        "repository": "https://github.com/BobPalmer/Malemute"
+        "repository": "https://github.com/UmbraSpaceIndustries/Malemute"
     },
     "version": "0.2.2.0",
     "ksp_version": "1.2.0",
@@ -34,7 +34,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Malemute/releases/download/0.2.2.0/Malemute_0.2.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Malemute/releases/download/0.2.2.0/Malemute_0.2.2.0.zip",
     "download_size": 7098047,
     "download_hash": {
         "sha1": "4BBE6BEBB88021A5B3E362172444B147357A4B7D",

--- a/MalemuteRover/MalemuteRover-0.2.3.0.ckan
+++ b/MalemuteRover/MalemuteRover-0.2.3.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139668-112",
-        "repository": "https://github.com/BobPalmer/Malemute"
+        "repository": "https://github.com/UmbraSpaceIndustries/Malemute"
     },
     "version": "0.2.3.0",
     "ksp_version_min": "1.2.0",
@@ -35,7 +35,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Malemute/releases/download/0.2.3.0/Malemute_0.2.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Malemute/releases/download/0.2.3.0/Malemute_0.2.3.0.zip",
     "download_size": 7103307,
     "download_hash": {
         "sha1": "6EEA27178AE0CCB370ECD9DF7AE833D2389AB512",

--- a/MalemuteRover/MalemuteRover-0.2.4.0.ckan
+++ b/MalemuteRover/MalemuteRover-0.2.4.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139668-112",
-        "repository": "https://github.com/BobPalmer/Malemute"
+        "repository": "https://github.com/UmbraSpaceIndustries/Malemute"
     },
     "version": "0.2.4.0",
     "ksp_version_min": "1.2.0",
@@ -35,7 +35,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Malemute/releases/download/0.2.4.0/Malemute_0.2.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Malemute/releases/download/0.2.4.0/Malemute_0.2.4.0.zip",
     "download_size": 7135690,
     "download_hash": {
         "sha1": "E845D9CBD0A5E6AC4ABBA2D7BCAAC37FB22D8486",

--- a/MalemuteRover/MalemuteRover-0.2.5.0.ckan
+++ b/MalemuteRover/MalemuteRover-0.2.5.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139668-112",
-        "repository": "https://github.com/BobPalmer/Malemute"
+        "repository": "https://github.com/UmbraSpaceIndustries/Malemute"
     },
     "version": "0.2.5.0",
     "ksp_version_min": "1.2.0",
@@ -35,7 +35,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Malemute/releases/download/0.2.5.0/Malemute_0.2.5.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Malemute/releases/download/0.2.5.0/Malemute_0.2.5.0.zip",
     "download_size": 7136767,
     "download_hash": {
         "sha1": "1AA7CA07E27D810AC548CE868112627B6C46F8E2",

--- a/MalemuteRover/MalemuteRover-0.2.6.0.ckan
+++ b/MalemuteRover/MalemuteRover-0.2.6.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139668-112",
-        "repository": "https://github.com/BobPalmer/Malemute"
+        "repository": "https://github.com/UmbraSpaceIndustries/Malemute"
     },
     "version": "0.2.6.0",
     "ksp_version_min": "1.2.0",
@@ -35,7 +35,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Malemute/releases/download/0.2.6.0/Malemute_0.2.6.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Malemute/releases/download/0.2.6.0/Malemute_0.2.6.0.zip",
     "download_size": 7140922,
     "download_hash": {
         "sha1": "ED0A0F4C83D68880C153F357CACB8055199423F0",

--- a/MalemuteRover/MalemuteRover-0.2.7.0.ckan
+++ b/MalemuteRover/MalemuteRover-0.2.7.0.ckan
@@ -8,7 +8,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139668-112",
-        "repository": "https://github.com/BobPalmer/Malemute"
+        "repository": "https://github.com/UmbraSpaceIndustries/Malemute"
     },
     "version": "0.2.7.0",
     "ksp_version_min": "1.2.0",
@@ -35,7 +35,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Malemute/releases/download/0.2.7.0/Malemute_0.2.7.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Malemute/releases/download/0.2.7.0/Malemute_0.2.7.0.zip",
     "download_size": 7141554,
     "download_hash": {
         "sha1": "E7B4DED5AFC16AB3B6203C17828992C9F76AAC10",


### PR DESCRIPTION
Follow-up of #2522, #2521, #2520, #2512, #2511, #2510, #2509, #2508, #2507
Updating the repo and download links of MalemuteRover

This one had the metnetkan file [updated in 2017](https://github.com/UmbraSpaceIndustries/CKAN/commit/33681b612d6bcb2fa467632f19592bb1ea7949a4#diff-e2207c103227179d0f342e58a3998a93f2a25d4c12e0132322100e5b3a1b4e14) already, so it was only a handful of older releases with pre-move repo links