### PR TITLE
Trim extra characters from resources.repository

### DIFF
--- a/CommunityRealAgencyPack/CommunityRealAgencyPack-v1.0.ckan
+++ b/CommunityRealAgencyPack/CommunityRealAgencyPack-v1.0.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166314-131-community-real-agency-pack/",
         "spacedock": "https://spacedock.info/mod/1543/Community%20Real%20Agency%20Pack",
-        "repository": "https://github.com/h0yer/CommunityRealAgencyPack/archive/v1.0.zip",
+        "repository": "https://github.com/h0yer/CommunityRealAgencyPack",
         "x_screenshot": "https://spacedock.info/content/h0yer_15991/Community_Real_Agency_Pack/Community_Real_Agency_Pack-1507556885.547659.png"
     },
     "version": "v1.0",

--- a/DSDMobileProcessingLabs/DSDMobileProcessingLabs-1.0.0.ckan
+++ b/DSDMobileProcessingLabs/DSDMobileProcessingLabs-1.0.0.ckan
@@ -7,7 +7,7 @@
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/128377",
-        "repository": "https://github.com/JDCollie/Data-Storage-Device/releases/tag/1.0"
+        "repository": "https://github.com/JDCollie/Data-Storage-Device"
     },
     "version": "1.0.0",
     "ksp_version_min": "1.0.0",

--- a/DSDMobileProcessingLabs/DSDMobileProcessingLabs-1.0.ckan
+++ b/DSDMobileProcessingLabs/DSDMobileProcessingLabs-1.0.ckan
@@ -7,7 +7,7 @@
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/128377",
-        "repository": "https://github.com/JDCollie/Data-Storage-Device/releases/tag/1.0",
+        "repository": "https://github.com/JDCollie/Data-Storage-Device",
         "kerbalstuff": "https://kerbalstuff.com/mod/989/DSD%20Mobile%20Processing%20Labs",
         "x_screenshot": "https://kerbalstuff.com/content/JDCollie_732/DSD_Mobile_Processing_Labs/DSD_Mobile_Processing_Labs-1436580788.9945219.png"
     },

--- a/ExplodiumBreathingEngines/ExplodiumBreathingEngines-1.0.0.ckan
+++ b/ExplodiumBreathingEngines/ExplodiumBreathingEngines-1.0.0.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/158717-122021-beta-explodium-breathing-engines-jet-engines-for-use-on-eve-07-may-2017/",
         "spacedock": "https://spacedock.info/mod/1362/Explodium%20Breathing%20Engines",
-        "repository": "https://github.com/gordonfpanam/ExplodiumBreathingEngines/tree/v1.0.0",
+        "repository": "https://github.com/gordonfpanam/ExplodiumBreathingEngines",
         "x_screenshot": "https://spacedock.info/content/gordonfpanam_12748/Explodium_Breathing_Engines/Explodium_Breathing_Engines-1494195432.5289135.png"
     },
     "version": "1.0.0",

--- a/ExplodiumBreathingEngines/ExplodiumBreathingEngines-1.1.0.ckan
+++ b/ExplodiumBreathingEngines/ExplodiumBreathingEngines-1.1.0.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/158717-122021-beta-explodium-breathing-engines-jet-engines-for-use-on-eve-07-may-2017/",
         "spacedock": "https://spacedock.info/mod/1362/Explodium%20Breathing%20Engines",
-        "repository": "https://github.com/gordonfpanam/ExplodiumBreathingEngines/tree/v1.0.0",
+        "repository": "https://github.com/gordonfpanam/ExplodiumBreathingEngines",
         "x_screenshot": "https://spacedock.info/content/gordonfpanam_12748/Explodium_Breathing_Engines/Explodium_Breathing_Engines-1494195432.5289135.png"
     },
     "version": "1.1.0",

