### PR TITLE
Put more specific Parallax texture dependencies first

### DIFF
--- a/Parallax-StockScatterTextures/Parallax-StockScatterTextures-2.0.0.ckan
+++ b/Parallax-StockScatterTextures/Parallax-StockScatterTextures-2.0.0.ckan
@@ -23,10 +23,10 @@
             "name": "ModuleManager"
         },
         {
-            "name": "Parallax"
+            "name": "Parallax-StockTextures"
         },
         {
-            "name": "Parallax-StockTextures"
+            "name": "Parallax"
         }
     ],
     "conflicts": [


### PR DESCRIPTION
This is the historical counterpart of KSP-CKAN/NetKAN#9810.
Only one older module has an affected dependency.
