### PR TITLE
Remove fake ZeroMiniAVC dependencies from LGG's mods

### DIFF
--- a/ClickThroughBlocker/ClickThroughBlocker-0.1.9.5.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-0.1.9.5.ckan
@@ -19,9 +19,6 @@
     ],
     "depends": [
         {
-            "name": "ZeroMiniAVC"
-        },
-        {
             "name": "KerbalChangelog"
         }
     ],

--- a/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.10.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.10.ckan
@@ -19,9 +19,6 @@
     ],
     "depends": [
         {
-            "name": "ZeroMiniAVC"
-        },
-        {
             "name": "ToolbarController"
         }
     ],

--- a/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.11.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.11.ckan
@@ -19,9 +19,6 @@
     ],
     "depends": [
         {
-            "name": "ZeroMiniAVC"
-        },
-        {
             "name": "ToolbarController"
         }
     ],

--- a/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.12.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.12.ckan
@@ -19,9 +19,6 @@
     ],
     "depends": [
         {
-            "name": "ZeroMiniAVC"
-        },
-        {
             "name": "ToolbarController"
         }
     ],

--- a/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.13.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.13.ckan
@@ -19,9 +19,6 @@
     ],
     "depends": [
         {
-            "name": "ZeroMiniAVC"
-        },
-        {
             "name": "ToolbarController"
         }
     ],

--- a/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.14.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.14.ckan
@@ -20,9 +20,6 @@
     ],
     "depends": [
         {
-            "name": "ZeroMiniAVC"
-        },
-        {
             "name": "ToolbarController"
         }
     ],

--- a/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.15.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.15.ckan
@@ -21,9 +21,6 @@
     ],
     "depends": [
         {
-            "name": "ZeroMiniAVC"
-        },
-        {
             "name": "ToolbarController"
         }
     ],

--- a/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.16.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.16.ckan
@@ -21,9 +21,6 @@
     ],
     "depends": [
         {
-            "name": "ZeroMiniAVC"
-        },
-        {
             "name": "ToolbarController"
         }
     ],

--- a/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.17.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.17.ckan
@@ -21,9 +21,6 @@
     ],
     "depends": [
         {
-            "name": "ZeroMiniAVC"
-        },
-        {
             "name": "ToolbarController"
         }
     ],

--- a/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.6.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-1-0.1.10.6.ckan
@@ -19,9 +19,6 @@
     ],
     "depends": [
         {
-            "name": "ZeroMiniAVC"
-        },
-        {
             "name": "ToolbarController"
         }
     ],

--- a/ClickThroughBlocker/ClickThroughBlocker-1.10.5.ckan
+++ b/ClickThroughBlocker/ClickThroughBlocker-1.10.5.ckan
@@ -19,9 +19,6 @@
     ],
     "depends": [
         {
-            "name": "ZeroMiniAVC"
-        },
-        {
             "name": "ToolbarController"
         }
     ],

--- a/ToolbarController/ToolbarController-1-0.1.9.4.ckan
+++ b/ToolbarController/ToolbarController-1-0.1.9.4.ckan
@@ -22,9 +22,6 @@
     "depends": [
         {
             "name": "ClickThroughBlocker"
-        },
-        {
-            "name": "ZeroMiniAVC"
         }
     ],
     "recommends": [

--- a/ToolbarController/ToolbarController-1-0.1.9.5.ckan
+++ b/ToolbarController/ToolbarController-1-0.1.9.5.ckan
@@ -22,9 +22,6 @@
     "depends": [
         {
             "name": "ClickThroughBlocker"
-        },
-        {
-            "name": "ZeroMiniAVC"
         }
     ],
     "recommends": [

--- a/ToolbarController/ToolbarController-1-0.1.9.6.ckan
+++ b/ToolbarController/ToolbarController-1-0.1.9.6.ckan
@@ -22,9 +22,6 @@
     "depends": [
         {
             "name": "ClickThroughBlocker"
-        },
-        {
-            "name": "ZeroMiniAVC"
         }
     ],
     "recommends": [

--- a/ToolbarController/ToolbarController-1-0.1.9.7.ckan
+++ b/ToolbarController/ToolbarController-1-0.1.9.7.ckan
@@ -22,9 +22,6 @@
     "depends": [
         {
             "name": "ClickThroughBlocker"
-        },
-        {
-            "name": "ZeroMiniAVC"
         }
     ],
     "recommends": [


### PR DESCRIPTION
Historical counterpart of KSP-CKAN/NetKAN#9438, now no old versions of ToolbarController or ClickThroughBlocker depend on ZeroMiniAVC.