### PR TITLE
Limit CraftManager 1.1.5 compat to 1.4-1.7

### DIFF
--- a/CraftManager/CraftManager-1.1.5.ckan
+++ b/CraftManager/CraftManager-1.1.5.ckan
@@ -12,6 +12,7 @@
     },
     "version": "1.1.5",
     "ksp_version_min": "1.4",
+    "ksp_version_max": "1.7",
     "depends": [
         {
             "name": "KXAPI"


### PR DESCRIPTION
Follow-up to https://github.com/KSP-CKAN/NetKAN/pull/9110
I just noticed that the previous release also had no max KSP version set, but is supposed to be 1.4-1.7 only according to release notes.