### PR TITLE
Update DLC compatibility

### DIFF
--- a/BreakingGround-DLC/BreakingGround-DLC-1.7.1.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.7.1.ckan
@@ -6,7 +6,7 @@
     "author":       "SQUAD",
     "version":      "1.7.1",
     "ksp_version_min": "1.12.2",
-    "ksp_version_max": "1.12.3",
+    "ksp_version_max": "1.12.4",
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {

--- a/MakingHistory-DLC/MakingHistory-DLC-1.12.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.12.1.ckan
@@ -6,7 +6,7 @@
     "author":       "SQUAD",
     "version":      "1.12.1",
     "ksp_version_min": "1.12.2",
-    "ksp_version_max": "1.12.3",
+    "ksp_version_max": "1.12.4",
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {


### PR DESCRIPTION
The version numbers of the DLC were not updated with the latest KSP release, so the compatibility of the current versions is now extended to 1.12.4.