### PR TITLE
Retrofit CommunityTechTree conflict to all old RP-1 versions

### DIFF
--- a/RP-1/RP-1-v2.0.0.0.ckan
+++ b/RP-1/RP-1-v2.0.0.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.0.1.0.ckan
+++ b/RP-1/RP-1-v2.0.1.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.0.2.0.ckan
+++ b/RP-1/RP-1-v2.0.2.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.1.0.0.ckan
+++ b/RP-1/RP-1-v2.1.0.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.10.0.0.ckan
+++ b/RP-1/RP-1-v2.10.0.0.ckan
@@ -242,6 +242,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.11.0.0.ckan
+++ b/RP-1/RP-1-v2.11.0.0.ckan
@@ -242,6 +242,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.11.0.1.ckan
+++ b/RP-1/RP-1-v2.11.0.1.ckan
@@ -242,6 +242,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.12.0.0.ckan
+++ b/RP-1/RP-1-v2.12.0.0.ckan
@@ -285,6 +285,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.13.0.0.ckan
+++ b/RP-1/RP-1-v2.13.0.0.ckan
@@ -285,6 +285,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.2.0.0.ckan
+++ b/RP-1/RP-1-v2.2.0.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.3.0.0.ckan
+++ b/RP-1/RP-1-v2.3.0.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.4.0.0.ckan
+++ b/RP-1/RP-1-v2.4.0.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.4.1.0.ckan
+++ b/RP-1/RP-1-v2.4.1.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.4.2.0.ckan
+++ b/RP-1/RP-1-v2.4.2.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.5.0.0.ckan
+++ b/RP-1/RP-1-v2.5.0.0.ckan
@@ -246,6 +246,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.6.0.0.ckan
+++ b/RP-1/RP-1-v2.6.0.0.ckan
@@ -246,6 +246,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.6.1.1.ckan
+++ b/RP-1/RP-1-v2.6.1.1.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.6.2.0.ckan
+++ b/RP-1/RP-1-v2.6.2.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.6.3.0.ckan
+++ b/RP-1/RP-1-v2.6.3.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.6.4.0.ckan
+++ b/RP-1/RP-1-v2.6.4.0.ckan
@@ -243,6 +243,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.7.0.0.ckan
+++ b/RP-1/RP-1-v2.7.0.0.ckan
@@ -242,6 +242,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.7.1.0.ckan
+++ b/RP-1/RP-1-v2.7.1.0.ckan
@@ -242,6 +242,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.8.0.0.ckan
+++ b/RP-1/RP-1-v2.8.0.0.ckan
@@ -242,6 +242,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.8.1.0.ckan
+++ b/RP-1/RP-1-v2.8.1.0.ckan
@@ -242,6 +242,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.9.0.0.ckan
+++ b/RP-1/RP-1-v2.9.0.0.ckan
@@ -242,6 +242,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.9.0.1.ckan
+++ b/RP-1/RP-1-v2.9.0.1.ckan
@@ -242,6 +242,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.9.1.0.ckan
+++ b/RP-1/RP-1-v2.9.1.0.ckan
@@ -242,6 +242,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v2.9.1.1.ckan
+++ b/RP-1/RP-1-v2.9.1.1.ckan
@@ -242,6 +242,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.0.0.0.ckan
+++ b/RP-1/RP-1-v3.0.0.0.ckan
@@ -285,6 +285,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.0.0.1.ckan
+++ b/RP-1/RP-1-v3.0.0.1.ckan
@@ -285,6 +285,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.0.0.2.ckan
+++ b/RP-1/RP-1-v3.0.0.2.ckan
@@ -285,6 +285,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.0.1.0.ckan
+++ b/RP-1/RP-1-v3.0.1.0.ckan
@@ -285,6 +285,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.1.0.0.ckan
+++ b/RP-1/RP-1-v3.1.0.0.ckan
@@ -285,6 +285,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.1.1.0.ckan
+++ b/RP-1/RP-1-v3.1.1.0.ckan
@@ -285,6 +285,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.1.1.1.ckan
+++ b/RP-1/RP-1-v3.1.1.1.ckan
@@ -285,6 +285,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.1.1.2.ckan
+++ b/RP-1/RP-1-v3.1.1.2.ckan
@@ -285,6 +285,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.10.0.0.ckan
+++ b/RP-1/RP-1-v3.10.0.0.ckan
@@ -288,6 +288,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.11.0.0.ckan
+++ b/RP-1/RP-1-v3.11.0.0.ckan
@@ -288,6 +288,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.12.0.0.ckan
+++ b/RP-1/RP-1-v3.12.0.0.ckan
@@ -288,6 +288,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.13.0.0.ckan
+++ b/RP-1/RP-1-v3.13.0.0.ckan
@@ -288,6 +288,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.14.0.0.ckan
+++ b/RP-1/RP-1-v3.14.0.0.ckan
@@ -288,6 +288,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.15.0.0.ckan
+++ b/RP-1/RP-1-v3.15.0.0.ckan
@@ -288,6 +288,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.16.0.0.ckan
+++ b/RP-1/RP-1-v3.16.0.0.ckan
@@ -288,6 +288,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.2.0.0.ckan
+++ b/RP-1/RP-1-v3.2.0.0.ckan
@@ -285,6 +285,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.2.0.1.ckan
+++ b/RP-1/RP-1-v3.2.0.1.ckan
@@ -288,6 +288,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.2.1.0.ckan
+++ b/RP-1/RP-1-v3.2.1.0.ckan
@@ -292,6 +292,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.3.0.0.ckan
+++ b/RP-1/RP-1-v3.3.0.0.ckan
@@ -292,6 +292,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.3.0.1.ckan
+++ b/RP-1/RP-1-v3.3.0.1.ckan
@@ -292,6 +292,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.4.0.0.ckan
+++ b/RP-1/RP-1-v3.4.0.0.ckan
@@ -292,6 +292,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.5.0.0.ckan
+++ b/RP-1/RP-1-v3.5.0.0.ckan
@@ -292,6 +292,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.6.0.0.ckan
+++ b/RP-1/RP-1-v3.6.0.0.ckan
@@ -292,6 +292,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.6.1.0.ckan
+++ b/RP-1/RP-1-v3.6.1.0.ckan
@@ -292,6 +292,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.7.0.0.ckan
+++ b/RP-1/RP-1-v3.7.0.0.ckan
@@ -292,6 +292,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.8.0.0.ckan
+++ b/RP-1/RP-1-v3.8.0.0.ckan
@@ -292,6 +292,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {

--- a/RP-1/RP-1-v3.9.0.0.ckan
+++ b/RP-1/RP-1-v3.9.0.0.ckan
@@ -288,6 +288,9 @@
             "name": "HideEmptyTechNodes"
         },
         {
+            "name": "CommunityTechTree"
+        },
+        {
             "name": "MechJebForAll"
         },
         {


### PR DESCRIPTION
## Background

KSP-RO/RP-1#2482 added a conflict with `CommunityTechTree` to `RP-1`, which took effect in its `v3.17.0.0` release.

## Problem

All older releases also have the same functional conflict, but their metadata has not been updated. This has caused users who want both mods to install old releases of `RP-1`, when they shouldn't be able to install any of them.

## Changes

Now all old releases of `RP-1` also conflict with `CommunityTechTree`.

Fixes KSP-CKAN/CKAN#4325.
