### PR TITLE
Fix blackheart texture downloads

### DIFF
--- a/ProceduralParts-Textures-SCCKSCS/ProceduralParts-Textures-SCCKSCS-0.ckan
+++ b/ProceduralParts-Textures-SCCKSCS/ProceduralParts-Textures-SCCKSCS-0.ckan
@@ -26,7 +26,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://www.dropbox.com/s/qn02x7fwwg436bd/blackheart%203-18-14.zip?dl=1",
+    "download": "https://archive.org/download/ProceduralParts-Textures-SCCKSCS-0/DCF2111C-ProceduralParts-Textures-SCCKSCS-0.zip",
     "download_size": 4740096,
     "download_hash": {
         "sha1": "DCF2111CF27DB0445168D298A45090EEC0E5C0BB",

--- a/ProceduralParts-Textures-SCCKSCS/ProceduralParts-Textures-SCCKSCS-1.ckan
+++ b/ProceduralParts-Textures-SCCKSCS/ProceduralParts-Textures-SCCKSCS-1.ckan
@@ -30,7 +30,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://www.dropbox.com/s/amgpjjd7qfx84q4/blackheart%206-8-15.zip?dl=1",
+    "download": "https://archive.org/download/ProceduralParts-Textures-SCCKSCS-1/6614B7C5-ProceduralParts-Textures-SCCKSCS-1.zip",
     "download_size": 2519643,
     "download_hash": {
         "sha1": "6614B7C5D5058ACD106E8922BFFF715F10AA7E2E",


### PR DESCRIPTION
## Problem

@siimav reported on Discord that this mod fails to download and doesn't fallback to archive.org.

The license is CC-BY-NC-ND-3.0 (which is redistributable), and it is archived:

- https://archive.org/details/ProceduralParts-Textures-SCCKSCS-0
- https://archive.org/details/ProceduralParts-Textures-SCCKSCS-1

![image](https://user-images.githubusercontent.com/1559108/188334487-1bac2c7c-bc92-43c2-ac6d-db55fd0a1de5.png)

## Cause

Dropbox doesn't have the file anymore, but it reports an HTTP status of 200 instead of 404:

https://www.dropbox.com/s/amgpjjd7qfx84q4/blackheart%206-8-15.zip?dl=1

![image](https://user-images.githubusercontent.com/1559108/188334565-c82d1586-9cd8-4aa0-8b0c-9802505dcee5.png)

This makes CKAN save the error page to disk and try to add it to the cache, which fails the integrity checks.

## Changes

Now these mods are updated to use the archive.org link as primary.
