### PR TITLE
Use JSON mimetype for GitHub release source archives

### DIFF
--- a/CLLS/CLLS-1.0.ckan
+++ b/CLLS/CLLS-1.0.ckan
@@ -23,6 +23,6 @@
         "sha1": "A524D4A18692577C06DDF0818F9D111D1CB08B3C",
         "sha256": "979DEE3CA5C8D219B1CD57009D921A0DDCE41C422D8952CCD5BEB2FF3AB6BF71"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/CLLS/CLLS-1.1.ckan
+++ b/CLLS/CLLS-1.1.ckan
@@ -28,6 +28,6 @@
         "sha1": "2B564156E26D09656844234772A61FD7139E7D2C",
         "sha256": "054034A7F02D38C5FEA30EF40F198F82F30B507D4C357075B49336F1EFCD99CF"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/CLLS/CLLS-1.2.ckan
+++ b/CLLS/CLLS-1.2.ckan
@@ -28,6 +28,6 @@
         "sha1": "FDB270C3BD1001A31966EEFF74602AF16FBE044A",
         "sha256": "E2ED8680787A9880B0DDA2692EB99AED05929137014E2A51B03877C6090BCB52"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/CLLS/CLLS-1.3.ckan
+++ b/CLLS/CLLS-1.3.ckan
@@ -35,7 +35,7 @@
         "sha1": "C0A9A6BC9F43D2D42125CFDD2D5A041EBE5CEEE7",
         "sha256": "1F5349A02A35302B9100C7CB462941FA1B1CE44CE4D6993E4B84980861FB63DF"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "release_date": "2017-06-28T18:25:21Z",
     "x_generated_by": "netkan"
 }

--- a/CustomAsteroids-Pops-OPM-Outer/CustomAsteroids-Pops-OPM-Outer-v1.0.0.ckan
+++ b/CustomAsteroids-Pops-OPM-Outer/CustomAsteroids-Pops-OPM-Outer-v1.0.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.10",
     "identifier": "CustomAsteroids-Pops-OPM-Outer",
     "name": "Custom Asteroids (unofficial OPM config)",
     "abstract": "Adds Kentaurs and trans-Neidonian objects",

--- a/CustomAsteroids-Pops-OPM-Outer/CustomAsteroids-Pops-OPM-Outer-v1.0.0.ckan
+++ b/CustomAsteroids-Pops-OPM-Outer/CustomAsteroids-Pops-OPM-Outer-v1.0.0.ckan
@@ -38,7 +38,7 @@
         "sha1": "58F155F3D74679A07EAA36B931BCDADC1174A600",
         "sha256": "2C30C407294BBF9534AB3F0CEB4E52AD124D3ECAB543771A74E9C1624222F688"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_maintained_by": "Starstrider42",
     "x_generated_by": "netkan"
 }

--- a/CustomAsteroids-Pops-OPM-Outer/CustomAsteroids-Pops-OPM-Outer-v1.1.0.ckan
+++ b/CustomAsteroids-Pops-OPM-Outer/CustomAsteroids-Pops-OPM-Outer-v1.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.10",
     "comment": "Match to Custom Asteroids v1.9.0, see NetKAN#3841.",
     "identifier": "CustomAsteroids-Pops-OPM-Outer",
     "name": "Custom Asteroids (Kuiper belt analog for OPM)",

--- a/CustomAsteroids-Pops-OPM-Outer/CustomAsteroids-Pops-OPM-Outer-v1.1.0.ckan
+++ b/CustomAsteroids-Pops-OPM-Outer/CustomAsteroids-Pops-OPM-Outer-v1.1.0.ckan
@@ -46,7 +46,7 @@
         "sha1": "EB70FB88745D7CD533496EC789FD4BED5F86282A",
         "sha256": "C79BA2E8A74623E520BC48F6DB08AE7ED8D96A8B502A51D5E02CEE67396B698D"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "release_date": "2019-03-22T04:26:03Z",
     "x_maintained_by": "Starstrider42",
     "x_generated_by": "netkan"

