### PR TITLE
Epoch historical KerbalWind versions

### DIFF
--- a/KerbalWind/KerbalWind-1-7.1.ckan
+++ b/KerbalWind/KerbalWind-1-7.1.ckan
@@ -14,7 +14,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/107989",
         "repository": "https://github.com/DaMichel/KerbalWind"
     },
-    "version": "R11",
+    "version": "1:7.1",
     "ksp_version": "1.0",
     "provides": [
         "FARWind"
@@ -34,11 +34,11 @@
             "name": "FARWind"
         }
     ],
-    "download": "https://github.com/DaMichel/KerbalWind/releases/download/R11/KerbalWindR11.zip",
-    "download_size": 17253,
+    "download": "https://github.com/DaMichel/KerbalWind/releases/download/7.1/KerbalWindR7.1.zip",
+    "download_size": 12698,
     "download_hash": {
-        "sha1": "7D359A0E25FF1DE44861E98C2A969A8C24C7F06B",
-        "sha256": "C8991B5926AE6D5617EAAF23BC9C3ED33CE9A7D95E5C6994745C1F0E56A63C2D"
+        "sha1": "BCCDDF5821B032E479F6CB23BC3BCD8760A817C5",
+        "sha256": "A6C943031082E8D77317C4311E7B475CEE88220577C49DA9EE723BE4246EDDB0"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KerbalWind/KerbalWind-1-R10.ckan
+++ b/KerbalWind/KerbalWind-1-R10.ckan
@@ -14,7 +14,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/107989",
         "repository": "https://github.com/DaMichel/KerbalWind"
     },
-    "version": "7.1",
+    "version": "1:R10",
     "ksp_version": "1.0",
     "provides": [
         "FARWind"
@@ -34,11 +34,11 @@
             "name": "FARWind"
         }
     ],
-    "download": "https://github.com/DaMichel/KerbalWind/releases/download/7.1/KerbalWindR7.1.zip",
-    "download_size": 12698,
+    "download": "https://github.com/DaMichel/KerbalWind/releases/download/R10/KerbalWindR10.zip",
+    "download_size": 14888,
     "download_hash": {
-        "sha1": "BCCDDF5821B032E479F6CB23BC3BCD8760A817C5",
-        "sha256": "A6C943031082E8D77317C4311E7B475CEE88220577C49DA9EE723BE4246EDDB0"
+        "sha1": "D77004E86F6515B6614E76BC599DC139E1ABB507",
+        "sha256": "D20DC2CA28A0FAFB2329B2162188155293036CD914D8B393CD7DF1916D9ACF73"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KerbalWind/KerbalWind-1-R11.ckan
+++ b/KerbalWind/KerbalWind-1-R11.ckan
@@ -14,7 +14,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/107989",
         "repository": "https://github.com/DaMichel/KerbalWind"
     },
-    "version": "R10",
+    "version": "1:R11",
     "ksp_version": "1.0",
     "provides": [
         "FARWind"
@@ -34,11 +34,11 @@
             "name": "FARWind"
         }
     ],
-    "download": "https://github.com/DaMichel/KerbalWind/releases/download/R10/KerbalWindR10.zip",
-    "download_size": 14888,
+    "download": "https://github.com/DaMichel/KerbalWind/releases/download/R11/KerbalWindR11.zip",
+    "download_size": 17253,
     "download_hash": {
-        "sha1": "D77004E86F6515B6614E76BC599DC139E1ABB507",
-        "sha256": "D20DC2CA28A0FAFB2329B2162188155293036CD914D8B393CD7DF1916D9ACF73"
+        "sha1": "7D359A0E25FF1DE44861E98C2A969A8C24C7F06B",
+        "sha256": "C8991B5926AE6D5617EAAF23BC9C3ED33CE9A7D95E5C6994745C1F0E56A63C2D"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KerbalWind/KerbalWind-1-R12.ckan
+++ b/KerbalWind/KerbalWind-1-R12.ckan
@@ -3,7 +3,7 @@
     "comment": "FAR only supports one wind provider at once",
     "identifier": "KerbalWind",
     "name": "Kerbal Wind",
-    "abstract": "Adds wind to the game. It opens a dialog box where you can set wind direction and speed. Inspired by KerbalWeatherSystem by silverfox8124. But this is much simpler, omitting the actual weather simulation.",
+    "abstract": "Implements wind and a continuous-gusts model for Ferram Aerospace Research. Provides GUI with settings for wind direction, speed and turbulence magnitude.",
     "author": [
         "DaMichel",
         "silverfox8124"
@@ -14,8 +14,8 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/107989",
         "repository": "https://github.com/DaMichel/KerbalWind"
     },
-    "version": "R9",
-    "ksp_version": "1.0",
+    "version": "1:R12",
+    "ksp_version": "1.1",
     "provides": [
         "FARWind"
     ],
@@ -34,11 +34,11 @@
             "name": "FARWind"
         }
     ],
