### PR TITLE
Revert too early Kopernicus metadata updates

### DIFF
--- a/Kopernicus/Kopernicus-2-release-1.12.1-132.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.12.1-132.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "Kopernicus",
     "name": "Kopernicus Planetary System Modifier",
-    "abstract": "Allows users to replace the planetary system used by the game",
+    "abstract": "Allows users to replace the planetary system used by the game.",
     "author": [
         "BryceSchroeder",
         "Teknoman117",
@@ -44,14 +44,17 @@
         {
             "name": "ModularFlightIntegrator",
             "min_version": "1.2.4.0"
-        },
-        {
-            "name": "Harmony2"
         }
     ],
     "suggests": [
         {
             "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/Kopernicus/Kopernicus/releases/download/release-132/Kopernicus-1.12.1-132.zip",

--- a/Kopernicus/Kopernicus-2-release-1.8.1-132.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.8.1-132.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "Kopernicus",
     "name": "Kopernicus Planetary System Modifier",
-    "abstract": "Allows users to replace the planetary system used by the game",
+    "abstract": "Allows users to replace the planetary system used by the game.",
     "author": [
         "BryceSchroeder",
         "Teknoman117",
@@ -44,14 +44,17 @@
         {
             "name": "ModularFlightIntegrator",
             "min_version": "1.2.4.0"
-        },
-        {
-            "name": "Harmony2"
         }
     ],
     "suggests": [
         {
             "name": "KittopiaTech"
+        }
+    ],
+    "install": [
+        {
+            "find": "Kopernicus",
+            "install_to": "GameData"
         }
     ],
     "download": "https://github.com/Kopernicus/Kopernicus/releases/download/release-132/Kopernicus-1.8.1-132.zip",


### PR DESCRIPTION
While https://github.com/KSP-CKAN/NetKAN/pull/9202 has been merged after the new releases happened (which the CI run confirmed by showing the new releases), the bot somehow still ended up updating the metadata of the previous releases instead of pulling in the new one.

So let's revert the changes.