### PR TITLE
Update MiniAirbrakes homepage

### DIFF
--- a/MiniAirbrakes/MiniAirbrakes-1.1.ckan
+++ b/MiniAirbrakes/MiniAirbrakes-1.1.ckan
@@ -6,7 +6,7 @@
     "author": "FishInferno",
     "license": "CC-BY-4.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/120086-Mini-Airbrakes?p=1917174#post1917174",
+        "homepage": "https://forum.kerbalspaceprogram.com/topic/108121-*",
         "kerbalstuff": "https://kerbalstuff.com/mod/758/Mini%20Airbrakes",
         "x_screenshot": "https://kerbalstuff.com/content/FishInferno_9757/Mini_Airbrakes/Mini_Airbrakes-1431035827.0628638.png"
     },


### PR DESCRIPTION
This mod's `resources.homepage` was generated before KerbalStuff shut down, so unsurprisingly it is no longer valid. Now it's updated.

Fixes KSP-CKAN/NetKAN#9974.