--- a/InlineBallutes/InlineBallutes-1.2.1.ckan
+++ b/InlineBallutes/InlineBallutes-1.2.1.ckan
@@ -7,7 +7,7 @@
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/134573-1-0-4-Inline-Ballutes-IB-(v1-2-1)-23-9-2015",
-        "repository": "https://github.com/riocrokite/InlineBallutes/releases/tag/1.2.1",
+        "repository": "https://github.com/riocrokite/InlineBallutes",
         "kerbalstuff": "https://kerbalstuff.com/mod/1166/Inline%20Ballutes",
         "x_screenshot": "https://kerbalstuff.com/content/riocrokite_11317/Inline_Ballutes/Inline_Ballutes-1442905160.891667.png"
     },

--- a/InlineBallutes/InlineBallutes-1.2.2.ckan
+++ b/InlineBallutes/InlineBallutes-1.2.2.ckan
@@ -7,7 +7,7 @@
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/134573-1-0-4-Inline-Ballutes-IB-(v1-2-1)-23-9-2015",
-        "repository": "https://github.com/riocrokite/InlineBallutes/releases/tag/1.2.1",
+        "repository": "https://github.com/riocrokite/InlineBallutes",
         "kerbalstuff": "https://kerbalstuff.com/mod/1166/Inline%20Ballutes",
         "x_screenshot": "https://kerbalstuff.com/content/riocrokite_11317/Inline_Ballutes/Inline_Ballutes-1442905160.891667.png"
     },

--- a/InlineBallutes/InlineBallutes-1.2.3.ckan
+++ b/InlineBallutes/InlineBallutes-1.2.3.ckan
@@ -7,7 +7,7 @@
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/134573-1-0-4-Inline-Ballutes-IB-(v1-2-1)-23-9-2015",
-        "repository": "https://github.com/riocrokite/InlineBallutes/releases/tag/1.2.1",
+        "repository": "https://github.com/riocrokite/InlineBallutes",
         "kerbalstuff": "https://kerbalstuff.com/mod/1166/Inline%20Ballutes",
         "x_screenshot": "https://kerbalstuff.com/content/riocrokite_11317/Inline_Ballutes/Inline_Ballutes-1442905160.891667.png"
     },

--- a/JackOLantern/JackOLantern-1.0.0.1.ckan
+++ b/JackOLantern/JackOLantern-1.0.0.1.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189466-happy-halloween/&tab=comments#comment-3698070",
         "spacedock": "https://spacedock.info/mod/2261/Jack-O'-Lantern",
-        "repository": "https://github.com/zer0Kerbal/Jack-O-Lantern/releases/tag/1.0.0.1",
+        "repository": "https://github.com/zer0Kerbal/Jack-O-Lantern",
         "x_screenshot": "https://spacedock.info/content/zer0Kerbal_21147/Jack-O-Lantern/Jack-O-Lantern-1572555611.266492.jpg"
     },
     "version": "1.0.0.1",

--- a/JackOLantern/JackOLantern-1.0.0.2.ckan
+++ b/JackOLantern/JackOLantern-1.0.0.2.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189466-happy-halloween/&tab=comments#comment-3698070",
         "spacedock": "https://spacedock.info/mod/2261/Jack-O'-Lantern",
-        "repository": "https://github.com/zer0Kerbal/Jack-O-Lantern/releases/tag/1.0.0.1",
+        "repository": "https://github.com/zer0Kerbal/Jack-O-Lantern",
         "x_screenshot": "https://spacedock.info/content/zer0Kerbal_21147/Jack-O-Lantern/Jack-O-Lantern-1572555611.266492.jpg"
     },
     "version": "1.0.0.2",

--- a/LIME/LIME-v1.0.1.ckan
+++ b/LIME/LIME-v1.0.1.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201227-1112-fruitkocktail-a-collection-of-mini-life-improvement-mods-with-fruit-based-acronyms-as-names/",
         "spacedock": "https://spacedock.info/mod/2664/Lie%20In%20Must%20Ensue%20(L.I.M.E.)",
