### PR TITLE
Restore HazardTanks depends on ProceduralParts

### DIFF
--- a/HazardTanksTextures/HazardTanksTextures-1.0.ckan
+++ b/HazardTanksTextures/HazardTanksTextures-1.0.ckan
@@ -22,9 +22,7 @@
     "depends": [
         {
             "name": "VensStylePPTextures"
-        }
-    ],
-    "suggests": [
+        },
         {
             "name": "ProceduralParts"
         }


### PR DESCRIPTION
## Problem

`HazardTanksTextures` contains textures to be used by `ProceduralParts`, but it only `suggests` PP rather than `depends`.

## Cause

This seems to have been done in KSP-CKAN/NetKAN#5106 to bypass installation errors from Travis. The validation script at that time installed on KSP 1.2.2, but ProceduralParts was only compatible up to 1.2.1 until KSP-CKAN/NetKAN#5448. We don't have the logs from that time, but we can see that the first commit failed to validate, and the second commit moved PP from depends to suggests:

![image](https://user-images.githubusercontent.com/1559108/152701309-84f63c42-23cd-4f1b-8cdc-fee3d3e2b3a2.png)

But this doesn't reflect the intended relationship between these modules.

## Changes

Now `HazardTanksTextures` depends on `ProceduralParts` again.

Fixes KSP-CKAN/NetKAN#8998. (The part of that issue about Ven's Revamp Style Textures is not applicable and already working as intended.)