### PR TITLE
Fix historical KerbalImprovedSaveSystem compat

### DIFF
--- a/KerbalImprovedSaveSystem/KerbalImprovedSaveSystem-v2.1.0.ckan
+++ b/KerbalImprovedSaveSystem/KerbalImprovedSaveSystem-v2.1.0.ckan
@@ -12,7 +12,8 @@
         "x_screenshot": "https://spacedock.info/content/Aerospike_3976/Kerbal_Improved_Save_System/Kerbal_Improved_Save_System-1479679709.6126864.jpg"
     },
     "version": "v2.1.0",
-    "ksp_version": "1.2.2",
+    "ksp_version_min": "1.1.3",
+    "ksp_version_max": "1.2.2",
     "download": "https://spacedock.info/mod/583/Kerbal%20Improved%20Save%20System/download/2.1.0",
     "download_size": 14815,
     "download_hash": {


### PR DESCRIPTION
See KSP-CKAN/NetKAN#8979, this mod's netkan had an override for this version that was failing to apply. Now the intended compatibility is set.