### PR TITLE
Remove CustomBarnKit depends from FacilityTree

### DIFF
--- a/FacilityTree/FacilityTree-1-V1.ckan
+++ b/FacilityTree/FacilityTree-1-V1.ckan
@@ -27,9 +27,6 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "CustomBarnKit"
         }
     ],
     "recommends": [

--- a/FacilityTree/FacilityTree-1-V2.ckan
+++ b/FacilityTree/FacilityTree-1-V2.ckan
@@ -27,9 +27,6 @@
     "depends": [
         {
             "name": "ModuleManager"
-        },
-        {
-            "name": "CustomBarnKit"
         }
     ],
     "recommends": [


### PR DESCRIPTION
Historical extension of KSP-CKAN/NetKAN#8929.

https://spacedock.info/mod/2918/FacilityTree#changelog

![image](https://user-images.githubusercontent.com/1559108/147530205-39eb124e-1f5a-4d75-9728-cf8c00983737.png)
