### PR TITLE
Fix historical MechJeb2 download

### DIFF
--- a/MechJeb2/MechJeb2-2.12.3.0.ckan
+++ b/MechJeb2/MechJeb2-2.12.3.0.ckan
@@ -36,11 +36,11 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://ksp.sarbian.com/jenkins/job/MechJeb2-Release/33/artifact/MechJeb2-2.12.3.0.zip",
-    "download_size": 3959240,
+    "download": "https://ksp.sarbian.com/jenkins/job/MechJeb2-Release/32/artifact/MechJeb2-2.12.3.0.zip",
+    "download_size": 3959238,
     "download_hash": {
-        "sha1": "A9D6313FCF9A8D1D6E0F90531F946B7F7F790A7A",
-        "sha256": "38F647962F04C21212353C6EB60A1EE903CEF2575E99FB6684B70461ACFE58D8"
+        "sha1": "4E5196BDBD815401BE51F85EBCD9145FD147A263",
+        "sha256": "089FF399300D96C2BC9A9DE5AEF23F9BB9C93DAAD8765800C97E428C22349FE9"
     },
     "download_content_type": "application/zip",
     "release_date": "2022-03-31T16:10:04.92Z",


### PR DESCRIPTION
## Problem

An old version of MechJeb has a download link that's a 404 now.

![image](https://user-images.githubusercontent.com/1559108/171279072-828088b1-e736-40da-94a0-31144a186fdf.png)

## Cause

I guess @sarbian removed that build?

https://ksp.sarbian.com/jenkins/job/MechJeb2-Release/33/

These seem to be the ones that are left:

![image](https://user-images.githubusercontent.com/1559108/171278754-ad12d10a-889e-4662-bfb8-30c487906244.png)

https://ksp.sarbian.com/jenkins/job/MechJeb2-Release/

## Changes

Now the download is switched to the previous build, which was for the same version: 

https://ksp.sarbian.com/jenkins/job/MechJeb2-Release/32/
