### PR TITLE
Mark HyperDriveMod as version independent

### DIFF
--- a/HyperDriveMod/HyperDriveMod-2.4.ckan
+++ b/HyperDriveMod/HyperDriveMod-2.4.ckan
@@ -8,7 +8,7 @@
         "Monniasza"
     ],
     "version": "2.4",
-    "ksp_version": "1.8.1",
+    "ksp_version": "any",
     "license": "public-domain",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179321-hyper-drive-mod/",

--- a/HyperDriveMod/HyperDriveMod-2.5.ckan
+++ b/HyperDriveMod/HyperDriveMod-2.5.ckan
@@ -8,8 +8,7 @@
         "Monniasza"
     ],
     "version": "2.5",
-    "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.99.99",
+    "ksp_version": "any",
     "license": "public-domain",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179321-hyper-drive-mod/",

--- a/HyperDriveMod/HyperDriveMod-2.5.ckan
+++ b/HyperDriveMod/HyperDriveMod-2.5.ckan
@@ -8,7 +8,8 @@
         "Monniasza"
     ],
     "version": "2.5",
-    "ksp_version": "1.8.1",
+    "ksp_version_min": "1.0.0",
+    "ksp_version_max": "1.99.99",
     "license": "public-domain",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179321-hyper-drive-mod/",


### PR DESCRIPTION
<https://www.curseforge.com/kerbal/ksp-mods/simplehyperdrive>

![image](https://user-images.githubusercontent.com/1559108/220208196-5ac2b26a-7169-438f-ae80-c6e6baaa0a5b.png)

This is the historical counterpart of KSP-CKAN/NetKAN#9575.