### PR TITLE
Download more of taniwha's mods from archive.org

### DIFF
--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-4.4.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-4.4.0.ckan
@@ -40,7 +40,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v4.4.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-4.4.0/20DA311A-ExtraPlanetaryLaunchpads-4.4.0.zip",
     "download_size": 14294037,
     "download_hash": {
         "sha1": "20DA311AD129CEDC38F2D40E2F6534D75236EACE",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-4.5.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-4.5.0.ckan
@@ -40,7 +40,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v4.5.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-4.5.0/A15BE7B6-ExtraPlanetaryLaunchpads-4.5.0.zip",
     "download_size": 14293357,
     "download_hash": {
         "sha1": "A15BE7B67059BB5BBC210427AF6A7FA7564535DD",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.0.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.0.0.ckan
@@ -41,7 +41,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.0.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.0.0/E9BC8952-ExtraPlanetaryLaunchpads-5.0.0.zip",
     "download_size": 14295137,
     "download_hash": {
         "sha1": "E9BC89526E9EDBC420456B69D31313AD22B3365F",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.0.1.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.0.1.ckan
@@ -41,7 +41,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.0.1.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.0.1/99FEFE8F-ExtraPlanetaryLaunchpads-5.0.1.zip",
     "download_size": 14300342,
     "download_hash": {
         "sha1": "99FEFE8F7188E0E3A4D7EF4062532D211945B71F",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.0.2.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.0.2.ckan
@@ -41,7 +41,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.0.2.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.0.2/B320280F-ExtraPlanetaryLaunchpads-5.0.2.zip",
     "download_size": 14299805,
     "download_hash": {
         "sha1": "B320280F74779B94FEC55E8748E318F38FC06A49",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.2.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.2.ckan
@@ -41,7 +41,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.1.2.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.1.2/ADC04B7D-ExtraPlanetaryLaunchpads-5.1.2.zip",
     "download_size": 14302106,
     "download_hash": {
         "sha1": "ADC04B7DEA439E216E1554C43EAA60E152751F0D",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.90.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.90.ckan
@@ -44,7 +44,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.1.90.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.1.90/C2548A66-ExtraPlanetaryLaunchpads-5.1.90.zip",
     "download_size": 14407171,
     "download_hash": {
         "sha1": "C2548A66626CAD1ED3CB4BA0E9C1748EC9CD86C8",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.92.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.92.ckan
@@ -44,7 +44,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.1.92.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.1.92/A638A8A2-ExtraPlanetaryLaunchpads-5.1.92.zip",
     "download_size": 14407389,
     "download_hash": {
         "sha1": "A638A8A29F5723B20FFFB0E0338FD89EAB44FA61",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.93.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.93.ckan
@@ -44,7 +44,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.1.93.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.1.93/F5B50C4F-ExtraPlanetaryLaunchpads-5.1.93.zip",
     "download_size": 14407987,
     "download_hash": {
         "sha1": "F5B50C4FEF79870B442B26B989290FBE2AB84B5D",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.94.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.1.94.ckan
@@ -44,7 +44,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.1.94.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.1.94/60D55194-ExtraPlanetaryLaunchpads-5.1.94.zip",
     "download_size": 14408952,
     "download_hash": {
         "sha1": "60D55194CECC99730BFBEE49B02D8B7F9B696F06",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.2.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.2.0.ckan
@@ -45,7 +45,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.2.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.2.0/E9B088B7-ExtraPlanetaryLaunchpads-5.2.0.zip",
     "download_size": 14549809,
     "download_hash": {
         "sha1": "E9B088B7D5660B01F18ACAC73B145447B2B67BF9",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.2.1.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.2.1.ckan
@@ -45,7 +45,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.2.1.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.2.1/3B6CB54C-ExtraPlanetaryLaunchpads-5.2.1.zip",
     "download_size": 14551016,
     "download_hash": {
         "sha1": "3B6CB54CAB5A8DFD1C73D8118773766BD8A5A282",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.2.2.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.2.2.ckan
@@ -45,7 +45,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.2.2.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.2.2/081FB37E-ExtraPlanetaryLaunchpads-5.2.2.zip",
     "download_size": 14561176,
     "download_hash": {
         "sha1": "081FB37EEA80699B17AED8A4FB9E2FCEE96C20B7",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.2.94.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.2.94.ckan
@@ -45,7 +45,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.2.94.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.2.94/CBDBD92D-ExtraPlanetaryLaunchpads-5.2.94.zip",
     "download_size": 13285264,
     "download_hash": {
         "sha1": "CBDBD92D0C6EF7A308932BEB627F30F86EAFB2F3",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.2.95.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.2.95.ckan
@@ -45,7 +45,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.2.95.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.2.95/5A4FCB4E-ExtraPlanetaryLaunchpads-5.2.95.zip",
     "download_size": 13287667,
     "download_hash": {
         "sha1": "5A4FCB4E3F4D1C092F8D118A2A71812A3CC616E8",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.3.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.3.0.ckan
@@ -45,7 +45,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.3.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.3.0/EB0E116B-ExtraPlanetaryLaunchpads-5.3.0.zip",
     "download_size": 13237244,
     "download_hash": {
         "sha1": "EB0E116B8B06E30FA0DC7014BD63A9D9431D756C",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.3.2.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.3.2.ckan
@@ -44,7 +44,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.3.2.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.3.2/0912326C-ExtraPlanetaryLaunchpads-5.3.2.zip",
     "download_size": 13299286,
     "download_hash": {
         "sha1": "0912326CDC49EBAA282EC3B8F26CCEA0B156C07E",

--- a/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.4.0.ckan
+++ b/ExtraPlanetaryLaunchpads/ExtraPlanetaryLaunchpads-5.4.0.ckan
@@ -45,7 +45,7 @@
             "filter": "Ships"
         }
     ],
-    "download": "http://taniwha.org/~bill/Extraplanetary_Launchpads_v5.4.0.zip",
+    "download": "https://archive.org/download/ExtraPlanetaryLaunchpads-5.4.0/4C559DEE-ExtraPlanetaryLaunchpads-5.4.0.zip",
     "download_size": 13395550,
     "download_hash": {
         "sha1": "4C559DEE84B550D12FD20CDBAED864DEB2ABE602",

--- a/FreeEVA/FreeEVA-0.3.0.ckan
+++ b/FreeEVA/FreeEVA-0.3.0.ckan
@@ -11,7 +11,7 @@
     },
     "version": "0.3.0",
     "ksp_version": "0.90",
-    "download": "http://taniwha.org/~bill/FreeEVA-0.3.0.zip",
+    "download": "https://archive.org/download/FreeEVA-0.3.0/613B863A-FreeEVA-0.3.0.zip",
     "download_size": 24915,
     "download_hash": {
         "sha1": "613B863A803B3B9C92BBFDE44E306077B376FAD7",

--- a/KerbalStats/KerbalStats-1.0.0.ckan
+++ b/KerbalStats/KerbalStats-1.0.0.ckan
@@ -17,7 +17,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "http://taniwha.org/~bill/KerbalStats_v1.0.0.zip",
+    "download": "https://archive.org/download/KerbalStats-1.0.0/989EA764-KerbalStats-1.0.0.zip",
     "download_size": 19143,
     "download_hash": {
         "sha1": "989EA76401CB8E9D79DBA233E8ED11F7489B0D63",

--- a/KerbalStats/KerbalStats-1.1.0.ckan
+++ b/KerbalStats/KerbalStats-1.1.0.ckan
@@ -17,7 +17,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "http://taniwha.org/~bill/KerbalStats_v1.1.0.zip",
+    "download": "https://archive.org/download/KerbalStats-1.1.0/31A6200D-KerbalStats-1.1.0.zip",
     "download_size": 19516,
     "download_hash": {
         "sha1": "31A6200DD2B7146DC9578AE55E97011C389F9D88",

--- a/KerbalStats/KerbalStats-1.1.1.ckan
+++ b/KerbalStats/KerbalStats-1.1.1.ckan
@@ -18,7 +18,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "http://taniwha.org/~bill/KerbalStats_v1.1.1.zip",
+    "download": "https://archive.org/download/KerbalStats-1.1.1/F9D334AD-KerbalStats-1.1.1.zip",
     "download_size": 19518,
     "download_hash": {
         "sha1": "F9D334ADF49B746EDDFD1AE6D3B5F349E4CCF1C1",

--- a/KerbalStats/KerbalStats-2.0.0.ckan
+++ b/KerbalStats/KerbalStats-2.0.0.ckan
@@ -19,7 +19,7 @@
             "filter": "KerbalStatsWrapper.cs"
         }
     ],
-    "download": "http://taniwha.org/~bill/KerbalStats_v2.0.0.zip",
+    "download": "https://archive.org/download/KerbalStats-2.0.0/D84A7F21-KerbalStats-2.0.0.zip",
     "download_size": 18873,
     "download_hash": {
         "sha1": "D84A7F21F30B9599B88579AFBB7E10764D5F910C",

--- a/KerbalStats/KerbalStats-2.1.0.ckan
+++ b/KerbalStats/KerbalStats-2.1.0.ckan
@@ -19,7 +19,7 @@
             "filter": "KerbalStatsWrapper.cs"
         }
     ],
-    "download": "http://taniwha.org/~bill/KerbalStats_v2.1.0.zip",
+    "download": "http://taniwhahttps://archive.org/download/KerbalStats-2.1.0/802658A2-KerbalStats-2.1.0.zip",
     "download_size": 18643,
     "download_hash": {
         "sha1": "802658A2E8CFEC6ECA38B42FE9A73F0CC23224DA",

--- a/ModularFuelTanks/ModularFuelTanks-5.3.0.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.3.0.ckan
@@ -80,7 +80,7 @@
             "name": "TVPP"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.3.0.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.3.0/D319C42B-ModularFuelTanks-5.3.0.zip",
     "download_size": 35010,
     "download_hash": {
         "sha1": "D319C42B6AD92C25E48B5398452A8A9E71E001FB",

--- a/ModularFuelTanks/ModularFuelTanks-5.5.1.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.5.1.ckan
@@ -75,7 +75,7 @@
             "name": "TVPP"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.5.1.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.5.1/47B338C2-ModularFuelTanks-5.5.1.zip",
     "download_size": 84763,
     "download_hash": {
         "sha1": "47B338C2FB87C4C73B2781942188EDF134AA5A5A",

--- a/ModularFuelTanks/ModularFuelTanks-5.5.2.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.5.2.ckan
@@ -75,7 +75,7 @@
             "name": "TVPP"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.5.2.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.5.2/C6182F32-ModularFuelTanks-5.5.2.zip",
     "download_size": 86470,
     "download_hash": {
         "sha1": "C6182F32B9CE21734E1A3CB7EC4D9C5042E2D122",

--- a/ModularFuelTanks/ModularFuelTanks-5.6.0.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.6.0.ckan
@@ -80,7 +80,7 @@
             "name": "TVPP"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.6.0.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.6.0/F807D77B-ModularFuelTanks-5.6.0.zip",
     "download_size": 87716,
     "download_hash": {
         "sha1": "F807D77BA93E10D89CE645F60ABB5B3A344AEC81",

--- a/ModularFuelTanks/ModularFuelTanks-5.6.1.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.6.1.ckan
@@ -80,7 +80,7 @@
             "name": "TVPP"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.6.1.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.6.1/9D1771A3-ModularFuelTanks-5.6.1.zip",
     "download_size": 86987,
     "download_hash": {
         "sha1": "9D1771A380EDCF4F4BE7006FCBD84CEBDA932DC7",

--- a/ModularFuelTanks/ModularFuelTanks-5.7.0.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.7.0.ckan
@@ -80,7 +80,7 @@
             "name": "TVPP"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.7.0.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.7.0/36C60FE6-ModularFuelTanks-5.7.0.zip",
     "download_size": 36265,
     "download_hash": {
         "sha1": "36C60FE66DA232876C8A4FE0EC8E744CD3702B22",

--- a/ModularFuelTanks/ModularFuelTanks-5.7.4.ckan
+++ b/ModularFuelTanks/ModularFuelTanks-5.7.4.ckan
@@ -80,7 +80,7 @@
             "name": "TVPP"
         }
     ],
-    "download": "http://taniwha.org/~bill/ModularFuelTanks_v5.7.4.zip",
+    "download": "https://archive.org/download/ModularFuelTanks-5.7.4/C52E0DC8-ModularFuelTanks-5.7.4.zip",
     "download_size": 36604,
     "download_hash": {
         "sha1": "C52E0DC8B469307FCF3B8E37795CD04B3B146C26",


### PR DESCRIPTION
After #3193, I ran:

```
egrep -r 'download.*taniwha' * --include='*.ckan'
```

and cross referenced with

<https://archive.org/details/kspckanmods?query=taniwha&sort=-publicdate>

... and noticed that some mods weren't updated. I think my picking through the list on the web page was more haphazard than I realized.

Now a bunch more are updated.
