### PR TITLE
Make Kabrams sunflare abstracts module-specific

### DIFF
--- a/KabramsSunFlaresPack-Blue-High/KabramsSunFlaresPack-Blue-High-001.ckan
+++ b/KabramsSunFlaresPack-Blue-High/KabramsSunFlaresPack-Blue-High-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Blue-High",
     "name": "Kabrams Sun Flare Blue High",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "High quality blue sunflare for Scatterer, for support of up to 4K screen sizes",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Blue-Low/KabramsSunFlaresPack-Blue-Low-001.ckan
+++ b/KabramsSunFlaresPack-Blue-Low/KabramsSunFlaresPack-Blue-Low-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Blue-Low",
     "name": "Kabrams Sun Flare Blue Low",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Low quality blue sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Blue-Medium/KabramsSunFlaresPack-Blue-Medium-001.ckan
+++ b/KabramsSunFlaresPack-Blue-Medium/KabramsSunFlaresPack-Blue-Medium-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Blue-Medium",
     "name": "Kabrams Sun Flare Blue Medium",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Medium quality blue sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Diamond-High/KabramsSunFlaresPack-Diamond-High-001.ckan
+++ b/KabramsSunFlaresPack-Diamond-High/KabramsSunFlaresPack-Diamond-High-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Diamond-High",
     "name": "Kabrams Sun Flare Diamond High",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "High quality diamond sunflare for Scatterer, for support of up to 4K screen sizes",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Diamond-Low/KabramsSunFlaresPack-Diamond-Low-001.ckan
+++ b/KabramsSunFlaresPack-Diamond-Low/KabramsSunFlaresPack-Diamond-Low-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Diamond-Low",
     "name": "Kabrams Sun Flare Diamond Low",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Low quality diamond sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Diamond-Medium/KabramsSunFlaresPack-Diamond-Medium-001.ckan
+++ b/KabramsSunFlaresPack-Diamond-Medium/KabramsSunFlaresPack-Diamond-Medium-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Diamond-Medium",
     "name": "Kabrams Sun Flare Diamond Medium",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Medium quality diamond sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Green-High/KabramsSunFlaresPack-Green-High-001.ckan
+++ b/KabramsSunFlaresPack-Green-High/KabramsSunFlaresPack-Green-High-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Green-High",
     "name": "Kabrams Sun Flare Green High",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "High quality green sunflare for Scatterer, for support of up to 4K screen sizes",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Green-Low/KabramsSunFlaresPack-Green-Low-001.ckan
+++ b/KabramsSunFlaresPack-Green-Low/KabramsSunFlaresPack-Green-Low-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Green-Low",
     "name": "Kabrams Sun Flare Green Low",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Low quality green sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Green-Medium/KabramsSunFlaresPack-Green-Medium-001.ckan
+++ b/KabramsSunFlaresPack-Green-Medium/KabramsSunFlaresPack-Green-Medium-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Green-Medium",
     "name": "Kabrams Sun Flare Green Medium",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Medium quality green sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Orange-High/KabramsSunFlaresPack-Orange-High-001.ckan
+++ b/KabramsSunFlaresPack-Orange-High/KabramsSunFlaresPack-Orange-High-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Orange-High",
     "name": "Kabrams Sun Flare Orange High",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "High quality orange sunflare for Scatterer, for support of up to 4K screen sizes",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Orange-Low/KabramsSunFlaresPack-Orange-Low-001.ckan
+++ b/KabramsSunFlaresPack-Orange-Low/KabramsSunFlaresPack-Orange-Low-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Orange-Low",
     "name": "Kabrams Sun Flare Orange Low",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Low quality orange sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Orange-Medium/KabramsSunFlaresPack-Orange-Medium-001.ckan
+++ b/KabramsSunFlaresPack-Orange-Medium/KabramsSunFlaresPack-Orange-Medium-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Orange-Medium",
     "name": "Kabrams Sun Flare Orange Medium",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Medium quality orange sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Red-High/KabramsSunFlaresPack-Red-High-001.ckan
+++ b/KabramsSunFlaresPack-Red-High/KabramsSunFlaresPack-Red-High-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Red-High",
     "name": "Kabrams Sun Flare Red High",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "High quality red sunflare for Scatterer, for support of up to 4K screen sizes",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Red-Low/KabramsSunFlaresPack-Red-Low-001.ckan
+++ b/KabramsSunFlaresPack-Red-Low/KabramsSunFlaresPack-Red-Low-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Red-Low",
     "name": "Kabrams Sun Flare Red Low",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Low quality red sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-Red-Medium/KabramsSunFlaresPack-Red-Medium-001.ckan
+++ b/KabramsSunFlaresPack-Red-Medium/KabramsSunFlaresPack-Red-Medium-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-Red-Medium",
     "name": "Kabrams Sun Flare Red Medium",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Medium quality red sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-White-High/KabramsSunFlaresPack-White-High-001.ckan
+++ b/KabramsSunFlaresPack-White-High/KabramsSunFlaresPack-White-High-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-White-High",
     "name": "Kabrams Sun Flare White High",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "High quality white sunflare for Scatterer, for support of up to 4K screen sizes",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-White-Low/KabramsSunFlaresPack-White-Low-001.ckan
+++ b/KabramsSunFlaresPack-White-Low/KabramsSunFlaresPack-White-Low-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-White-Low",
     "name": "Kabrams Sun Flare White Low",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Low quality white sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",

--- a/KabramsSunFlaresPack-White-Medium/KabramsSunFlaresPack-White-Medium-001.ckan
+++ b/KabramsSunFlaresPack-White-Medium/KabramsSunFlaresPack-White-Medium-001.ckan
@@ -2,7 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "KabramsSunFlaresPack-White-Medium",
     "name": "Kabrams Sun Flare White Medium",
-    "abstract": "(6) High Quality flares for the Scatterer mod. Including Low, Medium, and High quality presets, for support of up to 4K screen sizes.",
+    "abstract": "Medium quality white sunflare for Scatterer",
     "author": "0_0_1",
     "version": "001",
     "ksp_version": "any",


### PR DESCRIPTION
The mods from KSP-CKAN/NetKAN#6521 all have the same abstract scraped from the same SpaceDock entry, which makes the Scatterer sunflare selection prompt look worse than it needs to:

![image](https://github.com/KSP-CKAN/CKAN-meta/assets/1559108/c26a46cc-5aad-44e4-bf87-b05bdb20151f)

Now each one has an individual abstract. The netkans are already frozen, so they won't need to be updated unless we unfreeze them.
