### PR TITLE
Add conflict between UKS and KaribouExpeditionRover

### DIFF
--- a/KaribouExpeditionRover/KaribouExpeditionRover-0.0.4.ckan
+++ b/KaribouExpeditionRover/KaribouExpeditionRover-0.0.4.ckan
@@ -12,6 +12,11 @@
     },
     "version": "0.0.4",
     "ksp_version": "1.0.4",
+    "conflicts": [
+        {
+            "name": "UKS"
+        }
+    ],
     "depends": [
         {
             "name": "FirespitterCore"

--- a/KaribouExpeditionRover/KaribouExpeditionRover-0.0.5.ckan
+++ b/KaribouExpeditionRover/KaribouExpeditionRover-0.0.5.ckan
@@ -12,6 +12,11 @@
     },
     "version": "0.0.5",
     "ksp_version": "1.0.4",
+    "conflicts": [
+        {
+            "name": "UKS"
+        }
+    ],
     "depends": [
         {
             "name": "FirespitterCore"

--- a/KaribouExpeditionRover/KaribouExpeditionRover-0.1.0.1.ckan
+++ b/KaribouExpeditionRover/KaribouExpeditionRover-0.1.0.1.ckan
@@ -12,6 +12,11 @@
     },
     "version": "0.1.0.1",
     "ksp_version": "1.0.4",
+    "conflicts": [
+        {
+            "name": "UKS"
+        }
+    ],
     "depends": [
         {
             "name": "FirespitterCore"

--- a/KaribouExpeditionRover/KaribouExpeditionRover-0.1.0.ckan
+++ b/KaribouExpeditionRover/KaribouExpeditionRover-0.1.0.ckan
@@ -12,6 +12,11 @@
     },
     "version": "0.1.0",
     "ksp_version": "1.0.4",
+    "conflicts": [
+        {
+            "name": "UKS"
+        }
+    ],
     "depends": [
         {
             "name": "FirespitterCore"

--- a/KaribouExpeditionRover/KaribouExpeditionRover-0.1.1.0.ckan
+++ b/KaribouExpeditionRover/KaribouExpeditionRover-0.1.1.0.ckan
@@ -12,6 +12,11 @@
     },
     "version": "0.1.1.0",
     "ksp_version": "1.0.5",
+    "conflicts": [
+        {
+            "name": "UKS"
+        }
+    ],
     "depends": [
         {
             "name": "FirespitterCore"


### PR DESCRIPTION
## Background

Many years ago (circa KSP 1.0), there was a mod called Karibou Expedition Rover. It was merged into UKS and sunsetted:

<https://forum.kerbalspaceprogram.com/topic/119907-12-karibou-expedition-rover-030/?do=findComment&comment=2906423>

![image](https://github.com/user-attachments/assets/72672b81-f896-4bff-a3eb-8ebe6e332ab5)

In response, CKAN deleted the netkan (see KSP-CKAN/NetKAN#5362) and updated KaribouExpeditionRover's abstract to note the merger (see 049eb32f5111e902840a25f5643344a55f808c80):

![image](https://github.com/user-attachments/assets/c4852a8a-a45b-4613-a55c-fadb1db5e2d3)

## Problem

If you nonetheless attempt to install the old mod and the mod into which it was merged at the same time, you get a file conflict.

## Changes

Now KaribouExpeditionRover has a `conflict` with UKS so CKAN won't even get to the install stage.

Fixes #10432.
