### PR TITLE
Purge lingering KerbalStuff homepage links

### DIFF
--- a/EBRCPartspack/EBRCPartspack-Wise_Penguin.ckan
+++ b/EBRCPartspack/EBRCPartspack-Wise_Penguin.ckan
@@ -6,7 +6,6 @@
     "author": "JC0013",
     "license": "MIT",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/946/EBRC%20Parts%20pack",
         "kerbalstuff": "https://kerbalstuff.com/mod/946/EBRC%20Parts%20pack",
         "x_screenshot": "https://kerbalstuff.com/content/JC0013_12054/EBRC_Parts_pack/EBRC_Parts_pack-1435439765.2526731.jpg"
     },

--- a/EasyLaunchpads/EasyLaunchpads-1.0.ckan
+++ b/EasyLaunchpads/EasyLaunchpads-1.0.ckan
@@ -6,7 +6,6 @@
     "author": "ABZB",
     "license": "CC-BY-4.0",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/944/ExtraPlanetary%20Launchpad%20Simplifier.",
         "kerbalstuff": "https://kerbalstuff.com/mod/944/ExtraPlanetary%20Launchpad%20Simplifier."
     },
     "version": "1.0",

--- a/FairingWithMass/FairingWithMass-1.3.1.ckan
+++ b/FairingWithMass/FairingWithMass-1.3.1.ckan
@@ -6,7 +6,6 @@
     "author": "Merill",
     "license": "MIT",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/725/Fairing%20With%20Mass",
         "kerbalstuff": "https://kerbalstuff.com/mod/725/Fairing%20With%20Mass",
         "x_screenshot": "https://kerbalstuff.com/content/Merill_8685/Fairing_With_Mass/Fairing_With_Mass-1430864791.4453962.png"
     },

--- a/GeometricShapeAeroTests/GeometricShapeAeroTests-0.2f.ckan
+++ b/GeometricShapeAeroTests/GeometricShapeAeroTests-0.2f.ckan
@@ -6,7 +6,6 @@
     "author": "TiktaalikDreaming",
     "license": "MIT",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/757/GeometricShapeAeroTests",
         "kerbalstuff": "https://kerbalstuff.com/mod/757/GeometricShapeAeroTests",
         "x_screenshot": "https://kerbalstuff.com/content/TiktaalikDreaming_7164/GeometricShapeAeroTests/GeometricShapeAeroTests-1431001911.158556.png"
     },

--- a/JettisonFuel/JettisonFuel-1.0.1.ckan
+++ b/JettisonFuel/JettisonFuel-1.0.1.ckan
@@ -6,7 +6,6 @@
     "author": "TechnicalTortoise",
     "license": "MIT",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/782/Jettison%20Fuel",
         "spacedock": "https://spacedock.info/mod/171/Jettison%20Fuel",
         "x_screenshot": "https://spacedock.info/content/TechnicalTortoise_831/Jettison_Fuel/Jettison_Fuel-1455874758.807693.png"
     },

--- a/JettisonFuel/JettisonFuel-1.ckan
+++ b/JettisonFuel/JettisonFuel-1.ckan
@@ -6,7 +6,6 @@
     "author": "TechnicalTortoise",
     "license": "MIT",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/782/Jettison%20Fuel",
         "kerbalstuff": "https://kerbalstuff.com/mod/782/Jettison%20Fuel"
     },
     "version": "1",

--- a/KerbalFuels/KerbalFuels-0.1.ckan
+++ b/KerbalFuels/KerbalFuels-0.1.ckan
@@ -6,7 +6,6 @@
     "author": "SorensonPA",
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/941/Kerbal%20Fuels",
         "kerbalstuff": "https://kerbalstuff.com/mod/941/Kerbal%20Fuels"
     },
     "version": "0.1",

