### PR TITLE
Fix historical Karbonite download URLs

### DIFF
--- a/Karbonite/Karbonite-0.4.4.ckan
+++ b/Karbonite/Karbonite-0.4.4.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/87335",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "0.4.4",
     "ksp_version": "0.25",
@@ -44,7 +44,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.4.4/Karbonite_0.4.4.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.4.4/Karbonite_0.4.4.zip",
     "download_size": 39015866,
     "download_hash": {
         "sha1": "BA893BD9135251EE445D913F148E33CA3F7C7873",

--- a/Karbonite/Karbonite-0.6.0.ckan
+++ b/Karbonite/Karbonite-0.6.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/87335",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "0.6.0",
     "ksp_version_min": "1.0.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.6.0/Karbonite_0.6.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.6.0/Karbonite_0.6.0.zip",
     "download_size": 26488108,
     "download_hash": {
         "sha1": "06E50237C7B92BF9EF4963B1CC16CCE9C165C8D4",

--- a/Karbonite/Karbonite-0.6.1.ckan
+++ b/Karbonite/Karbonite-0.6.1.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/87335",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "0.6.1",
     "ksp_version_min": "1.0.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.6.1/Karbonite_0.6.1.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.6.1/Karbonite_0.6.1.zip",
     "download_size": 16601070,
     "download_hash": {
         "sha1": "33723B3BF45FF5AF7FCA88E1FF539146C3D5692C",

--- a/Karbonite/Karbonite-0.6.2.ckan
+++ b/Karbonite/Karbonite-0.6.2.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/89401",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "0.6.2",
     "ksp_version_min": "1.0.2",
@@ -42,7 +42,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.6.2/Karbonite_0.6.2.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.6.2/Karbonite_0.6.2.zip",
     "download_size": 16626552,
     "download_hash": {
         "sha1": "E8E30359F08B2F84CE6BC6D7CB0B4D45CCD8E96B",

--- a/Karbonite/Karbonite-0.6.3.ckan
+++ b/Karbonite/Karbonite-0.6.3.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/89401",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "0.6.3",
     "ksp_version_min": "1.0.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.6.3/Karbonite_0.6.3.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.6.3/Karbonite_0.6.3.zip",
     "download_size": 16632653,
     "download_hash": {
         "sha1": "C18C1E53D3FED91BD5AED2FDA57B8B3891E95F02",

--- a/Karbonite/Karbonite-0.6.4.ckan
+++ b/Karbonite/Karbonite-0.6.4.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/89401",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "0.6.4",
     "ksp_version_min": "1.0.0",
@@ -42,7 +42,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.6.4/Karbonite_0.6.4.ZIP",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.6.4/Karbonite_0.6.4.ZIP",
     "download_size": 20904190,
     "download_hash": {
         "sha1": "CEA4EE43187E73CB67FD7B834630D3FE757044A3",

--- a/Karbonite/Karbonite-1-0.10.0.0.ckan
+++ b/Karbonite/Karbonite-1-0.10.0.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.10.0.0",
     "ksp_version_min": "1.3.1",
@@ -59,7 +59,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.10.0.0/Karbonite_0.10.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.10.0.0/Karbonite_0.10.0.0.zip",
     "download_size": 43391004,
     "download_hash": {
         "sha1": "70BEE195E55D64C75E6738CE296A9C76995794B5",

--- a/Karbonite/Karbonite-1-0.10.1.0.ckan
+++ b/Karbonite/Karbonite-1-0.10.1.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.10.1.0",
     "ksp_version_min": "1.3.1",
@@ -59,7 +59,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.10.1.0/Karbonite_0.10.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.10.1.0/Karbonite_0.10.1.0.zip",
     "download_size": 43405833,
     "download_hash": {
         "sha1": "F2EF52C34D49342B59809711C37A88D2590E124F",

--- a/Karbonite/Karbonite-1-0.11.0.0.ckan
+++ b/Karbonite/Karbonite-1-0.11.0.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.11.0.0",
     "ksp_version_min": "1.4.0",
@@ -59,7 +59,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.11.0.0/Karbonite_0.11.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.11.0.0/Karbonite_0.11.0.0.zip",
     "download_size": 43405916,
     "download_hash": {
         "sha1": "1B9062B55E039461C60CDFF4E56D086C8C550397",

--- a/Karbonite/Karbonite-1-0.12.0.0.ckan
+++ b/Karbonite/Karbonite-1-0.12.0.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.12.0.0",
     "ksp_version_min": "1.4.0",
@@ -59,7 +59,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.12.0.0/Karbonite_0.12.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.12.0.0/Karbonite_0.12.0.0.zip",
     "download_size": 43405539,
     "download_hash": {
         "sha1": "57FC11FD4776C6F68778DA8C93E9B4F9983FD14D",

--- a/Karbonite/Karbonite-1-0.6.5.0.ckan
+++ b/Karbonite/Karbonite-1-0.6.5.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/89401",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.6.5.0",
     "ksp_version_min": "1.0.0",
@@ -45,7 +45,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.6.5.0/Karbonite_0.6.5.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.6.5.0/Karbonite_0.6.5.0.zip",
     "download_size": 25486159,
     "download_hash": {
         "sha1": "4ADD16518629A71420C9A02A7C04F5E1EA225C1E",

--- a/Karbonite/Karbonite-1-0.6.6.0.ckan
+++ b/Karbonite/Karbonite-1-0.6.6.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/89401",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.6.6.0",
     "ksp_version_min": "1.0.0",
@@ -45,7 +45,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.6.6.0/Karbonite_0.6.6.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.6.6.0/Karbonite_0.6.6.0.zip",
     "download_size": 25490195,
     "download_hash": {
         "sha1": "EC4B8751F79F15CCA9B4CFEF70FCFCC206792D20",

--- a/Karbonite/Karbonite-1-0.6.7.0.ckan
+++ b/Karbonite/Karbonite-1-0.6.7.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.6.7.0",
     "ksp_version_min": "1.0.0",
@@ -45,7 +45,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.6.7.0/Karbonite_0.6.7.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.6.7.0/Karbonite_0.6.7.0.zip",
     "download_size": 25502221,
     "download_hash": {
         "sha1": "D240A3324E20D5B447305F89AA6372BD9E9AB7DA",

--- a/Karbonite/Karbonite-1-0.6.8.0.ckan
+++ b/Karbonite/Karbonite-1-0.6.8.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.6.8.0",
     "ksp_version_min": "1.0.0",
@@ -45,7 +45,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.6.8.0/Karbonite_0.6.8.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.6.8.0/Karbonite_0.6.8.0.zip",
     "download_size": 26317971,
     "download_hash": {
         "sha1": "9B1814C46DE88953B8489AFE64AABB1B44A66B0A",

--- a/Karbonite/Karbonite-1-0.7.0.0.ckan
+++ b/Karbonite/Karbonite-1-0.7.0.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.7.0.0",
     "ksp_version": "1.1.0",
@@ -49,7 +49,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.7.0.0/Karbonite_0.7.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.7.0.0/Karbonite_0.7.0.0.zip",
     "download_size": 26313086,
     "download_hash": {
         "sha1": "476E67A394A41ADAF374C10C86225ADD8F1E5DC8",

--- a/Karbonite/Karbonite-1-0.7.1.0.ckan
+++ b/Karbonite/Karbonite-1-0.7.1.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.7.1.0",
     "ksp_version": "1.1.0",
@@ -49,7 +49,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.7.1.0/Karbonite_0.7.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.7.1.0/Karbonite_0.7.1.0.zip",
     "download_size": 26708555,
     "download_hash": {
         "sha1": "C369B6EEECB01DBFDD08856CDD3C88410EDEB2A8",

--- a/Karbonite/Karbonite-1-0.7.2.0.ckan
+++ b/Karbonite/Karbonite-1-0.7.2.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.7.2.0",
     "ksp_version": "1.1.0",
@@ -49,7 +49,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.7.2.0/Karbonite_0.7.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.7.2.0/Karbonite_0.7.2.0.zip",
     "download_size": 26523078,
     "download_hash": {
         "sha1": "6BC6FD2A9BE21FACC8EF5D06C4E4BED7829BB5B9",

--- a/Karbonite/Karbonite-1-0.7.2.1.ckan
+++ b/Karbonite/Karbonite-1-0.7.2.1.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.7.2.1",
     "ksp_version_min": "1.1.0",
@@ -50,7 +50,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.7.2.1/Karbonite_0.7.2.1.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.7.2.1/Karbonite_0.7.2.1.zip",
     "download_size": 26527138,
     "download_hash": {
         "sha1": "84DF1F1BC91CA0BAFFAEFA91AC03E892C8C86921",

--- a/Karbonite/Karbonite-1-0.7.3.0.ckan
+++ b/Karbonite/Karbonite-1-0.7.3.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.7.3.0",
     "ksp_version_min": "1.1.0",
@@ -50,7 +50,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.7.3.0/Karbonite_0.7.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.7.3.0/Karbonite_0.7.3.0.zip",
     "download_size": 26526978,
     "download_hash": {
         "sha1": "28AFFE52BFF82E416B901C115A6E61AECE599FA2",

--- a/Karbonite/Karbonite-1-0.7.4.0.ckan
+++ b/Karbonite/Karbonite-1-0.7.4.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.7.4.0",
     "ksp_version_min": "1.1.0",
@@ -50,7 +50,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.7.4.0/Karbonite_0.7.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.7.4.0/Karbonite_0.7.4.0.zip",
     "download_size": 27489885,
     "download_hash": {
         "sha1": "FA09BE9F95306201A5733C1F7312BFEA396CF7EC",

--- a/Karbonite/Karbonite-1-0.8.0.0.ckan
+++ b/Karbonite/Karbonite-1-0.8.0.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.8.0.0",
     "ksp_version": "1.2.0",
@@ -49,7 +49,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.8.0.0/Karbonite_0.8.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.8.0.0/Karbonite_0.8.0.0.zip",
     "download_size": 28194705,
     "download_hash": {
         "sha1": "6049083DB4CFA80BB8FA3A224B02D978AC2CE671",

--- a/Karbonite/Karbonite-1-0.8.1.0.ckan
+++ b/Karbonite/Karbonite-1-0.8.1.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.8.1.0",
     "ksp_version": "1.2.0",
@@ -49,7 +49,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.8.1.0/Karbonite_0.8.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.8.1.0/Karbonite_0.8.1.0.zip",
     "download_size": 28195577,
     "download_hash": {
         "sha1": "EEF73E2CFCE7039C774FAC2EF6609B40BF4EB067",

--- a/Karbonite/Karbonite-1-0.8.2.0.ckan
+++ b/Karbonite/Karbonite-1-0.8.2.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.8.2.0",
     "ksp_version": "1.2.0",
@@ -49,7 +49,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.8.2.0/Karbonite_0.8.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.8.2.0/Karbonite_0.8.2.0.zip",
     "download_size": 28196762,
     "download_hash": {
         "sha1": "CBA177D7E2F08E3B52736A35899B0813B4FD1733",

--- a/Karbonite/Karbonite-1-0.8.3.0.ckan
+++ b/Karbonite/Karbonite-1-0.8.3.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.8.3.0",
     "ksp_version_min": "1.2.0",
@@ -50,7 +50,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.8.3.0/Karbonite_0.8.3.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.8.3.0/Karbonite_0.8.3.0.zip",
     "download_size": 41944321,
     "download_hash": {
         "sha1": "B8129A05600E068757BC57DDE038F64AC379DED6",

--- a/Karbonite/Karbonite-1-0.8.4.0.ckan
+++ b/Karbonite/Karbonite-1-0.8.4.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.8.4.0",
     "ksp_version_min": "1.2.0",
@@ -54,7 +54,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.8.4.0/Karbonite_0.8.4.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.8.4.0/Karbonite_0.8.4.0.zip",
     "download_size": 41975594,
     "download_hash": {
         "sha1": "3C35D95BC4958B93E67101D71B66A62CD715BC94",

--- a/Karbonite/Karbonite-1-0.8.5.0.ckan
+++ b/Karbonite/Karbonite-1-0.8.5.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.8.5.0",
     "ksp_version_min": "1.2.0",
@@ -54,7 +54,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.8.5.0/Karbonite_0.8.5.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.8.5.0/Karbonite_0.8.5.0.zip",
     "download_size": 41976750,
     "download_hash": {
         "sha1": "43D1479615FF0D49C5A0587ADB6D13BEA1587AAA",

--- a/Karbonite/Karbonite-1-0.8.6.0.ckan
+++ b/Karbonite/Karbonite-1-0.8.6.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.8.6.0",
     "ksp_version_min": "1.2.0",
@@ -54,7 +54,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.8.6.0/Karbonite_0.8.6.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.8.6.0/Karbonite_0.8.6.0.zip",
     "download_size": 41981043,
     "download_hash": {
         "sha1": "9B6FCFFA3C982082348E9D5411329EA28057844F",

--- a/Karbonite/Karbonite-1-0.8.7.0.ckan
+++ b/Karbonite/Karbonite-1-0.8.7.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.8.7.0",
     "ksp_version_min": "1.2.0",
@@ -54,7 +54,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.8.7.0/Karbonite_0.8.7.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.8.7.0/Karbonite_0.8.7.0.zip",
     "download_size": 41981565,
     "download_hash": {
         "sha1": "F4EF43FF4718784BA9074AB4014A4011C6965D4A",

--- a/Karbonite/Karbonite-1-0.8.8.0.ckan
+++ b/Karbonite/Karbonite-1-0.8.8.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/80650-105",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.8.8.0",
     "ksp_version_min": "1.2.0",
@@ -54,7 +54,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.8.8.0/Karbonite_0.8.8.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.8.8.0/Karbonite_0.8.8.0.zip",
     "download_size": 43248769,
     "download_hash": {
         "sha1": "17C329F292C044CD0CC174FC9804FEC2B3FA3DDF",

--- a/Karbonite/Karbonite-1-0.9.0.0.ckan
+++ b/Karbonite/Karbonite-1-0.9.0.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.9.0.0",
     "ksp_version_min": "1.2.9",
@@ -59,7 +59,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.9.1.0/Karbonite_0.9.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.9.1.0/Karbonite_0.9.1.0.zip",
     "download_size": 43350920,
     "download_hash": {
         "sha1": "1FEB341E757603A6ACFA4E770E7EA98F20D9E8BC",

--- a/Karbonite/Karbonite-1-0.9.1.0.ckan
+++ b/Karbonite/Karbonite-1-0.9.1.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.9.1.0",
     "ksp_version_min": "1.2.9",
@@ -59,7 +59,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.9.1.0/Karbonite_0.9.1.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.9.1.0/Karbonite_0.9.1.0.zip",
     "download_size": 43350920,
     "download_hash": {
         "sha1": "1FEB341E757603A6ACFA4E770E7EA98F20D9E8BC",

--- a/Karbonite/Karbonite-1-0.9.2.0.ckan
+++ b/Karbonite/Karbonite-1-0.9.2.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:0.9.2.0",
     "ksp_version_min": "1.2.9",
@@ -59,7 +59,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/0.9.2.0/Karbonite_0.9.2.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/0.9.2.0/Karbonite_0.9.2.0.zip",
     "download_size": 43367019,
     "download_hash": {
         "sha1": "24A96017830D73F50AC8A993A3917C41503F898D",

--- a/Karbonite/Karbonite-1-1.1.0.0.ckan
+++ b/Karbonite/Karbonite-1-1.1.0.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:1.1.0.0",
     "ksp_version_min": "1.6.0",
@@ -59,7 +59,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/1.1.0.0/Karbonite_1.1.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/1.1.0.0/Karbonite_1.1.0.0.zip",
     "download_size": 43429926,
     "download_hash": {
         "sha1": "CA1CEEDCE593A612F85712E650E14F8DB65BB8F0",

--- a/Karbonite/Karbonite-1-1.2.0.0.ckan
+++ b/Karbonite/Karbonite-1-1.2.0.0.ckan
@@ -9,7 +9,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/Karbonite"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite"
     },
     "version": "1:1.2.0.0",
     "ksp_version_min": "1.6.0",
@@ -59,7 +59,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/1.2.0.0/Karbonite_1.2.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/1.2.0.0/Karbonite_1.2.0.0.zip",
     "download_size": 43397454,
     "download_hash": {
         "sha1": "AA8A773E45BE414610C9D2EE6F8F4FCA6670D9CF",

--- a/Karbonite/Karbonite-1-1.3.0.0.ckan
+++ b/Karbonite/Karbonite-1-1.3.0.0.ckan
@@ -12,9 +12,9 @@
     "release_status": "stable",
     "resources": {
         "homepage": "http://umbraspaceindustries.github.io/UmbraSpaceIndustries/",
-        "repository": "https://github.com/BobPalmer/Karbonite",
-        "bugtracker": "https://github.com/BobPalmer/Karbonite/issues",
-        "metanetkan": "https://raw.githubusercontent.com/BobPalmer/CKAN/master/Karbonite.netkan"
+        "repository": "https://github.com/UmbraSpaceIndustries/Karbonite",
+        "bugtracker": "https://github.com/UmbraSpaceIndustries/Karbonite/issues",
+        "metanetkan": "https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/Karbonite.netkan"
     },
     "tags": [
         "parts",
@@ -65,7 +65,7 @@
             "install_to": "GameData/UmbraSpaceIndustries"
         }
     ],
-    "download": "https://github.com/BobPalmer/Karbonite/releases/download/1.3.0.0/Karbonite_1.3.0.0.zip",
+    "download": "https://github.com/UmbraSpaceIndustries/Karbonite/releases/download/1.3.0.0/Karbonite_1.3.0.0.zip",
     "download_size": 43396881,
     "download_hash": {
         "sha1": "C2A29F1708CF17EF660DDCFB06F1F65AC5BDE90F",


### PR DESCRIPTION
## Problem

Old Karbonite versions can no longer be downloaded.

## Cause

The repo used to be `BobPalmer/Karbonite` and was changed to `UmbraSpaceIndustries/Karbonite`, which broke all the old download links.

Previous fixes of this for other mods: #2525, #2524, #2522, #2521, #2520, #2512, #2511, #2510, #2509, #2508, #2507

## Changes

Now `BobPalmer` is changed to `UmbraSpaceIndustries` in the `download` and `resources.repository` for all historical versions of Karbonite.

```
sed -b -i 's/BobPalmer/UmbraSpaceIndustries/g' *.ckan
```

Fixes KSP-CKAN/CKAN#3601.