### PR TITLE
OrbitalSurveyPlus 2.3.6 is forward compatible

### DIFF
--- a/OrbitalSurveyPlus/OrbitalSurveyPlus-2.3.6.ckan
+++ b/OrbitalSurveyPlus/OrbitalSurveyPlus-2.3.6.ckan
@@ -5,7 +5,8 @@
     "abstract": "A stock survey scanner overhaul!",
     "author": "Wheffle",
     "version": "2.3.6",
-    "ksp_version": "1.8.1",
+    "ksp_version_min": "1.8.1",
+    "ksp_version_max": "1.12",
     "license": "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/109207-11-orbital-survey-plus-122-a-stock-survey-scanner-tweak-now-with-biome-overlay/&page=1",


### PR DESCRIPTION
up to and including 1.12, according to the maintainer: https://forum.kerbalspaceprogram.com/index.php?/topic/109207-112x-orbital-survey-plus-v236/&do=findComment&comment=4132258