### PR TITLE
Fix historical MechJeb compat

### DIFF
--- a/MechJeb2/MechJeb2-2.14.0.0.ckan
+++ b/MechJeb2/MechJeb2-2.14.0.0.ckan
@@ -5,7 +5,7 @@
     "abstract": "Anatid Robotics and Multiversal Mechatronics proudly presents the first flight assistant autopilot: MechJeb",
     "author": "Sarbian",
     "version": "2.14.0.0",
-    "ksp_version_min": "1.8",
+    "ksp_version_min": "1.12.0",
     "ksp_version_max": "1.12.90",
     "license": "GPL-3.0",
     "resources": {


### PR DESCRIPTION
This is the historical part of KSP-CKAN/NetKAN#9059.
An old MechJeb version needs to have its min compat bumped up to 1.12.