### PR TITLE
Fix historical CryoTanks relationships

### DIFF
--- a/CryoTanks-Core/CryoTanks-Core-1.1.2.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.1.2.ckan
@@ -12,7 +12,7 @@
     "version": "1.1.2",
     "ksp_version_min": "1.7.0",
     "ksp_version_max": "1.7.99",
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.1.3.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.1.3.ckan
@@ -12,7 +12,7 @@
     "version": "1.1.3",
     "ksp_version_min": "1.7.0",
     "ksp_version_max": "1.7.99",
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.1.4.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.1.4.ckan
@@ -12,7 +12,7 @@
     "version": "1.1.4",
     "ksp_version_min": "1.7.0",
     "ksp_version_max": "1.7.99",
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.2.0.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.2.0.ckan
@@ -12,7 +12,7 @@
     "version": "1.2.0",
     "ksp_version_min": "1.7.0",
     "ksp_version_max": "1.7.99",
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.2.1.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.2.1.ckan
@@ -12,7 +12,7 @@
     "version": "1.2.1",
     "ksp_version_min": "1.7.0",
     "ksp_version_max": "1.7.99",
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.2.2.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.2.2.ckan
@@ -12,7 +12,7 @@
     "version": "1.2.2",
     "ksp_version_min": "1.7.3",
     "ksp_version_max": "1.7.99",
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.2.3.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.2.3.ckan
@@ -12,7 +12,7 @@
     "version": "1.2.3",
     "ksp_version_min": "1.7.3",
     "ksp_version_max": "1.7.99",
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.3.0.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.3.0.ckan
@@ -12,7 +12,7 @@
     "version": "1.3.0",
     "ksp_version_min": "1.7.3",
     "ksp_version_max": "1.7.99",
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.4.0.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.4.0.ckan
@@ -16,7 +16,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.4.2.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.4.2.ckan
@@ -16,7 +16,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.5.0.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.5.0.ckan
@@ -16,7 +16,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.5.1.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.5.1.ckan
@@ -17,7 +17,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.5.2.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.5.2.ckan
@@ -17,7 +17,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.5.3.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.5.3.ckan
@@ -17,7 +17,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.5.4.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.5.4.ckan
@@ -17,7 +17,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.5.5.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.5.5.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.5.6.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.5.6.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.6.0.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.6.0.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.6.1.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.6.1.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.6.2.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.6.2.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.6.3.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.6.3.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks-Core/CryoTanks-Core-1.6.4.ckan
+++ b/CryoTanks-Core/CryoTanks-Core-1.6.4.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "supports": [
+    "depends": [
         {
             "name": "CryoTanks"
         }

--- a/CryoTanks/CryoTanks-1.1.0.ckan
+++ b/CryoTanks/CryoTanks-1.1.0.ckan
@@ -16,6 +16,9 @@
             "name": "ModuleManager"
         },
         {
+            "name": "B9PartSwitch"
+        },
+        {
             "name": "CommunityResourcePack"
         },
         {

--- a/CryoTanks/CryoTanks-1.1.1.ckan
+++ b/CryoTanks/CryoTanks-1.1.1.ckan
@@ -16,6 +16,9 @@
             "name": "ModuleManager"
         },
         {
+            "name": "B9PartSwitch"
+        },
+        {
             "name": "CommunityResourcePack"
         },
         {

--- a/CryoTanks/CryoTanks-1.1.2.ckan
+++ b/CryoTanks/CryoTanks-1.1.2.ckan
@@ -14,10 +14,13 @@
     "ksp_version_max": "1.7.99",
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.1.3.ckan
+++ b/CryoTanks/CryoTanks-1.1.3.ckan
@@ -21,10 +21,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.1.4.ckan
+++ b/CryoTanks/CryoTanks-1.1.4.ckan
@@ -21,10 +21,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.2.0.ckan
+++ b/CryoTanks/CryoTanks-1.2.0.ckan
@@ -21,10 +21,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.2.1.ckan
+++ b/CryoTanks/CryoTanks-1.2.1.ckan
@@ -21,10 +21,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.2.2.ckan
+++ b/CryoTanks/CryoTanks-1.2.2.ckan
@@ -21,10 +21,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.2.3.ckan
+++ b/CryoTanks/CryoTanks-1.2.3.ckan
@@ -22,10 +22,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.3.0.ckan
+++ b/CryoTanks/CryoTanks-1.3.0.ckan
@@ -22,10 +22,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.4.0.ckan
+++ b/CryoTanks/CryoTanks-1.4.0.ckan
@@ -26,10 +26,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.4.2.ckan
+++ b/CryoTanks/CryoTanks-1.4.2.ckan
@@ -26,10 +26,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.5.0.ckan
+++ b/CryoTanks/CryoTanks-1.5.0.ckan
@@ -26,10 +26,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.5.1.ckan
+++ b/CryoTanks/CryoTanks-1.5.1.ckan
@@ -27,10 +27,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.5.2.ckan
+++ b/CryoTanks/CryoTanks-1.5.2.ckan
@@ -27,10 +27,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.5.3.ckan
+++ b/CryoTanks/CryoTanks-1.5.3.ckan
@@ -27,10 +27,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.5.4.ckan
+++ b/CryoTanks/CryoTanks-1.5.4.ckan
@@ -27,10 +27,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.5.5.ckan
+++ b/CryoTanks/CryoTanks-1.5.5.ckan
@@ -28,10 +28,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.5.6.ckan
+++ b/CryoTanks/CryoTanks-1.5.6.ckan
@@ -28,10 +28,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.6.0.ckan
+++ b/CryoTanks/CryoTanks-1.6.0.ckan
@@ -28,10 +28,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.6.1.ckan
+++ b/CryoTanks/CryoTanks-1.6.1.ckan
@@ -28,10 +28,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.6.2.ckan
+++ b/CryoTanks/CryoTanks-1.6.2.ckan
@@ -28,10 +28,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.6.3.ckan
+++ b/CryoTanks/CryoTanks-1.6.3.ckan
@@ -28,10 +28,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"

--- a/CryoTanks/CryoTanks-1.6.4.ckan
+++ b/CryoTanks/CryoTanks-1.6.4.ckan
@@ -28,10 +28,13 @@
     ],
     "depends": [
         {
+            "name": "ModuleManager"
+        },
+        {
             "name": "CryoTanks-Core"
         },
         {
-            "name": "ModuleManager"
+            "name": "B9PartSwitch"
         },
         {
             "name": "CommunityResourcePack"


### PR DESCRIPTION
This is the historical counterpart to KSP-CKAN/NetKAN#9964.

- All versions of CryoTanks-Core now depend on CryoTanks, to cancel out the split
- All historical versions at https://github.com/post-kerbin-mining-corporation/CryoTanks/releases have a bundled B9PartSwitch and therefore now also depend on it