-        "repository": "https://github.com/FruitGooseKSP/LieInMustEnsue/tree/v1.0.1"
+        "repository": "https://github.com/FruitGooseKSP/LieInMustEnsue"
     },
     "tags": [
         "plugin"

--- a/LIME/LIME-v1.1.0.ckan
+++ b/LIME/LIME-v1.1.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201227-1112-fruitkocktail-a-collection-of-mini-life-improvement-mods-with-fruit-based-acronyms-as-names/",
         "spacedock": "https://spacedock.info/mod/2664/Lie%20In%20Must%20Ensue%20(L.I.M.E.)",
-        "repository": "https://github.com/FruitGooseKSP/LieInMustEnsue/tree/v1.0.1"
+        "repository": "https://github.com/FruitGooseKSP/LieInMustEnsue"
     },
     "tags": [
         "plugin"

--- a/LIME/LIME-v1.1.1.ckan
+++ b/LIME/LIME-v1.1.1.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201227-1112-fruitkocktail-a-collection-of-mini-life-improvement-mods-with-fruit-based-acronyms-as-names/",
         "spacedock": "https://spacedock.info/mod/2664/Lie%20In%20Must%20Ensue%20(L.I.M.E.)",
-        "repository": "https://github.com/FruitGooseKSP/LieInMustEnsue/tree/v1.0.1",
+        "repository": "https://github.com/FruitGooseKSP/LieInMustEnsue",
         "x_screenshot": "https://spacedock.info/content/FruitGooseKSP_58074/Lie_In_Must_Ensue_L.I.M.E/Lie_In_Must_Ensue_L.I.M.E-1617380120.7263212.png"
     },
     "tags": [

--- a/LIME/LIME-v1.1.2.ckan
+++ b/LIME/LIME-v1.1.2.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201227-1112-fruitkocktail-a-collection-of-mini-life-improvement-mods-with-fruit-based-acronyms-as-names/",
         "spacedock": "https://spacedock.info/mod/2664/Lie%20In%20Must%20Ensue%20(L.I.M.E.)",
-        "repository": "https://github.com/FruitGooseKSP/LieInMustEnsue/tree/v1.0.1",
+        "repository": "https://github.com/FruitGooseKSP/LieInMustEnsue",
         "bugtracker": "https://github.com/FruitGooseKSP/LieInMustEnsue/issues",
         "x_screenshot": "https://spacedock.info/content/FruitGooseKSP_58074/Lie_In_Must_Ensue_L.I.M.E/Lie_In_Must_Ensue_L.I.M.E-1617380120.7263212.png"
     },

--- a/MicroSatRevived/MicroSatRevived-0.1.0.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.0.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "version": "0.1.0",

--- a/MicroSatRevived/MicroSatRevived-0.1.1.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.1.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "version": "0.1.1",

--- a/MicroSatRevived/MicroSatRevived-0.1.2.1.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.2.1.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "version": "0.1.2.1",

--- a/MicroSatRevived/MicroSatRevived-0.1.2.2.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.2.2.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "version": "0.1.2.2",

--- a/MicroSatRevived/MicroSatRevived-0.1.2.3.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.2.3.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "version": "0.1.2.3",

--- a/MicroSatRevived/MicroSatRevived-0.1.2.4.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.2.4.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "version": "0.1.2.4",

--- a/MicroSatRevived/MicroSatRevived-0.1.2.5.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.2.5.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "version": "0.1.2.5",

--- a/MicroSatRevived/MicroSatRevived-0.1.2.6.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.2.6.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "version": "0.1.2.6",

--- a/MicroSatRevived/MicroSatRevived-0.1.2.7.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.2.7.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "version": "0.1.2.7",

--- a/MicroSatRevived/MicroSatRevived-0.1.2.8.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.2.8.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "version": "0.1.2.8",

--- a/MicroSatRevived/MicroSatRevived-0.1.2.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.2.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "version": "0.1.2",

--- a/MicroSatRevived/MicroSatRevived-0.1.3.1.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.3.1.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "tags": [

--- a/MicroSatRevived/MicroSatRevived-0.1.3.2.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.3.2.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "remote-avc": "http://ksp.spacetux.net/avc/MicroSat",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },

