### PR TITLE
Freeze RealRoster and update its homepage

### DIFF
--- a/RealRoster/RealRoster-v2.1.frozen
+++ b/RealRoster/RealRoster-v2.1.frozen
@@ -7,7 +7,7 @@
     "name": "RealRoster - Editor Crew Tab Fixed",
     "ksp_version"   :   "0.25",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/87473",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/78920-*",
         "repository": "https://github.com/fingerboxes/KSPRealRoster"
     },
     "install": [


### PR DESCRIPTION
@linuxgurugamer found an ancient mod for KSP 0.25 that no longer has a working download, repository, or homepage. It was announced as abandoned a very long time ago, and apparently even the author doesn't have a copy of the source anymore:

![image](https://user-images.githubusercontent.com/1559108/185511283-d08bdf55-49ff-4571-87d3-94a6698a9ec1.png)

Now it's frozen, and `resources.homepage` is updated to the new forum URL format in case anybody is browsing frozen modules and wants to find the thread.

Fixes KSP-CKAN/NetKAN#9284.