### PR TITLE
Revert compat of allista's mods

### DIFF
--- a/AT-Utils/AT-Utils-v1.9.6.ckan
+++ b/AT-Utils/AT-Utils-v1.9.6.ckan
@@ -7,8 +7,7 @@
         "allista"
     ],
     "version": "v1.9.6",
-    "ksp_version_min": "1.9.0",
-    "ksp_version_max": "1.10.0",
+    "ksp_version": "1.10.0",
     "license": "MIT",
     "resources": {
         "homepage": "https://github.com/allista/AT_Utils",

--- a/ConfigurableContainers/ConfigurableContainers-2.6.1.ckan
+++ b/ConfigurableContainers/ConfigurableContainers-2.6.1.ckan
@@ -7,8 +7,7 @@
         "allista"
     ],
     "version": "2.6.1",
-    "ksp_version_min": "1.9.0",
-    "ksp_version_max": "1.10.0",
+    "ksp_version": "1.10.0",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/150104-12-configurable-containers",

--- a/ThrottleControlledAvionics/ThrottleControlledAvionics-v3.7.2.ckan
+++ b/ThrottleControlledAvionics/ThrottleControlledAvionics-v3.7.2.ckan
@@ -7,8 +7,7 @@
         "allista"
     ],
     "version": "v3.7.2",
-    "ksp_version_min": "1.9.0",
-    "ksp_version_max": "1.10.0",
+    "ksp_version": "1.10.0",
     "license": "CC-BY-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/97154-throttle-controlled-avionics",


### PR DESCRIPTION
These commits happened because the remote version files were updated to reflect new versions that haven't been created yet:

- da8386e3c9175b8127c109b1220d4c5b73badfa7, see KSP-CKAN/NetKAN#8085 and allista/ConfigurableContainers#40
- a1118defe0a68bf71f1c01f2d8773a0302a10155, see KSP-CKAN/NetKAN#8085 and allista/AT_Utils#24
- c555650a5d910ac1e21f551376aa1e3f5a86a1b8, see KSP-CKAN/NetKAN#8140 and allista/ThrottleControlledAvionics#102

This PR reverts that so the correct compatibility is restored. Merge after the new versions are indexed so the bot doesn't re-apply the bad changes.