--- a/MicroSatRevived/MicroSatRevived-0.1.3.ckan
+++ b/MicroSatRevived/MicroSatRevived-0.1.3.ckan
@@ -11,7 +11,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173508-13114-the-035m-ssr-microsat-and-airlaunch-vehicle/",
         "spacedock": "https://spacedock.info/mod/1795/The%20SSR%20MicroSat:%200.35m%20Probe%20Parts%20Revived",
-        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/releases/tag/0.1.0",
+        "repository": "https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/The_SSR_MicroSat_0.35m_Probe_Parts_Revived/The_SSR_MicroSat_0.35m_Probe_Parts_Revived-1522899511.4477434.png"
     },
     "tags": [

--- a/ORANGE/ORANGE-v1.0.0.ckan
+++ b/ORANGE/ORANGE-v1.0.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201227-1112-fruitkocktail-a-collection-of-mini-life-improvement-mods-with-fruit-based-acronyms-as-names/",
         "spacedock": "https://spacedock.info/mod/2665/Oh%20Really%20Another%20Name%20Generating%20Endeavour?!%20(O.R.A.N.G.E)",
-        "repository": "https://github.com/FruitGooseKSP/OhReallyAnotherNamingEndeavour/tree/v1.0.0"
+        "repository": "https://github.com/FruitGooseKSP/OhReallyAnotherNamingEndeavour"
     },
     "tags": [
         "plugin",

--- a/ORANGE/ORANGE-v1.0.2.ckan
+++ b/ORANGE/ORANGE-v1.0.2.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201227-1112-fruitkocktail-a-collection-of-mini-life-improvement-mods-with-fruit-based-acronyms-as-names/",
         "spacedock": "https://spacedock.info/mod/2665/Oh%20Really%20Another%20Name%20Generating%20Endeavour?!%20(O.R.A.N.G.E)",
-        "repository": "https://github.com/FruitGooseKSP/OhReallyAnotherNamingEndeavour/tree/v1.0.0",
+        "repository": "https://github.com/FruitGooseKSP/OhReallyAnotherNamingEndeavour",
         "x_screenshot": "https://spacedock.info/content/FruitGooseKSP_58074/Oh_Really_Another_Name_Generating_Endeavour_O.R.A.N.G.E/Oh_Really_Another_Name_Generating_Endeavour_O.R.A.N.G.E-1617380093.4125426.png"
     },
     "tags": [

--- a/ORANGE/ORANGE-v1.0.3.ckan
+++ b/ORANGE/ORANGE-v1.0.3.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201227-1112-fruitkocktail-a-collection-of-mini-life-improvement-mods-with-fruit-based-acronyms-as-names/",
         "spacedock": "https://spacedock.info/mod/2665/Oh%20Really%20Another%20Name%20Generating%20Endeavour?!%20(O.R.A.N.G.E)",
-        "repository": "https://github.com/FruitGooseKSP/OhReallyAnotherNamingEndeavour/tree/v1.0.0",
+        "repository": "https://github.com/FruitGooseKSP/OhReallyAnotherNamingEndeavour",
         "bugtracker": "https://github.com/FruitGooseKSP/OhReallyAnotherNamingEndeavour/issues",
         "x_screenshot": "https://spacedock.info/content/FruitGooseKSP_58074/Oh_Really_Another_Name_Generating_Endeavour_O.R.A.N.G.E/Oh_Really_Another_Name_Generating_Endeavour_O.R.A.N.G.E-1617380093.4125426.png"
     },

--- a/PEAR/PEAR-v1.0.0.ckan
+++ b/PEAR/PEAR-v1.0.0.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201227-1112-fruitkocktail-a-collection-of-mini-life-improvement-mods-with-fruit-based-acronyms-as-names/",
         "spacedock": "https://spacedock.info/mod/2667/Programmatic%20Extension%20And%20Retraction%20(PEAR)",
