### PR TITLE
Fix WBI USI play mode download

### DIFF
--- a/WildBlue-PlayMode-USI/WildBlue-PlayMode-USI-v1.0.0.2.ckan
+++ b/WildBlue-PlayMode-USI/WildBlue-PlayMode-USI-v1.0.0.2.ckan
@@ -527,7 +527,7 @@
             "find_matches_files": true
         }
     ],
-    "download": "https://github.com/TheDogKSP/WBIPlaymodeUSI/releases/download/v1.0.0.2/WBIPlaymodeUSI_v1002.zip",
+    "download": "https://archive.org/download/WildBlue-PlayMode-USI-v1.0.0.2/AB996AF2-WildBlue-PlayMode-USI-v1.0.0.2.zip",
     "download_size": 147099,
     "download_hash": {
         "sha1": "AB996AF2F88BBCF4E6803BE30B51839899D5B062",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/188484119-288b7b87-7273-4e05-addf-6db9edf24121.png)

This repo was deleted, see KSP-CKAN/NetKAN#9072.
Now we download it from archive.org by default.
