### PR TITLE
Fix historical ASET Consolidated installs

### DIFF
--- a/MK12PodIVAReplacementbyASET/MK12PodIVAReplacementbyASET-1-2.0.0.ckan
+++ b/MK12PodIVAReplacementbyASET/MK12PodIVAReplacementbyASET-1-2.0.0.ckan
@@ -58,7 +58,7 @@
     ],
     "install": [
         {
-            "find": "ASET_StockRpl_IVAs",
+            "find": "ASET",
             "install_to": "GameData",
             "include_only": [
                 "Assets",

--- a/Mk1CockpitIVAReplbyASET/Mk1CockpitIVAReplbyASET-2.0.0.ckan
+++ b/Mk1CockpitIVAReplbyASET/Mk1CockpitIVAReplbyASET-2.0.0.ckan
@@ -51,7 +51,7 @@
     ],
     "install": [
         {
-            "find": "ASET_StockRpl_IVAs",
+            "find": "ASET",
             "install_to": "GameData",
             "include_only": [
                 "ASET_StckRplc_Mk1_Cockpit.cfg",

--- a/Mk1LanderCanIVAReplbyASET/Mk1LanderCanIVAReplbyASET-2.0.0.ckan
+++ b/Mk1LanderCanIVAReplbyASET/Mk1LanderCanIVAReplbyASET-2.0.0.ckan
@@ -41,7 +41,7 @@
     ],
     "install": [
         {
-            "find": "ASET_StockRpl_IVAs",
+            "find": "ASET",
             "install_to": "GameData",
             "include_only": [
                 "ASET_StckRplc_Mk1_LCan.cfg",


### PR DESCRIPTION
KSP-CKAN/NetKAN#9560 switched the ASET IVA mods to a new fork, and in the process the install was changed from finding `ASET` to finding `ASET_StockRpl_IVAs`. This was wrong, and so far I have not been able to determine the cause of the error; it may have been a side effect of fiddling with `include_only` and figuring out how it works.

Now it's fixed.

Noticed while working on KSP-CKAN/NetKAN#9614.
