### PR TITLE
Filter game DLL from historical RocketEmporium

### DIFF
--- a/RocketEmporium/RocketEmporium-v1.8.3.ckan
+++ b/RocketEmporium/RocketEmporium-v1.8.3.ckan
@@ -16,6 +16,15 @@
             "name": "AnimatedAttachment"
         }
     ],
+    "install": [
+        {
+            "find": "RocketEmporium",
+            "install_to": "GameData",
+            "filter": [
+                "TDx.TDxInput.dll"
+            ]
+        }
+    ],
     "download": "https://github.com/KSPKatten/RocketEmporium/releases/download/v1.8.3/RocketEmporium_v1.8.3.zip",
     "download_size": 3079630,
     "download_hash": {


### PR DESCRIPTION
This is the historical counterpart of KSP-CKAN/NetKAN#9144. One old version of this mod contains an extra DLL that isn't supposed to be there. Now it's filtered out.