### PR TITLE
Revert change to ROSolar v1.1.1 versioning

### DIFF
--- a/ROSolar/ROSolar-v1.1.1.ckan
+++ b/ROSolar/ROSolar-v1.1.1.ckan
@@ -8,8 +8,8 @@
         "KSP-RO"
     ],
     "version": "v1.1.1",
-    "ksp_version_min": "1.8.1",
-    "ksp_version_max": "1.10.99",
+    "ksp_version_min": "1.10.1",
+    "ksp_version_max": "1.12.99",
     "license": "CC-BY-SA-4.0",
     "resources": {
         "homepage": "https://discordapp.com/invite/ZGbR6nv",


### PR DESCRIPTION
Looks like the issue was that we had a remote version file in the repo that overrode the versioning in the zip, but when a new ROSolar update was released, netkan had to get the version from the release zip, and thus reverted the metadata to the old versioning. The zip has been updated, but netkan is not re-indexing a prior release, thus we need to change the metadata in the CKAN.