### PR TITLE
Update Kopernicus CKAN metadata for legacy releases

### DIFF
--- a/Kopernicus/Kopernicus-2-release-1.12.1-140.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.12.1-140.ckan
@@ -16,7 +16,7 @@
         "prestja"
     ],
     "version": "2:release-1.12.1-140",
-    "ksp_version_min": "1.9.0",
+    "ksp_version_min": "1.12.0",
     "ksp_version_max": "1.12.99",
     "license": "LGPL-3.0",
     "release_status": "development",

--- a/Kopernicus/Kopernicus-2-release-1.12.1-141.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.12.1-141.ckan
@@ -16,7 +16,7 @@
         "prestja"
     ],
     "version": "2:release-1.12.1-141",
-   "ksp_version_min": "1.12.0",
+    "ksp_version_min": "1.12.0",
     "ksp_version_max": "1.12.99",
     "license": "LGPL-3.0",
     "release_status": "development",

--- a/Kopernicus/Kopernicus-2-release-1.12.1-141.ckan
+++ b/Kopernicus/Kopernicus-2-release-1.12.1-141.ckan
@@ -16,7 +16,7 @@
         "prestja"
     ],
     "version": "2:release-1.12.1-141",
-    "ksp_version_min": "1.9.0",
+   "ksp_version_min": "1.12.0",
     "ksp_version_max": "1.12.99",
     "license": "LGPL-3.0",
     "release_status": "development",


### PR DESCRIPTION
Release-140 and release-141 both are mistakenly marked as compatible with 1.10.x and 1.11.x when in actuality support was dropped.  This PR fixes that.