### PR TITLE
Fix SpaceDock deep links

### DIFF
--- a/DynamicBatteryStorage/DynamicBatteryStorage-1.0.0.ckan
+++ b/DynamicBatteryStorage/DynamicBatteryStorage-1.0.0.ckan
@@ -17,7 +17,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/content/Nertea_200/Kerbal_Atomics/Kerbal_Atomics-0.4.2.zip",
+    "download": "https://spacedock.info/mod/710/Kerbal%20Atomics/download/0.4.2",
     "download_size": 56855146,
     "download_hash": {
         "sha1": "AA53121FF12550FED323C85A14B4557641B79B75",

--- a/KSPRC-Textures/KSPRC-Textures-0.7.ckan
+++ b/KSPRC-Textures/KSPRC-Textures-0.7.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData/KSPRC"
         }
     ],
-    "download": "https://spacedock.info/content/Proot_4811/KSPRC_-_Renaissance_Compilation_artworks_remake/KSPRC_-_Renaissance_Compilation_artworks_remake-0.7_PreRelease_3.zip",
+    "download": "https://spacedock.info/mod/690/KSPRC%20-%20Renaissance%20Compilation:%20artworks%20remake/download/0.7_PreRelease_3",
     "download_size": 404683838,
     "download_hash": {
         "sha1": "36C1637D37543838526201F01C2115C42F26DFAC",

--- a/SASS-RevJ/SASS-RevJ-1.ckan
+++ b/SASS-RevJ/SASS-RevJ-1.ckan
@@ -29,7 +29,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/content/GregroxMun_214/GregroxMuns_Revolting_Jool_Recolor/GregroxMuns_Revolting_Jool_Recolor-1.zip",
+    "download": "https://spacedock.info/mod/776/GregroxMun's%20Revolting%20Jool%20Recolor/download/1",
     "download_size": 5172280,
     "download_hash": {
         "sha1": "F9B71E5D41999BF2B0935D7751812A38E4DEEAD0",

--- a/SASS-SE/SASS-SE-1.0.ckan
+++ b/SASS-SE/SASS-SE-1.0.ckan
@@ -29,7 +29,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/content/BorisBee_1293/Sentar_Expansion/Sentar_Expansion-1.0.zip",
+    "download": "https://spacedock.info/mod/238/Sentar%20Expansion/download/1.0",
     "download_size": 44528911,
     "download_hash": {
         "sha1": "ED12EF52AC25AE748C244A3EBC652CCCE566E2EB",


### PR DESCRIPTION
## Motivation

After KSP-CKAN/NetKAN-Infra#273, the download counter will print errors to Discord if it can't parse the mod id from a SpaceDock `download` URL. Such mods will be excluded from the download counts, and SpaceDock would fail to count any downloads originating from CKAN.

There are currently 4 such mods.

## Cause

The visible download links on SpaceDock are received by the Python code, which updates the download counts for that mod and redirects to the `/content/` location where the ZIP file actually lives, which is then handled by the Apache Traffic Server reverse proxy server for speed and caching. The URLs in question here have skipped that first step and gone directly to the "real" `/content/` link.

Checking the revision history, these URLs seem to have been generated by the bot in mid-late 2017, rather than being filled in manually, so I guess the SpaceDock translator had a bug back then. Probably a lot of mods were affected, and most would have been fixed by the bot automatically when the bug was fixed, but these few mods either had their netkans frozen first or updated to a new version such that the old version wasn't auto-updated by the bot anymore.

## Changes

Now these links are updated to their proper pre-redirect forms, so SpaceDock will count the downloads and the download counter will be able to get their counts.
