### PR TITLE
Update PartWizardContinued historical compat

### DIFF
--- a/PartWizardContinued/PartWizardContinued-1.3.8.3.ckan
+++ b/PartWizardContinued/PartWizardContinued-1.3.8.3.ckan
@@ -5,7 +5,7 @@
     "abstract": "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.  It provides a list of parts with part highlighting for easier identification, allows deleting of parts from the list on eligible parts, allows complete control of symmetry on eligible parts, allows selecting parts for Action Group assignment, shows either all parts or only those that are hidden from the editor's Parts List. (Helpful in finding obsolete parts when mod authors make updates.) and shows unavailable parts in career modes with options to buy one or all necessary parts for launch.",
     "author": "linuxgurugamer",
     "version": "1.3.8.3",
-    "ksp_version_min": "1.8.0",
+    "ksp_version_min": "1.12.0",
     "ksp_version_max": "1.12.1",
     "license": "BSD-3-clause",
     "resources": {


### PR DESCRIPTION
Fixes KSP-CKAN/NetKAN#9082. See discussion on that issue for background on why we think this makes sense; to sum up, this release targeted .NET Framework v4.7.2, and the release announcement can be interpreted to mean it was only compatible with KSP 1.12 and up.