### PR TITLE
Fix more historical MechJeb compat

### DIFF
--- a/MechJeb2/MechJeb2-2.8.3.0.ckan
+++ b/MechJeb2/MechJeb2-2.8.3.0.ckan
@@ -11,7 +11,8 @@
         "ci": "https://ksp.sarbian.com/jenkins/job/MechJeb2-Release/"
     },
     "version": "2.8.3.0",
-    "ksp_version": "1.6",
+    "ksp_version_min": "1.4",
+    "ksp_version_max": "1.6",
     "install": [
         {
             "find": "MechJeb2",


### PR DESCRIPTION
After #2634 I double checked the overrides for MechJeb, and sure enough the one from https://github.com/KSP-CKAN/NetKAN/commit/74a8335b126a38d133ffe030b0d32840dd121036 was never applied to CKAN-meta because there was already a newer version.
Now 2.8.3.0 is updated.