### PR TITLE
Download taniwha's mods from archive.org

### DIFF
--- a/CustomBulkheadProfiles/CustomBulkheadProfiles-0.1.0.0.ckan
+++ b/CustomBulkheadProfiles/CustomBulkheadProfiles-0.1.0.0.ckan
@@ -11,7 +11,7 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?showtopic=181645",
         "repository": "https://github.com/taniwha/CustomBulkheadProfiles"
     },
-    "download": "http://taniwha.org/~bill/CustomBulkheadProfiles_v0.1.0.zip",
+    "download": "https://archive.org/download/CustomBulkheadProfiles-0.1.0.0/6DA02757-CustomBulkheadProfiles-0.1.0.0.zip",
     "download_size": 8677,
     "download_hash": {
         "sha1": "6DA02757BC3CC8A2F7F9DDC38A85C7431474B98A",

--- a/CustomBulkheadProfiles/CustomBulkheadProfiles-0.2.0.0.ckan
+++ b/CustomBulkheadProfiles/CustomBulkheadProfiles-0.2.0.0.ckan
@@ -17,7 +17,7 @@
         "editor",
         "convenience"
     ],
-    "download": "http://taniwha.org/~bill/CustomBulkheadProfiles_v0.2.0.zip",
+    "download": "https://archive.org/download/CustomBulkheadProfiles-0.2.0.0/BF1400D3-CustomBulkheadProfiles-0.2.0.0.zip",
     "download_size": 8686,
     "download_hash": {
         "sha1": "BF1400D3749B57146EACCBE5464A46005A03BEC8",

--- a/EarlyBird/EarlyBird-0.1.5.0.ckan
+++ b/EarlyBird/EarlyBird-0.1.5.0.ckan
@@ -12,7 +12,7 @@
     "version": "0.1.5.0",
     "ksp_version_min": "1.3.1",
     "ksp_version_max": "1.5.99",
-    "download": "http://taniwha.org/~bill/EarlyBird_v0.1.5.zip",
+    "download": "https://archive.org/download/EarlyBird-0.1.5.0/A0985F07-EarlyBird-0.1.5.0.zip",
     "download_size": 12615,
     "download_hash": {
         "sha1": "A0985F078750A3158DFFB08E25521F559E317842",

--- a/EarlyBird/EarlyBird-0.1.5.ckan
+++ b/EarlyBird/EarlyBird-0.1.5.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "http://taniwha.org/~bill/EarlyBird_v0.1.5.zip",
+    "download": "https://archive.org/download/EarlyBird-0.1.5/A0985F07-EarlyBird-0.1.5.zip",
     "download_size": 12615,
     "download_hash": {
         "sha1": "A0985F078750A3158DFFB08E25521F559E317842",

--- a/EarlyBird/EarlyBird-0.1.6.0.ckan
+++ b/EarlyBird/EarlyBird-0.1.6.0.ckan
@@ -12,7 +12,7 @@
     "version": "0.1.6.0",
     "ksp_version_min": "1.3.1",
     "ksp_version_max": "1.5.99",
-    "download": "http://taniwha.org/~bill/EarlyBird_v0.1.6.zip",
+    "download": "https://archive.org/download/EarlyBird-0.1.6.0/58E51884-EarlyBird-0.1.6.0.zip",
     "download_size": 12637,
     "download_hash": {
         "sha1": "58E51884D5D48135103E89FA6934DC302AEF818F",

--- a/EarlyBird/EarlyBird-0.1.7.0.ckan
+++ b/EarlyBird/EarlyBird-0.1.7.0.ckan
@@ -12,7 +12,7 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/162477-*",
         "repository": "https://github.com/taniwha/EarlyBird"
     },
-    "download": "http://taniwha.org/~bill/EarlyBird_v0.1.7.zip",
+    "download": "https://archive.org/download/EarlyBird-0.1.7.0/A69DBCFA-EarlyBird-0.1.7.0.zip",
     "download_size": 12735,
     "download_hash": {
         "sha1": "A69DBCFA68C53A75BA6F48F0B17C4C6F8C6274A0",

--- a/EarlyBird/EarlyBird-0.2.0.0.ckan
+++ b/EarlyBird/EarlyBird-0.2.0.0.ckan
@@ -16,7 +16,7 @@
         "plugin",
         "convenience"
     ],
-    "download": "http://taniwha.org/~bill/EarlyBird_v0.2.0.zip",
+    "download": "https://archive.org/download/EarlyBird-0.2.0.0/A349F9A0-EarlyBird-0.2.0.0.zip",
     "download_size": 12855,
     "download_hash": {
         "sha1": "A349F9A016CB9AF1EFE5937F92D73A42122A8D72",

--- a/EarlyBird/EarlyBird-0.2.1.0.ckan
+++ b/EarlyBird/EarlyBird-0.2.1.0.ckan
@@ -17,7 +17,7 @@
         "plugin",
         "convenience"
     ],
-    "download": "http://taniwha.org/~bill/EarlyBird_v0.2.1.zip",
+    "download": "https://archive.org/download/EarlyBird-0.2.1.0/5A01D667-EarlyBird-0.2.1.0.zip",
     "download_size": 17994,
     "download_hash": {
         "sha1": "5A01D667317EB01854C87FC86276EC057709CC53",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.5.1.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.5.1.ckan
@@ -44,7 +44,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.5.1.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.5.1/E07678FC-ExtraPlanetaryLaunchpads-5.5.1.zip",
     "download_size": 13405864,
     "download_hash": {
         "sha1": "E07678FCD7392EA195D58903A8F2E458DF66FA52",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.5.3.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.5.3.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.5.3.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.5.3.0/6FB415F7-ExtraPlanetaryLaunchpads-5.5.3.0.zip",
     "download_size": 13405824,
     "download_hash": {
         "sha1": "6FB415F7DD4AF24E00AADFED8EFBD9D45810276C",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.6.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.6.0.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.6.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.6.0.0/241C4EF6-ExtraPlanetaryLaunchpads-5.6.0.0.zip",
     "download_size": 13406279,
     "download_hash": {
         "sha1": "241C4EF65E5ECBDF7D3A60267E89A98CFEA22390",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.7.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.7.1.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.7.1.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.7.1.0/02199107-ExtraPlanetaryLaunchpads-5.7.1.0.zip",
     "download_size": 13884159,
     "download_hash": {
         "sha1": "021991076084BBE7D22D4C53D4A9B0C23E59EDE6",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.7.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.7.2.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.7.2.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.7.2.0/F5B70B98-ExtraPlanetaryLaunchpads-5.7.2.0.zip",
     "download_size": 13890644,
     "download_hash": {
         "sha1": "F5B70B983A6B4470087F4E9C19646465CACD02B3",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.8.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.8.0.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.8.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.8.0.0/CA6F8361-ExtraPlanetaryLaunchpads-5.8.0.0.zip",
     "download_size": 13898119,
     "download_hash": {
         "sha1": "CA6F8361FA1E2B6FA0D0A6A30C278C0B1F3BC936",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.9.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.9.0.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.9.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.9.0.0/AB3F210F-ExtraPlanetaryLaunchpads-5.9.0.0.zip",
     "download_size": 13914972,
     "download_hash": {
         "sha1": "AB3F210F843C37BDE53B3D02C11A5AEF16226BE5",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.0.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.0.0.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v6.0.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.0.0.0/CCD1D7D6-ExtraPlanetaryLaunchpads-6.0.0.0.zip",
     "download_size": 14788639,
     "download_hash": {
         "sha1": "CCD1D7D6FC2AC0ADCFCD562C918E825820C1D4FE",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.1.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.1.0.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v6.1.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.1.0.0/E66AADBC-ExtraPlanetaryLaunchpads-6.1.0.0.zip",
     "download_size": 14785983,
     "download_hash": {
         "sha1": "E66AADBCBAEC60177657F110B37A81AAC159143A",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.0.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v6.2.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.2.0.0/420E9361-ExtraPlanetaryLaunchpads-6.2.0.0.zip",
     "download_size": 17217505,
     "download_hash": {
         "sha1": "420E9361445AB1AA6D535E16BD18C504551B4ACF",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.1.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v6.2.1.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.2.1.0/A109E597-ExtraPlanetaryLaunchpads-6.2.1.0.zip",
     "download_size": 17217399,
     "download_hash": {
         "sha1": "A109E5971D434144E2D0D60602422BA1C79DDBEC",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.2.2.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v6.2.2.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.2.2.0/73F37340-ExtraPlanetaryLaunchpads-6.2.2.0.zip",
     "download_size": 17219930,
     "download_hash": {
         "sha1": "73F3734049087CB5A5BD8B30F94B59535B27E088",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.0.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.3.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.3.0.0/0F65D6F7-ExtraPlanetaryLaunchpads-6.3.0.0.zip",
     "download_size": 17221619,
     "download_hash": {
         "sha1": "0F65D6F7F2CD444394CC3968A8D3AB4881995D33",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.1.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.3.1.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.3.1.0/CDC483A1-ExtraPlanetaryLaunchpads-6.3.1.0.zip",
     "download_size": 17338171,
     "download_hash": {
         "sha1": "CDC483A1394517758258C2CD0DD93A375D7C76FF",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.2.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.3.2.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.3.2.0/769F4C3F-ExtraPlanetaryLaunchpads-6.3.2.0.zip",
     "download_size": 17341041,
     "download_hash": {
         "sha1": "769F4C3F93F75C4FD69FC82CF496AD2592DDA834",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.3.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.3.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.3.3.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.3.3.0/CEBA460F-ExtraPlanetaryLaunchpads-6.3.3.0.zip",
     "download_size": 17805941,
     "download_hash": {
         "sha1": "CEBA460FCE0967DC09F9735D221291CC941CE766",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.4.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.4.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.3.4.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.3.4.0/DF44A4CF-ExtraPlanetaryLaunchpads-6.3.4.0.zip",
     "download_size": 17806225,
     "download_hash": {
         "sha1": "DF44A4CFD9E3BF7EC6EE1FE8377B7B1FD18803F5",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.5.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.3.5.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.3.5.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.3.5.0/A5E115D9-ExtraPlanetaryLaunchpads-6.3.5.0.zip",
     "download_size": 17807561,
     "download_hash": {
         "sha1": "A5E115D98B14C078311B454AA93395DD1E2CA058",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.4.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.4.0.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.4.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.4.0.0/2A8CFF1A-ExtraPlanetaryLaunchpads-6.4.0.0.zip",
     "download_size": 17808776,
     "download_hash": {
         "sha1": "2A8CFF1A4DB6AEDAC1AF453BEC5BC910BC5B3382",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.5.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.5.0.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.5.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.5.0.0/CF4396D5-ExtraPlanetaryLaunchpads-6.5.0.0.zip",
     "download_size": 18176169,
     "download_hash": {
         "sha1": "CF4396D52F5CE33D6409ED7DC814A6ED61FE349B",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.5.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.5.1.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.5.1.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.5.1.0/4048A03F-ExtraPlanetaryLaunchpads-6.5.1.0.zip",
     "download_size": 18176159,
     "download_hash": {
         "sha1": "4048A03F79F1E9AED73FC70E552BB2F07A854DE1",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.0.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.6.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.6.0.0/3AE23560-ExtraPlanetaryLaunchpads-6.6.0.0.zip",
     "download_size": 18179373,
     "download_hash": {
         "sha1": "3AE23560C21D187A8C9E4576D0AADEB0C002923A",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.1.0.ckan
@@ -52,7 +52,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.6.1.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.6.1.0/9A268166-ExtraPlanetaryLaunchpads-6.6.1.0.zip",
     "download_size": 18179774,
     "download_hash": {
         "sha1": "9A268166EE9FBD73875EC68D16323F1408AE0B26",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.6.2.0.ckan
@@ -57,7 +57,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.6.2.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.6.2.0/5271CF27-ExtraPlanetaryLaunchpads-6.6.2.0.zip",
     "download_size": 18183647,
     "download_hash": {
         "sha1": "5271CF27738CB8E9E35AACF8DBCCBD30E018DC85",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.0.0.ckan
@@ -57,7 +57,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.7.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.7.0.0/25A24F47-ExtraPlanetaryLaunchpads-6.7.0.0.zip",
     "download_size": 18183738,
     "download_hash": {
         "sha1": "25A24F474C00FED976A2B170A9DD7FB252C01D1E",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.1.0.ckan
@@ -58,7 +58,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.7.1.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.7.1.0/785C3FE0-ExtraPlanetaryLaunchpads-6.7.1.0.zip",
     "download_size": 18183828,
     "download_hash": {
         "sha1": "785C3FE02EF9B7D035CAC49F65B92F1B203BF39C",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.2.0.ckan
@@ -58,7 +58,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.7.2.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.7.2.0/CCDC3190-ExtraPlanetaryLaunchpads-6.7.2.0.zip",
     "download_size": 18184067,
     "download_hash": {
         "sha1": "CCDC31902325E5FD817EDA06F3CC9BC1EBF80259",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.3.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.7.3.0.ckan
@@ -61,7 +61,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.7.3.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.7.3.0/A37014B9-ExtraPlanetaryLaunchpads-6.7.3.0.zip",
     "download_size": 18227772,
     "download_hash": {
         "sha1": "A37014B9C66A45145CD18840D81CEF5F9A53EC69",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.0.0.ckan
@@ -61,7 +61,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.8.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.8.0.0/36C397B2-ExtraPlanetaryLaunchpads-6.8.0.0.zip",
     "download_size": 18230412,
     "download_hash": {
         "sha1": "36C397B26A51D1E4C26A88EB1D0EA6AC8A8C1133",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.1.0.ckan
@@ -61,7 +61,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.8.1.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.8.1.0/0A1D1D1C-ExtraPlanetaryLaunchpads-6.8.1.0.zip",
     "download_size": 18230426,
     "download_hash": {
         "sha1": "0A1D1D1C86BD019A16A91657CA6CB5DF49F4E7D0",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.2.0.ckan
@@ -61,7 +61,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.8.2.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.8.2.0/D94CBC7D-ExtraPlanetaryLaunchpads-6.8.2.0.zip",
     "download_size": 18228029,
     "download_hash": {
         "sha1": "D94CBC7DCBFDC35604261DAB8980573CCFD09330",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.3.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.8.3.0.ckan
@@ -62,7 +62,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.8.3.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.8.3.0/A6354C21-ExtraPlanetaryLaunchpads-6.8.3.0.zip",
     "download_size": 18232052,
     "download_hash": {
         "sha1": "A6354C2176D92CAD55ABDE5E6C87451E75919E41",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.99.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.99.0.0.ckan
@@ -63,7 +63,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.99.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.99.0.0/15EEDF06-ExtraPlanetaryLaunchpads-6.99.0.0.zip",
     "download_size": 18325994,
     "download_hash": {
         "sha1": "15EEDF063DA29B6D85FF4F47A6846FBFFF6912F4",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.99.1.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.99.1.0.ckan
@@ -63,7 +63,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.99.1.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.99.1.0/78A1025C-ExtraPlanetaryLaunchpads-6.99.1.0.zip",
     "download_size": 18493579,
     "download_hash": {
         "sha1": "78A1025CEA65BB0BCF2E62C2A64B74F337F1631C",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.99.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.99.2.0.ckan
@@ -64,7 +64,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.99.2.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.99.2.0/4638BAE2-ExtraPlanetaryLaunchpads-6.99.2.0.zip",
     "download_size": 16912700,
     "download_hash": {
         "sha1": "4638BAE2F83A124640E31FCC487DE2A762137295",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.99.3.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-6.99.3.0.ckan
@@ -64,7 +64,7 @@
             "install_to": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/ExtraplanetaryLaunchpads_v6.99.3.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-6.99.3.0/A1FEDDFC-ExtraPlanetaryLaunchpads-6.99.3.0.zip",
     "download_size": 16913553,
     "download_hash": {
         "sha1": "A1FEDDFC3448564F81A79F7EAB9F61E7EDDC2D87",

--- a/KerbalStats/KerbalStats-3.0.0.ckan
+++ b/KerbalStats/KerbalStats-3.0.0.ckan
@@ -19,7 +19,7 @@
             "filter": "KerbalStatsWrapper.cs"
         }
     ],
-    "download": "http://taniwha.org/~bill/KerbalStats_v3.0.0.zip",
+    "download": "https://archive.org/download/KerbalStats-3.0.0/6C62A8DD-KerbalStats-3.0.0.zip",
     "download_size": 23987,
     "download_hash": {
         "sha1": "6C62A8DD52991A4D2C49B1C0CD7CD3165FD13CD9",

--- a/KerbalStats/KerbalStats-3.0.1.ckan
+++ b/KerbalStats/KerbalStats-3.0.1.ckan
@@ -19,7 +19,7 @@
             "filter": "KerbalStatsWrapper.cs"
         }
     ],
-    "download": "http://taniwha.org/~bill/KerbalStats_v3.0.1.zip",
+    "download": "https://archive.org/download/KerbalStats-3.0.1/1BFBAF46-KerbalStats-3.0.1.zip",
     "download_size": 24661,
     "download_hash": {
         "sha1": "1BFBAF46ABB014A242C6F36CDA0B29138566F2A4",

--- a/KerbalStats/KerbalStats-3.0.2.ckan
+++ b/KerbalStats/KerbalStats-3.0.2.ckan
@@ -19,7 +19,7 @@
             "filter": "KerbalStatsWrapper.cs"
         }
     ],
-    "download": "http://taniwha.org/~bill/KerbalStats_v3.0.2.zip",
+    "download": "https://archive.org/download/KerbalStats-3.0.2/16980E9B-KerbalStats-3.0.2.zip",
     "download_size": 24339,
     "download_hash": {
         "sha1": "16980E9B3F2BF84CEF50F7CC2AA462344FCFB8CF",

--- a/KerbalStats/KerbalStats-3.1.0.ckan
+++ b/KerbalStats/KerbalStats-3.1.0.ckan
@@ -23,7 +23,7 @@
             "filter": "KerbalStatsWrapper.cs"
         }
     ],
-    "download": "http://taniwha.org/~bill/KerbalStats_v3.1.0.zip",
+    "download": "https://archive.org/download/KerbalStats-3.1.0/0E71BD9E-KerbalStats-3.1.0.zip",
     "download_size": 24616,
     "download_hash": {
         "sha1": "0E71BD9E8CAC6A736F11000BA23D4691498825D4",

--- a/ModularFuelTanks/ModularFuelTanks-5.10.0.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.10.0.ckan
@@ -56,7 +56,7 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.10.0.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.10.0/D0392663-ModularFuelTanks-5.10.0.zip",
     "download_size": 38115,
     "download_hash": {
         "sha1": "D03926630C6CBB2E4606FD560A09DD07D4068A30",

--- a/ModularFuelTanks/ModularFuelTanks-5.11.0.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.11.0.ckan
@@ -56,7 +56,7 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.11.0.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.11.0/BBBCB87F-ModularFuelTanks-5.11.0.zip",
     "download_size": 38749,
     "download_hash": {
         "sha1": "BBBCB87F8E2416385C1F7AB7EF46AA3482BA526A",

--- a/ModularFuelTanks/ModularFuelTanks-5.11.1.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.11.1.ckan
@@ -57,7 +57,7 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.11.1.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.11.1/2FBE36AE-ModularFuelTanks-5.11.1.zip",
     "download_size": 38785,
     "download_hash": {
         "sha1": "2FBE36AE123AA0599AFDDBEE1BA0E644528DCFA9",

--- a/ModularFuelTanks/ModularFuelTanks-5.12.0.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.12.0.ckan
@@ -56,7 +56,7 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.12.0.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.12.0/A5CFB970-ModularFuelTanks-5.12.0.zip",
     "download_size": 39172,
     "download_hash": {
         "sha1": "A5CFB970B1A67B831CB61BB159DB408EB3B08667",

--- a/ModularFuelTanks/ModularFuelTanks-5.12.1.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.12.1.ckan
@@ -56,7 +56,7 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.12.1.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.12.1/9C1FC883-ModularFuelTanks-5.12.1.zip",
     "download_size": 39132,
     "download_hash": {
         "sha1": "9C1FC883B0B517CC6DD700A70029453623317883",

--- a/ModularFuelTanks/ModularFuelTanks-5.12.2.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.12.2.ckan
@@ -57,7 +57,7 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.12.2.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.12.2/AB3FA4BA-ModularFuelTanks-5.12.2.zip",
     "download_size": 40319,
     "download_hash": {
         "sha1": "AB3FA4BA8E80E8DB8EE978CA43BE0C5FA005A912",

--- a/ModularFuelTanks/ModularFuelTanks-5.12.3.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.12.3.ckan
@@ -57,7 +57,7 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.12.3.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.12.3/B0B341DB-ModularFuelTanks-5.12.3.zip",
     "download_size": 40797,
     "download_hash": {
         "sha1": "B0B341DBC90AF7CE07C52132E4AE1D6606680FE1",

--- a/ModularFuelTanks/ModularFuelTanks-5.13.0.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.13.0.ckan
@@ -60,7 +60,7 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.13.0.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.13.0/6ABFED64-ModularFuelTanks-5.13.0.zip",
     "download_size": 41596,
     "download_hash": {
         "sha1": "6ABFED64792B7217460625A673002CACF534328B",

--- a/ModularFuelTanks/ModularFuelTanks-5.13.1.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.13.1.ckan
@@ -61,7 +61,7 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.13.1.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.13.1/133FBD08-ModularFuelTanks-5.13.1.zip",
     "download_size": 41607,
     "download_hash": {
         "sha1": "133FBD08A779DE25593BB1CCB23E421F36409D56",

--- a/ModularFuelTanks/ModularFuelTanks-5.7.6.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.7.6.ckan
@@ -80,7 +80,7 @@
             "name": "TVPP"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.7.6.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.7.6/9AF800ED-ModularFuelTanks-5.7.6.zip",
     "download_size": 36933,
     "download_hash": {
         "sha1": "9AF800EDBF77CF079A463030FE73E03105B41191",

--- a/ModularFuelTanks/ModularFuelTanks-5.8.1.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.8.1.ckan
@@ -80,7 +80,7 @@
             "name": "TVPP"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.8.1.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.8.1/DCB898D9-ModularFuelTanks-5.8.1.zip",
     "download_size": 35058,
     "download_hash": {
         "sha1": "DCB898D93071FCA36310E3ACE8899DC1EF768455",

--- a/ModularFuelTanks/ModularFuelTanks-5.8.2.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.8.2.ckan
@@ -80,7 +80,7 @@
             "name": "TVPP"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.8.2.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.8.2/263F29FD-ModularFuelTanks-5.8.2.zip",
     "download_size": 35425,
     "download_hash": {
         "sha1": "263F29FD1056D863B73C7DCA24457BD9BE3055D3",

--- a/ModularFuelTanks/ModularFuelTanks-5.8.3.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.8.3.ckan
@@ -80,7 +80,7 @@
             "name": "TVPP"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.8.3.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.8.3/7BD8D51B-ModularFuelTanks-5.8.3.zip",
     "download_size": 35483,
     "download_hash": {
         "sha1": "7BD8D51BD62F0C692F0BBA71A0F848E405C45F84",

--- a/ModularFuelTanks/ModularFuelTanks-5.9.0.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.9.0.ckan
@@ -56,7 +56,7 @@
             "name": "SpaceShuttleEngines"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.9.0.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.9.0/5312D4A0-ModularFuelTanks-5.9.0.zip",
     "download_size": 35813,
     "download_hash": {
         "sha1": "5312D4A0F0081C626D750F5BB3BE03D1F98CB184",

--- a/Shabby/Shabby-0.3.0.0.ckan
+++ b/Shabby/Shabby-0.3.0.0.ckan
@@ -19,7 +19,7 @@
             "name": "Harmony2"
         }
     ],
-    "download": "http://taniwha.org/~bill/Shabby_v0.3.0.zip",
+    "download": "https://archive.org/download/Shabby-0.3.0.0/67798B09-Shabby-0.3.0.0.zip",
     "download_size": 388639,
     "download_hash": {
         "sha1": "67798B09CA1EF68A4125E96D650ECD9709443794",

--- a/TalisarParts/TalisarParts-v1.2.1.ckan
+++ b/TalisarParts/TalisarParts-v1.2.1.ckan
@@ -22,7 +22,7 @@
         "en-us",
         "ja"
     ],
-    "download": "http://taniwha.org/~bill/TalisarParts-1.2.1.zip",
+    "download": "https://archive.org/download/TalisarParts-v1.2.1/044771FC-TalisarParts-v1.2.1.zip",
     "download_size": 7723945,
     "download_hash": {
         "sha1": "044771FCE912D94FEAD679268A1F76DBDF0FA138",

--- a/TalisarParts/TalisarParts-v1.3.0.ckan
+++ b/TalisarParts/TalisarParts-v1.3.0.ckan
@@ -24,7 +24,7 @@
         "ru",
         "zh-cn"
     ],
-    "download": "http://taniwha.org/~bill/TalisarParts-1.3.0.zip",
+    "download": "https://archive.org/download/TalisarParts-v1.3.0/F64CE19E-TalisarParts-v1.3.0.zip",
     "download_size": 7702427,
     "download_hash": {
         "sha1": "F64CE19E795B6AECB4A7B19E5CE31031A19FF87D",


### PR DESCRIPTION
This is the continuation of KSP-CKAN/NetKAN#9734. Taniwha's mods are hosted on an author-owned server, which is slowly disintegrating into a pile of dust. Attempts to address this root cause have failed. The netkans have been frozen.

Now the affected mods that have backups on archive.org are updated to download from there. That host isn't perfect, but at least when it fails, it'll register as a network failure rather than a corrupted file, and therefore be more easily recoverable.
