### PR TITLE
Update StarshipExpansionProject MetaData

### DIFF
--- a/StarshipExpansionProject/StarshipExpansionProject-v.3.0.0-b1.ckan
+++ b/StarshipExpansionProject/StarshipExpansionProject-v.3.0.0-b1.ckan
@@ -48,6 +48,9 @@
             "name": "TexturesUnlimited"
         },
         {
+            "name": "Resurfaced"
+        },
+        {
             "name": "KerbalJointReinforcementNext"
         }
     ],

--- a/StarshipExpansionProject/StarshipExpansionProject-v.3.0.0-b1.ckan
+++ b/StarshipExpansionProject/StarshipExpansionProject-v.3.0.0-b1.ckan
@@ -32,6 +32,9 @@
         },
         {
             "name": "Waterfall"
+        },
+        {
+            "name": "KSPCommunityPartModules"
         }
     ],
     "recommends": [
@@ -40,9 +43,6 @@
         },
         {
             "name": "StarshipLaunchExpansion"
-        },
-        {
-            "name": "TundraExploration"
         },
         {
             "name": "TexturesUnlimited"
@@ -57,6 +57,9 @@
         },
         {
             "name": "ModularLaunchPads"
+        },        
+        {
+            "name": "TundraExploration"
         },
         {
             "name": "FMRS"

--- a/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.0.1.ckan
+++ b/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.0.1.ckan
@@ -26,6 +26,9 @@
             "name": "StarshipExpansionProject"
         },
         {
+            "name": "B9PartSwitch"
+        },
+        {
             "name": "NearFutureProps"
         },
         {

--- a/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.0.2.ckan
+++ b/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.0.2.ckan
@@ -26,6 +26,9 @@
             "name": "StarshipExpansionProject"
         },
         {
+            "name": "B9PartSwitch"
+        },
+        {
             "name": "NearFutureProps"
         },
         {

--- a/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.0.3.1.ckan
+++ b/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.0.3.1.ckan
@@ -28,6 +28,9 @@
             "name": "ModuleManager"
         },
         {
+            "name": "B9PartSwitch"
+        },
+        {
             "name": "StarshipExpansionProject"
         },
         {

--- a/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.0.3.ckan
+++ b/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.0.3.ckan
@@ -26,6 +26,9 @@
             "name": "StarshipExpansionProject"
         },
         {
+            "name": "B9PartSwitch"
+        },
+        {
             "name": "NearFutureProps"
         },
         {

--- a/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.1.0.ckan
+++ b/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.1.0.ckan
@@ -28,6 +28,9 @@
             "name": "ModuleManager"
         },
         {
+            "name": "B9PartSwitch"
+        },
+        {
             "name": "StarshipExpansionProject"
         },
         {

--- a/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.2.0.ckan
+++ b/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.2.2.0.ckan
@@ -28,6 +28,9 @@
             "name": "ModuleManager"
         },
         {
+            "name": "B9PartSwitch"
+        },
+        {
             "name": "StarshipExpansionProject"
         },
         {

--- a/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.3.0.0-b1.ckan
+++ b/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v.3.0.0-b1.ckan
@@ -27,6 +27,9 @@
             "name": "ModuleManager"
         },
         {
+            "name": "B9PartSwitch"
+        },
+        {
             "name": "StarshipExpansionProject"
         },
         {

--- a/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v2.0.0.ckan
+++ b/StarshipExpansionProjectIVA/StarshipExpansionProjectIVA-v2.0.0.ckan
@@ -26,6 +26,9 @@
             "name": "StarshipExpansionProject"
         },
         {
+            "name": "B9PartSwitch"
+        },
+        {
             "name": "NearFutureProps"
         },
         {


### PR DESCRIPTION
While making changes to move SEP’s relationships to internal .ckan files I noticed that the IVA section of the mod had always been missing its dependency on B9PartSwitch, even though it depends on SEP, which itself depends on B9PS this seemed best to fix anyways.
Secondly there were a few small mistakes in the relationships for the first beta release of version 3.0.0 for SEP itself so these have also been corrected.

this should ideally only be merged after both https://github.com/KSP-CKAN/NetKAN/pull/10325 has been merged and SEP v3.0.0-b2 has been indexed on ckan.

Thanks in advance again!