--- a/CustomAsteroids-Pops-OPM-Outer/CustomAsteroids-Pops-OPM-Outer-v1.2.0.ckan
+++ b/CustomAsteroids-Pops-OPM-Outer/CustomAsteroids-Pops-OPM-Outer-v1.2.0.ckan
@@ -57,7 +57,7 @@
         "sha1": "56A2F860F9BD130ED98E3C6B0E95B2A2444957CA",
         "sha256": "A4080A213D0F4AD5FB3A125E42A63F4FB52C38A722D63F303155EE9000C90260"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "install_size": 8622,
     "release_date": "2021-01-24T23:01:34Z",
     "x_maintained_by": "Starstrider42",

--- a/CustomAsteroids-Pops-OPM-Reconfig/CustomAsteroids-Pops-OPM-Reconfig-v1.1.0.ckan
+++ b/CustomAsteroids-Pops-OPM-Reconfig/CustomAsteroids-Pops-OPM-Reconfig-v1.1.0.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.10",
     "identifier": "CustomAsteroids-Pops-OPM-Reconfig",
     "name": "Custom Asteroids (alternative OPM config)",
     "abstract": "Replaces default OPM asteroid config with one that uses Custom Asteroids",

--- a/CustomAsteroids-Pops-OPM-Reconfig/CustomAsteroids-Pops-OPM-Reconfig-v1.1.0.ckan
+++ b/CustomAsteroids-Pops-OPM-Reconfig/CustomAsteroids-Pops-OPM-Reconfig-v1.1.0.ckan
@@ -52,7 +52,7 @@
         "sha1": "EB70FB88745D7CD533496EC789FD4BED5F86282A",
         "sha256": "C79BA2E8A74623E520BC48F6DB08AE7ED8D96A8B502A51D5E02CEE67396B698D"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "release_date": "2019-03-22T04:26:03Z",
     "x_maintained_by": "HSJasperism",
     "x_generated_by": "netkan"

--- a/CustomAsteroids-Pops-OPM-Reconfig/CustomAsteroids-Pops-OPM-Reconfig-v1.2.0.ckan
+++ b/CustomAsteroids-Pops-OPM-Reconfig/CustomAsteroids-Pops-OPM-Reconfig-v1.2.0.ckan
@@ -52,7 +52,7 @@
         "sha1": "56A2F860F9BD130ED98E3C6B0E95B2A2444957CA",
         "sha256": "A4080A213D0F4AD5FB3A125E42A63F4FB52C38A722D63F303155EE9000C90260"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "install_size": 5681,
     "release_date": "2021-01-24T23:01:34Z",
     "x_maintained_by": "HSJasperism",

--- a/ExtendedAntennaProgression/ExtendedAntennaProgression-v0.1.1.ckan
+++ b/ExtendedAntennaProgression/ExtendedAntennaProgression-v0.1.1.ckan
@@ -26,7 +26,7 @@
         "sha1": "76F974C2E7E816E5A8F41FBBC60E3AAE5624B774",
         "sha256": "83A28B76E2D651E72A1548B4B30282770D41B3637DD86D422C9383E396A3F6F9"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_via": "Automated Linuxgurugamer CKAN script",
     "x_generated_by": "netkan"
 }

--- a/ExtendedAntennaProgression/ExtendedAntennaProgression-v0.1.2.ckan
+++ b/ExtendedAntennaProgression/ExtendedAntennaProgression-v0.1.2.ckan
@@ -32,6 +32,6 @@
         "sha1": "5C3E04CB442E4944D798199A0144316ED0034EEE",
         "sha256": "3A3D2C368E8350EA06E11F64DABEEC1D100DBED2DFDE1FC487CD7346160885B1"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/IXSWarpship-Blueshift/IXSWarpship-Blueshift-1-v.1.0.6.ckan
+++ b/IXSWarpship-Blueshift/IXSWarpship-Blueshift-1-v.1.0.6.ckan
@@ -62,7 +62,7 @@
         "sha1": "010C52B9E3C6AAD236A46062A1569F2A1CD8BB31",
         "sha256": "DED39BAB575DBBDA736BCB13EB4F90A054896E82892A361B25073CDC7C05FD9A"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "install_size": 211198,
     "release_date": "2021-05-30T05:45:39Z",
     "x_generated_by": "netkan"

--- a/KRnD/KRnD-1.10.ckan
+++ b/KRnD/KRnD-1.10.ckan
@@ -57,6 +57,6 @@
         "sha1": "5F46605FF144B163F5E632173020F58F77872317",
         "sha256": "BB914A148B77A66C8988784D85B0A687BE8E742BA66875E64B2B3BFCB955ADB2"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KRnD/KRnD-1.11.ckan
