### PR TITLE
Mark historical KopernicusExpansionContinueder beta version as prerelease

### DIFF
--- a/KopernicusExpansionContinueder/KopernicusExpansionContinueder-Beta9.1.ckan
+++ b/KopernicusExpansionContinueder/KopernicusExpansionContinueder-Beta9.1.ckan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.18",
+    "spec_version": "v1.36",
     "identifier": "KopernicusExpansionContinueder",
     "name": "Kopernicus Expansion Continued-er",
     "abstract": "Kopernicus dev tools and footprints",
@@ -11,6 +11,7 @@
     "version": "Beta9.1",
     "ksp_version_min": "1.10",
     "license": "GPL-3.0",
+    "release_status": "testing",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/195844-110-112-kopernicus-expansion-continued-er/",
         "spacedock": "https://spacedock.info/mod/3357/Kopernicus%20Expansion%20Continued-er",


### PR DESCRIPTION
All of this mod's releases are labeled "Beta" in their version strings on SpaceDock. After KSP-CKAN/CKAN#4260, the latest release was marked as a prerelease, which has caused the previous release to be treated as the latest for users with the current stable CKAN client. But they're both betas, so they shouldn't be treated differently.

Now the historical beta release has a `release_status` of `testing`, the same as the latest release.
