### PR TITLE
Fix compat of old ContractConfigurator

### DIFF
--- a/ContractConfigurator/ContractConfigurator-1.28.0.ckan
+++ b/ContractConfigurator/ContractConfigurator-1.28.0.ckan
@@ -6,7 +6,7 @@
     "author": "nightingale",
     "version": "1.28.0",
     "ksp_version_min": "1.8.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.8.99",
     "ksp_version_strict": true,
     "license": "MIT",
     "release_status": "stable",

--- a/ContractConfigurator/ContractConfigurator-1.30.1.ckan
+++ b/ContractConfigurator/ContractConfigurator-1.30.1.ckan
@@ -6,7 +6,7 @@
     "author": "nightingale",
     "version": "1.30.1",
     "ksp_version_min": "1.8.1",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.10",
     "ksp_version_strict": true,
     "license": "MIT",
     "release_status": "stable",

--- a/ContractConfigurator/ContractConfigurator-1.30.2.ckan
+++ b/ContractConfigurator/ContractConfigurator-1.30.2.ckan
@@ -6,7 +6,7 @@
     "author": "nightingale",
     "version": "1.30.2",
     "ksp_version_min": "1.8.1",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.10",
     "ksp_version_strict": true,
     "license": "MIT",
     "release_status": "stable",

--- a/ContractConfigurator/ContractConfigurator-1.30.3.ckan
+++ b/ContractConfigurator/ContractConfigurator-1.30.3.ckan
@@ -6,7 +6,7 @@
     "author": "nightingale",
     "version": "1.30.3",
     "ksp_version_min": "1.8.1",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.10",
     "ksp_version_strict": true,
     "license": "MIT",
     "release_status": "stable",

--- a/ContractConfigurator/ContractConfigurator-1.30.4.ckan
+++ b/ContractConfigurator/ContractConfigurator-1.30.4.ckan
@@ -6,7 +6,7 @@
     "author": "nightingale",
     "version": "1.30.4",
     "ksp_version_min": "1.8.1",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.10",
     "ksp_version_strict": true,
     "license": "MIT",
     "release_status": "stable",

--- a/ContractConfigurator/ContractConfigurator-1.30.5.ckan
+++ b/ContractConfigurator/ContractConfigurator-1.30.5.ckan
@@ -6,7 +6,7 @@
     "author": "nightingale",
     "version": "1.30.5",
     "ksp_version_min": "1.8.1",
-    "ksp_version_max": "1.99.99",
+    "ksp_version_max": "1.10",
     "ksp_version_strict": true,
     "license": "MIT",
     "release_status": "stable",


### PR DESCRIPTION
There's an old version with much broader compatibility than its successors:

![image](https://user-images.githubusercontent.com/1559108/203225950-457e79f3-8358-4311-9b04-01ebf4a16ac5.png)

Hmm, I guess I missed a few...
