### PR TITLE
Fix historical NearFutureSolar relationships

### DIFF
--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.6.0.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.6.0.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.6.0",
     "ksp_version": "1.1.0",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.6.1.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.6.1.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.6.1",
     "ksp_version": "1.1.2",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.6.2.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.6.2.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.6.2",
     "ksp_version": "1.1.3",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.7.0.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.7.0.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.7.0",
     "ksp_version": "1.2.0",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.7.1.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.7.1.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.7.1",
     "ksp_version": "1.2.1",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.7.2.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.7.2.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.7.2",
     "ksp_version": "1.2.2",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.0.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.0.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.8.0",
     "ksp_version": "1.3.0",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.1.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.1.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.8.1",
     "ksp_version": "1.3.0",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.10.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.10.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.8.10",
     "ksp_version": "1.4.2",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.11.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.11.ckan
@@ -14,7 +14,7 @@
     "version": "0.8.11",
     "ksp_version_min": "1.4.2",
     "ksp_version_max": "1.4.9",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.12.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.12.ckan
@@ -14,7 +14,7 @@
     "version": "0.8.12",
     "ksp_version_min": "1.4.4",
     "ksp_version_max": "1.4.99",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.13.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.13.ckan
@@ -14,7 +14,7 @@
     "version": "0.8.13",
     "ksp_version_min": "1.5.0",
     "ksp_version_max": "1.5.99",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.14.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.14.ckan
@@ -14,7 +14,7 @@
     "version": "0.8.14",
     "ksp_version_min": "1.6.0",
     "ksp_version_max": "1.6.99",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.15.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.15.ckan
@@ -14,7 +14,7 @@
     "version": "0.8.15",
     "ksp_version_min": "1.6.0",
     "ksp_version_max": "1.6.99",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.2.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.2.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.8.2",
     "ksp_version": "1.3.0",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.3.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.3.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.8.3",
     "ksp_version": "1.3.0",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.4.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.4.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.8.4",
     "ksp_version": "1.3.0",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.5.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.5.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.8.5",
     "ksp_version": "1.3.0",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.6.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.6.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.8.6",
     "ksp_version": "1.3.0",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.7.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.7.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.8.7",
     "ksp_version": "1.3.1",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.8.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.8.ckan
@@ -13,7 +13,7 @@
     },
     "version": "0.8.8",
     "ksp_version": "1.3.1",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-0.8.9.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-0.8.9.ckan
@@ -14,7 +14,7 @@
     "version": "0.8.9",
     "ksp_version_min": "1.4.1",
     "ksp_version_max": "1.4.2",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.0.0.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.0.0.ckan
@@ -14,7 +14,7 @@
     "version": "1.0.0",
     "ksp_version_min": "1.7.0",
     "ksp_version_max": "1.7.99",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.0.1.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.0.1.ckan
@@ -14,7 +14,7 @@
     "version": "1.0.1",
     "ksp_version_min": "1.7.0",
     "ksp_version_max": "1.7.99",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.0.2.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.0.2.ckan
@@ -14,7 +14,7 @@
     "version": "1.0.2",
     "ksp_version_min": "1.7.0",
     "ksp_version_max": "1.7.99",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.0.3.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.0.3.ckan
@@ -14,7 +14,7 @@
     "version": "1.0.3",
     "ksp_version_min": "1.7.0",
     "ksp_version_max": "1.7.99",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.0.4.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.0.4.ckan
@@ -14,7 +14,7 @@
     "version": "1.0.4",
     "ksp_version_min": "1.7.3",
     "ksp_version_max": "1.7.99",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.0.5.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.0.5.ckan
@@ -14,7 +14,7 @@
     "version": "1.0.5",
     "ksp_version_min": "1.7.3",
     "ksp_version_max": "1.7.99",
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.1.0.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.1.0.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.2.0.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.2.0.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.2.1.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.2.1.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.2.2.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.2.2.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.2.3.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.2.3.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.3.0.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.3.0.ckan
@@ -18,7 +18,7 @@
     "tags": [
         "plugin"
     ],
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }

--- a/NearFutureSolar-Core/NearFutureSolar-Core-1.3.1.ckan
+++ b/NearFutureSolar-Core/NearFutureSolar-Core-1.3.1.ckan
@@ -20,7 +20,7 @@
     "tags": [
         "plugin"
     ],
-    "recommends": [
+    "depends": [
         {
             "name": "NearFutureSolar"
         }


### PR DESCRIPTION
This is the historical counterpart of KSP-CKAN/NetKAN#9965. All versions of NearFutureSolar-Core now depend on NearFutureSolar, to cancel out the split.
