### PR TITLE
Spectra ckan fixes

### DIFF
--- a/Spectra/Spectra-v1.1.3.ckan
+++ b/Spectra/Spectra-v1.1.3.ckan
@@ -15,9 +15,6 @@
     "version": "v1.1.3",
     "ksp_version_min": "1.3",
     "ksp_version_max": "1.3.99",
-    "provides": [
-        "PlanetShine-Config"
-    ],
     "depends": [
         {
             "name": "KSPRC-Textures"
@@ -47,6 +44,9 @@
         },
         {
             "name": "WindowShineTR"
+        },
+        {
+            "name": "PlanetShine"
         }
     ],
     "conflicts": [

--- a/Spectra/Spectra-v1.1.3.ckan
+++ b/Spectra/Spectra-v1.1.3.ckan
@@ -49,11 +49,6 @@
             "name": "PlanetShine"
         }
     ],
-    "conflicts": [
-        {
-            "name": "PlanetShine-Config"
-        }
-    ],
     "install": [
         {
             "file": "Step 2 - Spectra/GameData/TextureReplacerReplaced",
@@ -63,10 +58,6 @@
         {
             "file": "Step 2 - Spectra/GameData/Spectra",
             "install_to": "GameData"
-        },
-        {
-            "file": "Step 4 - Extras/PlanetShine/Config",
-            "install_to": "GameData/PlanetShine"
         },
         {
             "file": "Step 4 - Extras/PlanetShine/Icons",

--- a/Spectra/Spectra-v1.1.4.ckan
+++ b/Spectra/Spectra-v1.1.4.ckan
@@ -14,9 +14,6 @@
     },
     "version": "v1.1.4",
     "ksp_version": "1.4.1",
-    "provides": [
-        "PlanetShine-Config"
-    ],
     "depends": [
         {
             "name": "KSPRC-Textures"
@@ -46,6 +43,9 @@
         },
         {
             "name": "WindowShineTR"
+        },
+        {
+            "name": "PlanetShine"
         }
     ],
     "conflicts": [

--- a/Spectra/Spectra-v1.1.4.ckan
+++ b/Spectra/Spectra-v1.1.4.ckan
@@ -48,11 +48,6 @@
             "name": "PlanetShine"
         }
     ],
-    "conflicts": [
-        {
-            "name": "PlanetShine-Config"
-        }
-    ],
     "install": [
         {
             "file": "Step 2 - Spectra/GameData/TextureReplacerReplaced",
@@ -62,10 +57,6 @@
         {
             "file": "Step 2 - Spectra/GameData/Spectra",
             "install_to": "GameData"
-        },
-        {
-            "file": "Step 4 - Extras/PlanetShine/Config",
-            "install_to": "GameData/PlanetShine"
         },
         {
             "file": "Step 4 - Extras/PlanetShine/Icons",

--- a/Spectra/Spectra-v1.1.5.ckan
+++ b/Spectra/Spectra-v1.1.5.ckan
@@ -14,9 +14,6 @@
     },
     "version": "v1.1.5",
     "ksp_version": "1.4.1",
-    "provides": [
-        "PlanetShine-Config"
-    ],
     "depends": [
         {
             "name": "KSPRC-Textures"
@@ -46,6 +43,9 @@
         },
         {
             "name": "WindowShineTR"
+        },
+        {
+            "name": "PlanetShine"
         }
     ],
     "conflicts": [

--- a/Spectra/Spectra-v1.1.5.ckan
+++ b/Spectra/Spectra-v1.1.5.ckan
@@ -48,11 +48,6 @@
             "name": "PlanetShine"
         }
     ],
-    "conflicts": [
-        {
-            "name": "PlanetShine-Config"
-        }
-    ],
     "install": [
         {
             "file": "Step 2 - Spectra/GameData/TextureReplacerReplaced",
@@ -62,10 +57,6 @@
         {
             "file": "Step 2 - Spectra/GameData/Spectra",
             "install_to": "GameData"
-        },
-        {
-            "file": "Step 4 - Extras/PlanetShine/Config",
-            "install_to": "GameData/PlanetShine"
         },
         {
             "file": "Step 4 - Extras/PlanetShine/Icons",

--- a/Spectra/Spectra-v1.1.6.ckan
+++ b/Spectra/Spectra-v1.1.6.ckan
@@ -14,9 +14,6 @@
     },
     "version": "v1.1.6",
     "ksp_version": "1.4.1",
-    "provides": [
-        "PlanetShine-Config"
-    ],
     "depends": [
         {
             "name": "KSPRC-Textures"
@@ -46,6 +43,9 @@
         },
         {
             "name": "WindowShineTR"
+        },
+        {
+            "name": "PlanetShine"
         }
     ],
     "conflicts": [

--- a/Spectra/Spectra-v1.1.6.ckan
+++ b/Spectra/Spectra-v1.1.6.ckan
@@ -48,11 +48,6 @@
             "name": "PlanetShine"
         }
     ],
-    "conflicts": [
-        {
-            "name": "PlanetShine-Config"
-        }
-    ],
     "install": [
         {
             "file": "Step 2 - Spectra/GameData/TextureReplacerReplaced",
@@ -62,10 +57,6 @@
         {
             "file": "Step 2 - Spectra/GameData/Spectra",
             "install_to": "GameData"
-        },
-        {
-            "file": "Step 4 - Extras/PlanetShine/Config",
-            "install_to": "GameData/PlanetShine"
         },
         {
             "file": "Step 4 - Extras/PlanetShine/Icons",

--- a/Spectra/Spectra-v1.1.7.ckan
+++ b/Spectra/Spectra-v1.1.7.ckan
@@ -14,9 +14,6 @@
     },
     "version": "v1.1.7",
     "ksp_version": "1.6.1",
-    "provides": [
-        "PlanetShine-Config"
-    ],
     "depends": [
         {
             "name": "KSPRC-Textures"
@@ -46,6 +43,9 @@
         },
         {
             "name": "WindowShineTR"
+        },
+        {
+            "name": "PlanetShine"
         }
     ],
     "conflicts": [

--- a/Spectra/Spectra-v1.1.7.ckan
+++ b/Spectra/Spectra-v1.1.7.ckan
@@ -48,11 +48,6 @@
             "name": "PlanetShine"
         }
     ],
-    "conflicts": [
-        {
-            "name": "PlanetShine-Config"
-        }
-    ],
     "install": [
         {
             "file": "Step 2 - Spectra/GameData/TextureReplacerReplaced",
@@ -62,10 +57,6 @@
         {
             "file": "Step 2 - Spectra/GameData/Spectra",
             "install_to": "GameData"
-        },
-        {
-            "file": "Step 4 - Extras/PlanetShine/Config",
-            "install_to": "GameData/PlanetShine"
         },
         {
             "file": "Step 4 - Extras/PlanetShine/Icons",

--- a/Spectra/Spectra-v1.2.1.ckan
+++ b/Spectra/Spectra-v1.2.1.ckan
@@ -15,7 +15,6 @@
     "version": "v1.2.1",
     "ksp_version": "1.6.1",
     "provides": [
-        "PlanetShine-Config",
         "EnvironmentalVisualEnhancements-Config",
         "Scatterer-sunflare"
     ],
@@ -51,6 +50,9 @@
         },
         {
             "name": "SpaceplaneCorrections"
+        },
+        {
+            "name": "PlanetShine"
         }
     ],
     "conflicts": [

--- a/Spectra/Spectra-v1.2.1.ckan
+++ b/Spectra/Spectra-v1.2.1.ckan
@@ -50,9 +50,6 @@
         },
         {
             "name": "SpaceplaneCorrections"
-        },
-        {
-            "name": "PlanetShine"
         }
     ],
     "conflicts": [

--- a/Spectra/Spectra-v1.2.1.ckan
+++ b/Spectra/Spectra-v1.2.1.ckan
@@ -54,9 +54,6 @@
     ],
     "conflicts": [
         {
-            "name": "PlanetShine-Config"
-        },
-        {
             "name": "EnvironmentalVisualEnhancements-Config"
         },
         {
@@ -79,10 +76,6 @@
         {
             "file": "Step 2 - Spectra/GameData/KSPRC",
             "install_to": "GameData"
-        },
-        {
-            "file": "Step 3 - Extras/PlanetShine/Config",
-            "install_to": "GameData/PlanetShine"
         }
     ],
     "download": "https://spacedock.info/mod/1505/Spectra/download/v1.2.1",

--- a/Spectra/Spectra-v1.2.2.ckan
+++ b/Spectra/Spectra-v1.2.2.ckan
@@ -15,7 +15,6 @@
     "version": "v1.2.2",
     "ksp_version": "1.7.1",
     "provides": [
-        "PlanetShine-Config",
         "EnvironmentalVisualEnhancements-Config",
         "Scatterer-sunflare"
     ],

--- a/Spectra/Spectra-v1.2.2.ckan
+++ b/Spectra/Spectra-v1.2.2.ckan
@@ -54,9 +54,6 @@
     ],
     "conflicts": [
         {
-            "name": "PlanetShine-Config"
-        },
-        {
             "name": "EnvironmentalVisualEnhancements-Config"
         },
         {
@@ -79,10 +76,6 @@
         {
             "file": "Step 2 - Spectra/GameData/KSPRC",
             "install_to": "GameData"
-        },
-        {
-            "file": "Step 3 - Extras/PlanetShine/Config",
-            "install_to": "GameData/PlanetShine"
         }
     ],
     "download": "https://spacedock.info/mod/1505/Spectra/download/v1.2.2",

--- a/Spectra/Spectra-v1.2.3.ckan
+++ b/Spectra/Spectra-v1.2.3.ckan
@@ -59,9 +59,6 @@
     ],
     "conflicts": [
         {
-            "name": "PlanetShine-Config"
-        },
-        {
             "name": "EnvironmentalVisualEnhancements-Config"
         },
         {
@@ -84,10 +81,6 @@
         {
             "file": "Step 2 - Spectra/GameData/KSPRC",
             "install_to": "GameData"
-        },
-        {
-            "file": "Step 3 - Extras/PlanetShine/Config",
-            "install_to": "GameData/PlanetShine"
         }
     ],
     "download": "https://spacedock.info/mod/1505/Spectra/download/1.2.3",

--- a/Spectra/Spectra-v1.2.3.ckan
+++ b/Spectra/Spectra-v1.2.3.ckan
@@ -20,7 +20,6 @@
         "graphics"
     ],
     "provides": [
-        "PlanetShine-Config",
         "EnvironmentalVisualEnhancements-Config",
         "Scatterer-sunflare"
     ],

--- a/Spectra/Spectra-v1.2.4.ckan
+++ b/Spectra/Spectra-v1.2.4.ckan
@@ -59,9 +59,6 @@
     ],
     "conflicts": [
         {
-            "name": "PlanetShine-Config"
-        },
-        {
             "name": "EnvironmentalVisualEnhancements-Config"
         },
         {

--- a/Spectra/Spectra-v1.2.4.ckan
+++ b/Spectra/Spectra-v1.2.4.ckan
@@ -20,7 +20,6 @@
         "graphics"
     ],
     "provides": [
-        "PlanetShine-Config",
         "EnvironmentalVisualEnhancements-Config",
         "Scatterer-sunflare"
     ],

--- a/Spectra/Spectra-v1.2.5.ckan
+++ b/Spectra/Spectra-v1.2.5.ckan
@@ -60,9 +60,6 @@
     ],
     "conflicts": [
         {
-            "name": "PlanetShine-Config"
-        },
-        {
             "name": "EnvironmentalVisualEnhancements-Config"
         },
         {

--- a/Spectra/Spectra-v1.2.5.ckan
+++ b/Spectra/Spectra-v1.2.5.ckan
@@ -19,7 +19,6 @@
         "graphics"
     ],
     "provides": [
-        "PlanetShine-Config",
         "EnvironmentalVisualEnhancements-Config"
     ],
     "depends": [


### PR DESCRIPTION
Removing `PlanetShine-config` from `provides:` in all previous versions of Spectra, as this is causing CKAN to recommend installing ancient versions of Spectra to satisfy the config.