-    "download": "https://github.com/DaMichel/KerbalWind/releases/download/R9/KerbalWindR9.zip",
-    "download_size": 13218,
+    "download": "https://github.com/DaMichel/KerbalWind/releases/download/R12/KerbalWind12.zip",
+    "download_size": 17339,
     "download_hash": {
-        "sha1": "E329C4F5276107FBCACEA08B1A6092EFD0152DBE",
-        "sha256": "F43A5784CFD40E53ABED7522DC401B7643E90E3B25799231FE92863C99A00108"
+        "sha1": "E7C4530B3867F7E9B089BFF77904BE8D1AB13DF9",
+        "sha256": "D0253134341C22C669E8F8A4D858C316D09AF31C64A12CB24F934F22095A6E39"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KerbalWind/KerbalWind-1-R13.ckan
+++ b/KerbalWind/KerbalWind-1-R13.ckan
@@ -8,7 +8,7 @@
         "DaMichel",
         "silverfox8124"
     ],
-    "version": "R13",
+    "version": "1:R13",
     "ksp_version": "1.3",
     "license": "MIT",
     "release_status": "stable",

--- a/KerbalWind/KerbalWind-1-R8.ckan
+++ b/KerbalWind/KerbalWind-1-R8.ckan
@@ -3,7 +3,7 @@
     "comment": "FAR only supports one wind provider at once",
     "identifier": "KerbalWind",
     "name": "Kerbal Wind",
-    "abstract": "Implements wind and a continuous-gusts model for Ferram Aerospace Research. Provides GUI with settings for wind direction, speed and turbulence magnitude.",
+    "abstract": "Adds wind to the game. It opens a dialog box where you can set wind direction and speed. Inspired by KerbalWeatherSystem by silverfox8124. But this is much simpler, omitting the actual weather simulation.",
     "author": [
         "DaMichel",
         "silverfox8124"
@@ -14,8 +14,8 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/107989",
         "repository": "https://github.com/DaMichel/KerbalWind"
     },
-    "version": "R12",
-    "ksp_version": "1.1",
+    "version": "1:R8",
+    "ksp_version": "1.0",
     "provides": [
         "FARWind"
     ],
@@ -34,11 +34,11 @@
             "name": "FARWind"
         }
     ],
-    "download": "https://github.com/DaMichel/KerbalWind/releases/download/R12/KerbalWind12.zip",
-    "download_size": 17339,
+    "download": "https://github.com/DaMichel/KerbalWind/releases/download/R8/KerbalWindR8.zip",
+    "download_size": 13218,
     "download_hash": {
-        "sha1": "E7C4530B3867F7E9B089BFF77904BE8D1AB13DF9",
-        "sha256": "D0253134341C22C669E8F8A4D858C316D09AF31C64A12CB24F934F22095A6E39"
+        "sha1": "7173059D1B1809131C17E2D8B58D626EEDB7AF16",
+        "sha256": "450DC21A137F71D0EF472EE4E2A67F7A23B6AB54BB888CCE62B13A100B68BC75"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"

--- a/KerbalWind/KerbalWind-1-R9.ckan
+++ b/KerbalWind/KerbalWind-1-R9.ckan
@@ -14,7 +14,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/107989",
         "repository": "https://github.com/DaMichel/KerbalWind"
     },
-    "version": "R8",
+    "version": "1:R9",
     "ksp_version": "1.0",
     "provides": [
         "FARWind"
@@ -34,11 +34,11 @@
             "name": "FARWind"
         }
     ],
-    "download": "https://github.com/DaMichel/KerbalWind/releases/download/R8/KerbalWindR8.zip",
+    "download": "https://github.com/DaMichel/KerbalWind/releases/download/R9/KerbalWindR9.zip",
     "download_size": 13218,
     "download_hash": {
-        "sha1": "7173059D1B1809131C17E2D8B58D626EEDB7AF16",
-        "sha256": "450DC21A137F71D0EF472EE4E2A67F7A23B6AB54BB888CCE62B13A100B68BC75"
+        "sha1": "E329C4F5276107FBCACEA08B1A6092EFD0152DBE",
+        "sha256": "F43A5784CFD40E53ABED7522DC401B7643E90E3B25799231FE92863C99A00108"
     },
     "download_content_type": "application/zip",
     "x_generated_by": "netkan"


### PR DESCRIPTION
KerbalWind has an out of order version:

![screenshot](https://user-images.githubusercontent.com/1559108/187446979-0b8ee689-2f5f-4a9a-9781-f89e0c746770.png)

Noticed while investigating KSP-CKAN/NetKAN#9307.

Now an epoch is added to 7.1 and later.
