### PR TITLE
Add conflicts to KHNS for provides

### DIFF
--- a/KerbolsHumbleNeighboringStars/KerbolsHumbleNeighboringStars-1-Beta-1.1.ckan
+++ b/KerbolsHumbleNeighboringStars/KerbolsHumbleNeighboringStars-1-Beta-1.1.ckan
@@ -40,6 +40,14 @@
             "name": "EnvironmentalVisualEnhancements"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer-config"
+        },
+        {
+            "name": "Scatterer-sunflare"
+        }
+    ],
     "install": [
         {
             "find": "KHNS",

--- a/KerbolsHumbleNeighboringStars/KerbolsHumbleNeighboringStars-1-Beta-1.2.ckan
+++ b/KerbolsHumbleNeighboringStars/KerbolsHumbleNeighboringStars-1-Beta-1.2.ckan
@@ -40,6 +40,14 @@
             "name": "EnvironmentalVisualEnhancements"
         }
     ],
+    "conflicts": [
+        {
+            "name": "Scatterer-config"
+        },
+        {
+            "name": "Scatterer-sunflare"
+        }
+    ],
     "install": [
         {
             "find": "KHNS",


### PR DESCRIPTION
This is KSP-CKAN/NetKAN#9285 for historical data. ErsteSterne only has one release, so the bot has already updated it. KHNS has two prior releases with the affected `provides` values.