--- a/MeatlessIndustries/MeatlessIndustries-1.1.1.1.1.1.ckan
+++ b/MeatlessIndustries/MeatlessIndustries-1.1.1.1.1.1.ckan
@@ -6,7 +6,6 @@
     "author": "DuoDex",
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/889/Meatless%20Industries",
         "kerbalstuff": "https://kerbalstuff.com/mod/889/Meatless%20Industries"
     },
     "version": "1.1.1.1.1.1",

--- a/MeatlessIndustries/MeatlessIndustries-1.1.1.ckan
+++ b/MeatlessIndustries/MeatlessIndustries-1.1.1.ckan
@@ -6,7 +6,6 @@
     "author": "DuoDex",
     "license": "CC-BY-NC-SA-4.0",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/889/Meatless%20Industries",
         "kerbalstuff": "https://kerbalstuff.com/mod/889/Meatless%20Industries"
     },
     "version": "1.1.1",

--- a/MinkTechnologies/MinkTechnologies-1.02.ckan
+++ b/MinkTechnologies/MinkTechnologies-1.02.ckan
@@ -6,7 +6,6 @@
     "author": "KM3",
     "license": "MIT",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/696/Mink%20Technologies",
         "kerbalstuff": "https://kerbalstuff.com/mod/696/Mink%20Technologies"
     },
     "version": "1.02",

--- a/StockHeatManagementforKSPI/StockHeatManagementforKSPI-1.0.ckan
+++ b/StockHeatManagementforKSPI/StockHeatManagementforKSPI-1.0.ckan
@@ -6,7 +6,6 @@
     "author": "ABZB",
     "license": "GPL-3.0",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/850/Stock%20Heat%20Management%20for%20KSPI",
         "kerbalstuff": "https://kerbalstuff.com/mod/850/Stock%20Heat%20Management%20for%20KSPI"
     },
     "version": "1.0",

--- a/StockHeatManagementforKSPI/StockHeatManagementforKSPI-1.1.ckan
+++ b/StockHeatManagementforKSPI/StockHeatManagementforKSPI-1.1.ckan
@@ -6,7 +6,6 @@
     "author": "ABZB",
     "license": "GPL-3.0",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/850/Stock%20Heat%20Management%20for%20KSPI",
         "kerbalstuff": "https://kerbalstuff.com/mod/850/Stock%20Heat%20Management%20for%20KSPI"
     },
     "version": "1.1",

--- a/TACLSMining/TACLSMining-1-1.ckan
+++ b/TACLSMining/TACLSMining-1-1.ckan
@@ -6,7 +6,6 @@
     "author": "StevenJ",
     "license": "MIT",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/787/TACLS%20Mining",
         "kerbalstuff": "https://kerbalstuff.com/mod/787/TACLS%20Mining"
     },
     "version": "1:1",

--- a/TACLSMining/TACLSMining-1.ckan
+++ b/TACLSMining/TACLSMining-1.ckan
@@ -6,7 +6,6 @@
     "author": "StevenJ",
     "license": "MIT",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/787/TACLS%20Mining",
         "kerbalstuff": "https://kerbalstuff.com/mod/787/TACLS%20Mining"
     },
     "version": "1",

--- a/TrizzleAeroSpaceCompany/TrizzleAeroSpaceCompany-0.3.ckan
+++ b/TrizzleAeroSpaceCompany/TrizzleAeroSpaceCompany-0.3.ckan
@@ -6,7 +6,6 @@
     "author": "TrizzleAeroSpaceCo",
     "license": "MIT",
     "resources": {
-        "homepage": "https://kerbalstuff.com/mod/887/Trizzle%20AeroSpace%20Company",
         "kerbalstuff": "https://kerbalstuff.com/mod/887/Trizzle%20AeroSpace%20Company",
         "x_screenshot": "https://kerbalstuff.com/content/TrizzleAeroSpaceCo_11172/Trizzle_AeroSpace_Company/Trizzle_AeroSpace_Company-1433450031.7834775.png"
     },


### PR DESCRIPTION
A few old frozen mods still have `resources.homepage` pointing to KerbalStuff, which has been squatted by a malicious site for several years now.
Now these links are removed.
