### PR TITLE
Couple Parallax-StockTextures releases with the corresponding Parallax release

### DIFF
--- a/Parallax-StockTextures/Parallax-StockTextures-1.1.0_-_PRE.ckan
+++ b/Parallax-StockTextures/Parallax-StockTextures-1.1.0_-_PRE.ckan
@@ -25,7 +25,8 @@
             "name": "ModuleManager"
         },
         {
-            "name": "Parallax"
+            "name": "Parallax",
+            "version": "1.1.0_-_PRE"
         }
     ],
     "conflicts": [

--- a/Parallax-StockTextures/Parallax-StockTextures-1.1.1.ckan
+++ b/Parallax-StockTextures/Parallax-StockTextures-1.1.1.ckan
@@ -25,7 +25,8 @@
             "name": "ModuleManager"
         },
         {
-            "name": "Parallax"
+            "name": "Parallax",
+            "version": "1.1.1"
         }
     ],
     "conflicts": [

--- a/Parallax-StockTextures/Parallax-StockTextures-1.1.1b.ckan
+++ b/Parallax-StockTextures/Parallax-StockTextures-1.1.1b.ckan
@@ -25,7 +25,8 @@
             "name": "ModuleManager"
         },
         {
-            "name": "Parallax"
+            "name": "Parallax",
+            "version": "1.1.1b"
         }
     ],
     "conflicts": [

--- a/Parallax-StockTextures/Parallax-StockTextures-1.2.1.ckan
+++ b/Parallax-StockTextures/Parallax-StockTextures-1.2.1.ckan
@@ -23,7 +23,8 @@
             "name": "ModuleManager"
         },
         {
-            "name": "Parallax"
+            "name": "Parallax",
+            "version": "1.2.1"
         }
     ],
     "conflicts": [

--- a/Parallax-StockTextures/Parallax-StockTextures-1.2.2.ckan
+++ b/Parallax-StockTextures/Parallax-StockTextures-1.2.2.ckan
@@ -23,7 +23,8 @@
             "name": "ModuleManager"
         },
         {
-            "name": "Parallax"
+            "name": "Parallax",
+            "version": "1.2.2"
         }
     ],
     "conflicts": [

--- a/Parallax-StockTextures/Parallax-StockTextures-1.2.3.ckan
+++ b/Parallax-StockTextures/Parallax-StockTextures-1.2.3.ckan
@@ -23,7 +23,8 @@
             "name": "ModuleManager"
         },
         {
-            "name": "Parallax"
+            "name": "Parallax",
+            "version": "1.2.3"
         }
     ],
     "conflicts": [

--- a/Parallax-StockTextures/Parallax-StockTextures-1.3.0.ckan
+++ b/Parallax-StockTextures/Parallax-StockTextures-1.3.0.ckan
@@ -23,7 +23,8 @@
             "name": "ModuleManager"
         },
         {
-            "name": "Parallax"
+            "name": "Parallax",
+            "version": "1.3.0"
         }
     ],
     "conflicts": [

--- a/Parallax-StockTextures/Parallax-StockTextures-1.3.1.ckan
+++ b/Parallax-StockTextures/Parallax-StockTextures-1.3.1.ckan
@@ -23,7 +23,8 @@
             "name": "ModuleManager"
         },
         {
-            "name": "Parallax"
+            "name": "Parallax",
+            "version": "1.3.1"
         }
     ],
     "conflicts": [


### PR DESCRIPTION
Related to https://github.com/KSP-CKAN/NetKAN/pull/9323 / https://github.com/KSP-CKAN/NetKAN/pull/9321

## Problem

https://github.com/KSP-CKAN/NetKAN/pull/9323 fixed 2.0.0 of Parallax, and installing 1.3.1 through RP-1 still works, but installing 1.3.1 on its own doesn't because Parallax still tries to pull in 2.0.0 of Parallax-StockTextures, which in turn conflicts with the selected Parallax 1.3.1.
![image](https://user-images.githubusercontent.com/28812678/188679055-58967f37-90d8-4e65-bf89-0371052563e9.png)

```
The following inconsistencies were found:
* Parallax-StockTextures 2.0.0 conflicts with Parallax 1.3.1
Error during installation!
If the above message indicates a download error, please try again. Otherwise, please open an issue for us to investigate.
If you suspect a metadata problem: https://github.com/KSP-CKAN/NetKAN/issues/new/choose
If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/choose
```

## Changes

This tightly couples pre-2.0.0 releases of Parallax-StockTextures with Parallax be making the first ones depend on the exact Parallax versions.

This seems to give enough hints to our relationship resolver to figure out the correct version to install, and is a bit simpler than having two versioned conflict statements for each module for Parallax Parallax-StockTextures.

This time I made sure that all Parallax versions as well as RP-1 Express Install are still installable.