### PR TITLE
Update current DLC compat

### DIFF
--- a/BreakingGround-DLC/BreakingGround-DLC-1.7.1.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.7.1.ckan
@@ -5,7 +5,8 @@
     "abstract":     "The second expansion pack adds new science-collecting equipment to deploy on your missions, surface features to be investigated scattered across distant planets, and a wealth of new robotic parts for players to test their creativity with",
     "author":       "SQUAD",
     "version":      "1.7.1",
-    "ksp_version":  "1.12.2",
+    "ksp_version_min": "1.12.2",
+    "ksp_version_max": "1.12.3",
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {

--- a/MakingHistory-DLC/MakingHistory-DLC-1.12.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.12.1.ckan
@@ -5,7 +5,8 @@
     "abstract":     "The first expansion pack adds an immersive Mission Builder, a History Pack featuring missions inspired by historical events, and a wealth of new parts for players to use across their KSP experience",
     "author":       "SQUAD",
     "version":      "1.12.1",
-    "ksp_version":  "1.12.2",
+    "ksp_version_min": "1.12.2",
+    "ksp_version_max": "1.12.3",
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {


### PR DESCRIPTION
As far as I can tell, KSP 1.12.3 shipped without updating the DLCs, so the existing versions must be compatible with it.