### PR TITLE
KHNS Beta-1.1 already shipped with a full Scatterer config & sunflare

### DIFF
--- a/KerbolsHumbleNeighboringStars/KerbolsHumbleNeighboringStars-1-Beta-1.1.ckan
+++ b/KerbolsHumbleNeighboringStars/KerbolsHumbleNeighboringStars-1-Beta-1.1.ckan
@@ -17,6 +17,10 @@
         "config",
         "planet-pack"
     ],
+    "provides": [
+        "Scatterer-config",
+        "Scatterer-sunflare"
+    ],
     "depends": [
         {
             "name": "Kopernicus"


### PR DESCRIPTION
Backport of https://github.com/KSP-CKAN/NetKAN/pull/9128