### PR TITLE
Mark old Nehemiah mods as `replaced_by` newer one

### DIFF
--- a/KeminiResearchProgram/KeminiResearchProgram-0.7b2.ckan
+++ b/KeminiResearchProgram/KeminiResearchProgram-0.7b2.ckan
@@ -33,6 +33,9 @@
             "name": "K2CommandPodCont"
         }
     ],
+    "replaced_by": {
+        "name": "NehemiahEngineeringOrbitalScience"
+    },
     "install": [
         {
             "file": "NehemiahInc/Kemini",

--- a/KeminiResearchProgram/KeminiResearchProgram-0.7b2.ckan
+++ b/KeminiResearchProgram/KeminiResearchProgram-0.7b2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "KeminiResearchProgram",
     "name": "Kemini Research Program",
     "abstract": "Early science from experiments based on real experiments from the Gemini Program",

--- a/KerbalEnvironmentalEffectsStudy/KerbalEnvironmentalEffectsStudy-0.7b2.ckan
+++ b/KerbalEnvironmentalEffectsStudy/KerbalEnvironmentalEffectsStudy-0.7b2.ckan
@@ -28,6 +28,9 @@
         { "name": "K2CommandPodCont" },
         { "name": "UniversalStorage" }
     ],
+    "replaced_by": {
+        "name": "NehemiahEngineeringOrbitalScience"
+    },
     "install": [
         {
             "file": "NehemiahInc/KEES",

--- a/KerbalEnvironmentalEffectsStudy/KerbalEnvironmentalEffectsStudy-0.7b2.ckan
+++ b/KerbalEnvironmentalEffectsStudy/KerbalEnvironmentalEffectsStudy-0.7b2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "KerbalEnvironmentalEffectsStudy",
     "name": "Kerbal Environmental Effects Study",
     "abstract": "Science and money from experiments based on real space science.",

--- a/KerbalLifeScience/KerbalLifeScience-0.7b2.ckan
+++ b/KerbalLifeScience/KerbalLifeScience-0.7b2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "KerbalLifeScience",
     "name": "Kerbal Life Science",
     "abstract": "Use Kerbals as test subjects to get more science on your space station.",

--- a/KerbalLifeScience/KerbalLifeScience-0.7b2.ckan
+++ b/KerbalLifeScience/KerbalLifeScience-0.7b2.ckan
@@ -26,6 +26,9 @@
             "min_version": "1:0.7b2"
         }
     ],
+    "replaced_by": {
+        "name": "NehemiahEngineeringOrbitalScience"
+    },
     "install": [
         {
             "file": "NehemiahInc/KerbalLifeScience",

--- a/NehemiahInc-Complete/NehemiahInc-Complete-0.7b2.ckan
+++ b/NehemiahInc-Complete/NehemiahInc-Complete-0.7b2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "NehemiahInc-Complete",
     "name": "Nehemiah Inc - Complete Pack",
     "abstract": "All of N3h3miah's mods in one downloadable pack.",

--- a/NehemiahInc-Complete/NehemiahInc-Complete-0.7b2.ckan
+++ b/NehemiahInc-Complete/NehemiahInc-Complete-0.7b2.ckan
@@ -40,6 +40,9 @@
             "name": "UniversalStorage"
         }
     ],
+    "replaced_by": {
+        "name": "NehemiahEngineeringOrbitalScience"
+    },
     "install": [
         {
             "file": "NehemiahInc",

--- a/NehemiahMultiPurposeParts/NehemiahMultiPurposeParts-1-0.7b2.ckan
+++ b/NehemiahMultiPurposeParts/NehemiahMultiPurposeParts-1-0.7b2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "NehemiahMultiPurposeParts",
     "name": "Nehemiah Multipurpose Parts",
     "abstract": "Shared station parts used by N3h3miah's KLS and OMS mod.",

--- a/NehemiahMultiPurposeParts/NehemiahMultiPurposeParts-1-0.7b2.ckan
+++ b/NehemiahMultiPurposeParts/NehemiahMultiPurposeParts-1-0.7b2.ckan
@@ -26,6 +26,9 @@
             "name": "UniversalStorage"
         }
     ],
+    "replaced_by": {
+        "name": "NehemiahEngineeringOrbitalScience"
+    },
     "install": [
         {
             "file": "NehemiahInc/MultiPurposeParts",

--- a/NehemiahScienceCommon/NehemiahScienceCommon-1-0.7b2.ckan
+++ b/NehemiahScienceCommon/NehemiahScienceCommon-1-0.7b2.ckan
@@ -15,6 +15,9 @@
     "version": "1:0.7b2",
     "ksp_version_min": "1.3.0",
     "ksp_version_max": "1.3.99",
+    "replaced_by": {
+        "name": "NehemiahEngineeringOrbitalScience"
+    },
     "install": [
         {
             "file": "NehemiahInc/NE_Science_Common",

--- a/NehemiahScienceCommon/NehemiahScienceCommon-1-0.7b2.ckan
+++ b/NehemiahScienceCommon/NehemiahScienceCommon-1-0.7b2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "NehemiahScienceCommon",
     "name": "Nehemiah Science Common",
     "abstract": "Shared files used by all N3h3miah's mods.",

--- a/OrbitalMaterialScience/OrbitalMaterialScience-0.7b2.ckan
+++ b/OrbitalMaterialScience/OrbitalMaterialScience-0.7b2.ckan
@@ -26,6 +26,9 @@
             "min_version": "1:0.7b2"
         }
     ],
+    "replaced_by": {
+        "name": "NehemiahEngineeringOrbitalScience"
+    },
     "install": [
         {
             "file": "NehemiahInc/OMS",

--- a/OrbitalMaterialScience/OrbitalMaterialScience-0.7b2.ckan
+++ b/OrbitalMaterialScience/OrbitalMaterialScience-0.7b2.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier": "OrbitalMaterialScience",
     "name": "Orbital Material Science",
     "abstract": "Get more science from orbit. Adds science experiments for your space station, inspired by real space experiments.",


### PR DESCRIPTION
## Motivation

KSP-CKAN/NetKAN#7100 attempted to mark several old mods as replaced by a newer one. This was not successful because those netkans were already frozen, and if they hadn't been, there were syntax errors and the property name was wrong (see KSP-CKAN/NetKAN#10109 and KSP-CKAN/NetKAN#10110).

## Changes

Now the old modules have `replaced_by` set as originally intended.