+++ b/KRnD/KRnD-1.11.ckan
@@ -57,6 +57,6 @@
         "sha1": "2A1E4D7C4D786D251F6FED1DBF836DABA5499C17",
         "sha256": "71E8E89D1628F9DDB3A5CC348DF0DC0D05EE6648A33955DB0B2B5C27DA88DBD2"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KRnD/KRnD-1.12.ckan
+++ b/KRnD/KRnD-1.12.ckan
@@ -57,6 +57,6 @@
         "sha1": "020DAF4C3231442F1B7201D498ECA4BDBDA08FF1",
         "sha256": "89AEE887E3B21740D1A34A59BADDC4160F46CDD790B6ECB86316A79534FE90CB"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KRnD/KRnD-1.13.ckan
+++ b/KRnD/KRnD-1.13.ckan
@@ -57,6 +57,6 @@
         "sha1": "0976A24EC5B5F17AF552F8D3C0EF2E4BD6AFF768",
         "sha256": "12A240CBB278BF7D463465A161671A20069EEE903E43373D6DA43B8037CBBE3E"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KRnD/KRnD-1.14.ckan
+++ b/KRnD/KRnD-1.14.ckan
@@ -57,6 +57,6 @@
         "sha1": "21062D53A2386EF961A56931408795E6FEE51EBF",
         "sha256": "9D5DD86738E26305685942C5B8D69CCDAEF962113AB25F8E8620985D18E36682"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KRnD/KRnD-1.15.ckan
+++ b/KRnD/KRnD-1.15.ckan
@@ -62,6 +62,6 @@
         "sha1": "5FC16E9E3BF544001F149E6DB3D7371DAE1AFD05",
         "sha256": "ED8C35D6CC1DAE83B158315CA085226524D384B05187805EB081D18EBEF36A1B"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KRnD/KRnD-1.8.ckan
+++ b/KRnD/KRnD-1.8.ckan
@@ -57,6 +57,6 @@
         "sha1": "CF46F1966A7F95A84ADB1B81BE4EF1D154CEE24C",
         "sha256": "F8271B4891645B4146DFEE9F1988ABA975A7208E4498A46EE683BB6EC1FED365"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KRnD/KRnD-1.9.ckan
+++ b/KRnD/KRnD-1.9.ckan
@@ -57,6 +57,6 @@
         "sha1": "A253F845FD3BEFCBB459176FC808FAC787E22D95",
         "sha256": "041A7CA5124DA22667609BA2D84AFAF322E97BF5569AD846BF81A94A74AEFFC7"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.0.ckan
+++ b/KSTS/KSTS-1.0.ckan
@@ -23,6 +23,6 @@
         "sha1": "B8DBED792DD120C87696E66B7919307CD4443D94",
         "sha256": "544B5CE0FDA94E4AA3230BD3FD2C6525ED51E3577DE988D7EE8DE5AD0BF1A302"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.1.ckan
+++ b/KSTS/KSTS-1.1.ckan
@@ -23,6 +23,6 @@
         "sha1": "1038D72AE5A006008D5564401EC32659E03626FC",
         "sha256": "45BD9DAEFBC5DD0A895953F156AA6861C0EDC9E069319D2E7E85B1ECEB508572"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.10.ckan
+++ b/KSTS/KSTS-1.10.ckan
@@ -23,6 +23,6 @@
         "sha1": "AC096220DF3FD6829469AD7BC4398FD643A04920",
         "sha256": "21F57D1A11A79F45516B1FF256972B4186E88888C8CA931812D00D70D7E2609A"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.11.ckan
+++ b/KSTS/KSTS-1.11.ckan
@@ -36,6 +36,6 @@
         "sha1": "BB86CF0F52AACB9D9148DA57E32B969577A60B9A",
         "sha256": "554C7B7DE0CD79606EB066C1D6B3BC0C12A90E817C3D5728049E2F66828C6140"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.12.ckan
+++ b/KSTS/KSTS-1.12.ckan
@@ -40,6 +40,6 @@
         "sha1": "EEF4D8D888E40C0A105A7B13A6FEF8CBB4BBC1BC",
         "sha256": "3C17B3B94C33E9BBFBCB95AA82319C3EC27E8570A9C91E50BE062D1A388EBDA1"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.2.ckan