-        "repository": "https://github.com/FruitGooseKSP/ProgramaticExtensionAndRetraction/tree/v1.0.0",
+        "repository": "https://github.com/FruitGooseKSP/ProgramaticExtensionAndRetraction",
         "x_screenshot": "https://spacedock.info/content/FruitGooseKSP_58074/Programmatic_Extension_And_Retraction_PEAR/Programmatic_Extension_And_Retraction_PEAR-1617379958.8779788.png"
     },
     "tags": [

--- a/PEAR/PEAR-v1.0.1.ckan
+++ b/PEAR/PEAR-v1.0.1.ckan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201227-1112-fruitkocktail-a-collection-of-mini-life-improvement-mods-with-fruit-based-acronyms-as-names/",
         "spacedock": "https://spacedock.info/mod/2667/Programmatic%20Extension%20And%20Retraction%20(PEAR)",
-        "repository": "https://github.com/FruitGooseKSP/ProgramaticExtensionAndRetraction/tree/v1.0.0",
+        "repository": "https://github.com/FruitGooseKSP/ProgramaticExtensionAndRetraction",
         "bugtracker": "https://github.com/FruitGooseKSP/ProgramaticExtensionAndRetraction/issues",
         "x_screenshot": "https://spacedock.info/content/FruitGooseKSP_58074/Programmatic_Extension_And_Retraction_PEAR/Programmatic_Extension_And_Retraction_PEAR-1617379958.8779788.png"
     },

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.0.1.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.0.1.ckan
@@ -7,7 +7,7 @@
     "license": "CC-BY-4.0",
     "resources": {
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.0.1",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.1.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.1.ckan
@@ -7,7 +7,7 @@
     "license": "CC-BY-4.0",
     "resources": {
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.1",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.10.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.10.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.10",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.11.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.11.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.11",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.12.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.12.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.12",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.13.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.13.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.13",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.14.1.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.14.1.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.14.1",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.14.2.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.14.2.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.14.2",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.14.3.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.14.3.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.14.3",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.14.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.14.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.14",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.2.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.2.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.2",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.3.1.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.3.1.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.3.1",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.3.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.3.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.3",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.4.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.4.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.4",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.5.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.5.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.5",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.6.1.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.6.1.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.6.1",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.6.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.6.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.6",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.7.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.7.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.7",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.8.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.8.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.8",

--- a/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.9.ckan
+++ b/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1.3.9.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/145635-113-quiztech-aero-pack-continued/",
         "spacedock": "https://spacedock.info/mod/836/QuizTechAeroPackContinued",
-        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued/releases/tag/1.3.0",
+        "repository": "https://github.com/linuxgurugamer/QuizTechAeroPackContinued",
         "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/QuizTechAeroPackContinued/QuizTechAeroPackContinued-1468183290.92634.png"
     },
     "version": "1.3.9",

--- a/RealAgenciesCollection/RealAgenciesCollection-v1.0.4.ckan
+++ b/RealAgenciesCollection/RealAgenciesCollection-v1.0.4.ckan
@@ -8,7 +8,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/165915-122-real-agencies-collection-v103/",
         "spacedock": "https://spacedock.info/mod/1532/Real%20Agencies%20Collection",
-        "repository": "https://github.com/h0yer/RealAgenciesCollection/archive/v1.0.4.zip",
+        "repository": "https://github.com/h0yer/RealAgenciesCollection",
         "x_screenshot": "https://spacedock.info/content/h0yer_15991/Real_Agencies_Collection/Real_Agencies_Collection-1506932972.330131.png"
     },
     "version": "v1.0.4",


### PR DESCRIPTION
While trying to confirm the character limits for GitHub users and repos given here:

https://github.com/dead-claudia/github-limits/blob/master/README.md

... my grep pattern revealed that several mods have `resources.repository` values with extra suffixes like `/releases/tag/1.0` (usually the _wrong_ tag, since it wouldn't be auto-updated after the initial release).

Now these are removed. If any come back with the next bot pass, I'll go purge them from SpaceDock.
