### PR TITLE
Capitalize TUFX in "name:" for BallisticFoxsNeutralTUFXProfile-V1.3.ckan

### DIFF
--- a/BallisticFoxsNeutralTUFXProfile/BallisticFoxsNeutralTUFXProfile-V1.3.ckan
+++ b/BallisticFoxsNeutralTUFXProfile/BallisticFoxsNeutralTUFXProfile-V1.3.ckan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "BallisticFoxsNeutralTUFXProfile",
-    "name": "ballisticfox's neutral tufx profile",
+    "name": "ballisticfox's neutral TUFX profile",
     "abstract": "Probably one of the most Neutral TUFX configs you can find. Requires TUFX obviously. Designed in RSS, looks good in Stock and KSRSS, BH is currently untested. Thank you Truthful and SovPenguin for testing!",
     "author": "ballisticfox0",
     "version": "V1.3",


### PR DESCRIPTION
The netkan file is missing a `name:` field or else I would have proposed this there; I'm guessing this file was auto-generated from SpaceDock, and the mod is lowercase in SpaceDock as the browser tab shows lowercase? I'm unsure if this change would stay for subsequent updates, though. Mod Author also messaged.

[Current appearance in CKAN](https://i.imgur.com/fNy5B4u.png)
[SpaceDock page header comparison](https://i.imgur.com/sTXLal0.png)