### PR TITLE
Revert AVP compat

### DIFF
--- a/AstronomersVisualPack/AstronomersVisualPack-3-v4.11.ckan
+++ b/AstronomersVisualPack/AstronomersVisualPack-3-v4.11.ckan
@@ -6,7 +6,7 @@
     "author": "themaster402",
     "version": "3:v4.11",
     "ksp_version_min": "1.11.0",
-    "ksp_version_max": "1.11.9",
+    "ksp_version_max": "1.12.9",
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*",


### PR DESCRIPTION
1. themaster402/AstronomersVisualPack#23 updated AVP's remote version file to reflect the correct compatibility
2. https://github.com/themaster402/AstronomersVisualPack/commit/05059fa817597b150bc479f6e3fa72aa2a3ebac5 changed the `VERSION` property before the referenced version was released, so those changes were lost in e0718307b1a12373d9e951e42e8f82dac6d2948c
3. After the next version is released, merging this PR will fix it