### PR TITLE
Fix RocketSoundEnhancement Default Configs name typo

### DIFF
--- a/RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.1.ckan
+++ b/RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.1.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "RocketSoundEnhancement-Config-Default",
-    "name": "Rocket Sound Enhancment - Default Configs",
+    "name": "Rocket Sound Enhancement - Default",
     "abstract": "RSE sounds for stock engines, wheels, decouplers, and more",
     "author": "ensou04",
     "version": "0.5.1",

--- a/RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.2.ckan
+++ b/RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.2.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "RocketSoundEnhancement-Config-Default",
-    "name": "Rocket Sound Enhancment - Default Configs",
+    "name": "Rocket Sound Enhancement - Default",
     "abstract": "RSE sounds for stock engines, wheels, decouplers, and more",
     "author": "ensou04",
     "version": "0.5.2",

--- a/RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.3.ckan
+++ b/RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.3.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "RocketSoundEnhancement-Config-Default",
-    "name": "Rocket Sound Enhancment - Default Configs",
+    "name": "Rocket Sound Enhancement - Default",
     "abstract": "RSE sounds for stock engines, wheels, decouplers, and more",
     "author": "ensou04",
     "version": "0.5.3",

--- a/RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.4.ckan
+++ b/RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.4.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "RocketSoundEnhancement-Config-Default",
-    "name": "Rocket Sound Enhancment - Default Configs",
+    "name": "Rocket Sound Enhancement - Default",
     "abstract": "RSE sounds for stock engines, wheels, decouplers, and more",
     "author": "ensou04",
     "version": "0.5.4",


### PR DESCRIPTION
This mod's `name` had a typo in it. Now it's fixed.
"Configs" is removed from the name as well as per author request.