### PR TITLE
Restore sunnypunny's forum thread, add curse links

### DIFF
--- a/FacilityTree/FacilityTree-1-V2.1.ckan
+++ b/FacilityTree/FacilityTree-1-V2.1.ckan
@@ -8,6 +8,8 @@
     "ksp_version": "1.12.3",
     "license": "MIT",
     "resources": {
+        "curse": "https://www.curseforge.com/kerbal/ksp-mods/facilitytree",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/205814-112x-career-rebalanced-modpack/",
         "spacedock": "https://spacedock.info/mod/2918/FacilityTree",
         "repository": "https://github.com/sunnypunny/FacilityTree",
         "bugtracker": "https://github.com/sunnypunny/FacilityTree/issues",

--- a/KerbalHero/KerbalHero-1-V2.1.ckan
+++ b/KerbalHero/KerbalHero-1-V2.1.ckan
@@ -8,7 +8,8 @@
     "ksp_version": "1.12.3",
     "license": "MIT",
     "resources": {
-        "homepage": "https://www.curseforge.com/kerbal/ksp-mods/kerbalhero",
+        "curse": "https://www.curseforge.com/kerbal/ksp-mods/kerbalhero",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/205814-112x-career-rebalanced-modpack/",
         "spacedock": "https://spacedock.info/mod/2916/KerbalHero",
         "repository": "https://github.com/sunnypunny/KerbalHero",
         "bugtracker": "https://github.com/sunnypunny/KerbalHero/issues",

--- a/KerbalWitchery/KerbalWitchery-1-V1.ckan
+++ b/KerbalWitchery/KerbalWitchery-1-V1.ckan
@@ -8,6 +8,8 @@
     "ksp_version": "1.12.3",
     "license": "MIT",
     "resources": {
+        "curse": "https://www.curseforge.com/kerbal/ksp-mods/kerbalwitchery",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/205814-112x-career-rebalanced-modpack/",
         "spacedock": "https://spacedock.info/mod/2917/KerbalWitchery",
         "repository": "https://github.com/sunnypunny/KerbalWitchery",
         "bugtracker": "https://github.com/sunnypunny/KerbalWitchery/issues",

--- a/OpenTree/OpenTree-1-v2.5.5.ckan
+++ b/OpenTree/OpenTree-1-v2.5.5.ckan
@@ -11,7 +11,8 @@
     "ksp_version": "1.12.2",
     "license": "MIT",
     "resources": {
-        "homepage": "https://www.curseforge.com/kerbal/ksp-mods/opentree",
+        "curse": "https://www.curseforge.com/kerbal/ksp-mods/opentree",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/205814-112x-kerbalhero-facilitytree-kerbalwitchery-opentree/",
         "spacedock": "https://spacedock.info/mod/2919/OpenTree",
         "repository": "https://github.com/sunnypunny/OpenTree",
         "bugtracker": "https://github.com/sunnypunny/OpenTree/issues",


### PR DESCRIPTION
These mods lost some metadata in the process of the author partially removing them by renaming them and replacing them with blank downloads:

https://github.com/KSP-CKAN/CKAN-meta/compare/1682c8ad98...14aae3d

Now that KSP-CKAN/NetKAN#8940 has frozen these mods, these changes are reverted and the new `resources.curse` links are added, so users will still be able to find the original forum thread and see that it has been cleared out, and also find the new homes on Curseforge.