### PR TITLE
Require BackgroundResources for DeepFreeze

### DIFF
--- a/DeepFreeze/DeepFreeze-V0.29.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.29.0.ckan
@@ -37,6 +37,9 @@
         },
         {
             "name": "CommunityResourcePack"
+        },
+        {
+            "name": "BackgroundResources"
         }
     ],
     "recommends": [
@@ -57,9 +60,6 @@
         },
         {
             "name": "AmpYearPowerManager"
-        },
-        {
-            "name": "BackgroundResources"
         }
     ],
     "suggests": [

--- a/DeepFreeze/DeepFreeze-V0.30.0.0.ckan
+++ b/DeepFreeze/DeepFreeze-V0.30.0.0.ckan
@@ -39,6 +39,9 @@
         },
         {
             "name": "CommunityResourcePack"
+        },
+        {
+            "name": "BackgroundResources"
         }
     ],
     "recommends": [
@@ -59,9 +62,6 @@
         },
         {
             "name": "AmpYearPowerManager"
-        },
-        {
-            "name": "BackgroundResources"
         }
     ],
     "suggests": [


### PR DESCRIPTION
Historical component of KSP-CKAN/NetKAN#9126, author confirmed BackgroundResources is supposed to be a dependency.