+++ b/KSTS/KSTS-1.2.ckan
@@ -23,6 +23,6 @@
         "sha1": "8B4BF0AE095C9908201E1A76A83DF3F332979E5A",
         "sha256": "442641CF13050F4F60550E40A40B176B541378380F20CD2456A3850F75192722"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.3.ckan
+++ b/KSTS/KSTS-1.3.ckan
@@ -23,6 +23,6 @@
         "sha1": "C1C2B1B1AABBA5F7C07A327B8055578AD1D38FE8",
         "sha256": "279D83BBF19E377E0B6D8DCD25F512E34215B8125193B42DD2CB959E1DAED7BF"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.4.ckan
+++ b/KSTS/KSTS-1.4.ckan
@@ -23,6 +23,6 @@
         "sha1": "769AC96F373B1677AD5BB11AA37511E1A8A71C1E",
         "sha256": "69519E346BDC73D83F8BE755AB54C118907278E23F6885EB96690A6F5919E0D1"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.5.ckan
+++ b/KSTS/KSTS-1.5.ckan
@@ -23,6 +23,6 @@
         "sha1": "E02F0060C557B613DC7AEA14ABEB1B41AEC0CD7C",
         "sha256": "DAFA7ED9740365FBA93F8D8D1C82A13EADC01B47D82BD65952736AB8BCE88325"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.6.ckan
+++ b/KSTS/KSTS-1.6.ckan
@@ -23,6 +23,6 @@
         "sha1": "893433783223A8EEFF98F6BE48FF24C48BDBBC3F",
         "sha256": "A20FDC05E4261BF4C3A27C685985A5B77F16CD414CEF32E96BD43C0265BA9B24"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.7.ckan
+++ b/KSTS/KSTS-1.7.ckan
@@ -23,6 +23,6 @@
         "sha1": "E4122D8060B598C57D350D93064933C87E848088",
         "sha256": "1F77E10D22C2926A6E4C663AD7A2289010A1EF69C90E0B095390798D0FBF5EA6"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.8.ckan
+++ b/KSTS/KSTS-1.8.ckan
@@ -23,6 +23,6 @@
         "sha1": "BED997320D7FD15F93C109B1794F060214ED4EAB",
         "sha256": "42DF11A6A1FDE46ADCA711FE96B64E1900DC6772C19AAD8995B5A4BD65DC61CF"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/KSTS/KSTS-1.9.ckan
+++ b/KSTS/KSTS-1.9.ckan
@@ -23,6 +23,6 @@
         "sha1": "FF8CCD15608FCCDE514860BC0DB70938DD7A495D",
         "sha256": "98EC988EA2DE9870F485CCE2D79F36D9F9E000800A74B1E72DD0CF30A69F6015"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/LudicrousPropulsionSystems/LudicrousPropulsionSystems-1-v0.2.6.ckan
+++ b/LudicrousPropulsionSystems/LudicrousPropulsionSystems-1-v0.2.6.ckan
@@ -28,7 +28,7 @@
         "sha1": "E8388791337EA683E47AB912267156377D3CA07F",
         "sha256": "97BCB183466F926D2CEE45B44B0236D74514D3870917447320D445DCD2D0657C"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "release_date": "2018-03-06T03:22:17Z",
     "x_generated_by": "netkan"
 }

--- a/LudicrousPropulsionSystems/LudicrousPropulsionSystems-v.0.2.4.3.ckan
+++ b/LudicrousPropulsionSystems/LudicrousPropulsionSystems-v.0.2.4.3.ckan
@@ -28,6 +28,6 @@
         "sha1": "A4F217533944A50DE6A4365545AA52B00279E369",
         "sha256": "D933069727DF087662ABF0D5A27B2E7124A5EB483B5F305BFDFFA170011BC8AC"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/LudicrousPropulsionSystems/LudicrousPropulsionSystems-v.0.2.5.2.ckan
+++ b/LudicrousPropulsionSystems/LudicrousPropulsionSystems-v.0.2.5.2.ckan
@@ -29,6 +29,6 @@
         "sha1": "5E20F4C95546BEE95141518953009DAF6EE60B18",
         "sha256": "AA825A3113B1F4174DC27CCEFEE0FB08C7D6EB67D0C544C80D51BD117EAE607C"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/MK2KSPIIntegration/MK2KSPIIntegration-1-8.9.1.T.ckan
+++ b/MK2KSPIIntegration/MK2KSPIIntegration-1-8.9.1.T.ckan
@@ -40,6 +40,6 @@
         "sha1": "9C3D72C70BD41CD32FF1A871350FE95A87E2492B",
         "sha256": "DF5A419591B73493E38E17A9D5592060B39F285342EB56CE35604060A3EE9403"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "x_generated_by": "netkan"
 }

--- a/TestLite/TestLite-0.2.2.ckan
+++ b/TestLite/TestLite-0.2.2.ckan
@@ -40,7 +40,7 @@
         "sha1": "A742FB36211DCF7BCDA4FEB17F27DFE5CC701F7E",
         "sha256": "A3A77308366EECA5926B30440070715C2F2E354726B1326CD8D8111074E3179D"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "release_date": "2019-08-09T22:54:04Z",
     "x_generated_by": "netkan"
 }

--- a/TestLite/TestLite-0.3.0.ckan
+++ b/TestLite/TestLite-0.3.0.ckan
@@ -39,7 +39,7 @@
         "sha1": "F14E730F25900F5157A80FB62BA73692BBE7511F",
         "sha256": "DEBBD83D2E05421F00DFC55B3920D27437ABACCB23BDE3F2A7EA23928C84E94C"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "release_date": "2020-07-02T20:41:27Z",
     "x_generated_by": "netkan"
 }

--- a/TestLite/TestLite-0.3.1.ckan
+++ b/TestLite/TestLite-0.3.1.ckan
@@ -40,7 +40,7 @@
         "sha1": "712BA9533B4EF6DA0887CEC09CB5C085F7771FAE",
         "sha256": "8A38A87F330F7476DE42260E17DE9FAC70163D01B1AAE7669EC740858032898C"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "release_date": "2020-12-29T22:34:35Z",
     "x_generated_by": "netkan"
 }

--- a/TestLite/TestLite-0.3.2.ckan
+++ b/TestLite/TestLite-0.3.2.ckan
@@ -40,7 +40,7 @@
         "sha1": "E98FFAD95A830CB146C71D1125B032508980A831",
         "sha256": "A176A00247E018C1B6A3D42F1DDAE35D7C8375BC1E4C8C0008E230E5060FCAA5"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "install_size": 65730,
     "release_date": "2021-02-26T03:01:26Z",
     "x_generated_by": "netkan"

--- a/TestLite/TestLite-0.3.4.ckan
+++ b/TestLite/TestLite-0.3.4.ckan
@@ -41,7 +41,7 @@
         "sha1": "7DDBF466495A7FB992A609848EB33F3CD3A59469",
         "sha256": "2FEE0A24271A23CB289356C1C5C8D1DC5BFB0529592BD2881B298A51F8E82D4C"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "install_size": 32148,
     "release_date": "2023-03-31T15:43:22Z",
     "x_generated_by": "netkan"

--- a/kOS-AddOns-Ferram/kOS-AddOns-Ferram-v1.2.1.ckan
+++ b/kOS-AddOns-Ferram/kOS-AddOns-Ferram-v1.2.1.ckan
@@ -36,7 +36,7 @@
         "sha1": "9AD9F1C77695F05E3F728D347FDC762D6C6B683D",
         "sha256": "3A598C1195BD657B342EED2D5F345D90EE43B1764A2A011499AA33FCDFC07487"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "install_size": 15872,
     "release_date": "2024-01-18T00:20:55Z",
     "x_generated_by": "netkan"

--- a/kOS-AddOns-Ferram/kOS-AddOns-Ferram-v1.2.ckan
+++ b/kOS-AddOns-Ferram/kOS-AddOns-Ferram-v1.2.ckan
@@ -36,7 +36,7 @@
         "sha1": "DA486AE6FDC2E9FB3962F6E6CB492E184143F280",
         "sha256": "EDA26394B1BA76E9941FD1C02B062C593F1BCE1A8238FA0C264D1F5F0A178F0A"
     },
-    "download_content_type": "application/zip",
+    "download_content_type": "application/vnd.github+json",
     "install_size": 15872,
     "release_date": "2023-11-23T17:09:32Z",
     "x_generated_by": "netkan"


### PR DESCRIPTION
See the middle fix of KSP-CKAN/CKAN#4192, GitHub now requires us to use an incorrect mime type to download source archives.

Now we comply.

Fixes part of KSP-CKAN/CKAN#4234.
