### PR TITLE
Update install_size for SmartTank

### DIFF
--- a/SmartTank/SmartTank-v0.1.0.ckan
+++ b/SmartTank/SmartTank-v0.1.0.ckan
@@ -49,6 +49,8 @@
         "sha256": "CF989E62958229B68AE52AE66A0E42AC98944550E0F5D69F9A1626A8AD0764C7"
     },
     "download_content_type": "application/zip",
+    "install_size": 197712,
+    "release_date": "2017-07-01T02:28:25Z",
     "kind": "package",
     "x_generated_by": "netkan"
 }

--- a/SmartTank/SmartTank-v0.1.1.ckan
+++ b/SmartTank/SmartTank-v0.1.1.ckan
@@ -50,6 +50,8 @@
         "sha256": "62D124FD8164FB751236755AA2BB9F431CBF4CBE8C2D75506A6209C6B102EE9D"
     },
     "download_content_type": "application/zip",
+    "install_size": 202626,
+    "release_date": "2017-08-16T20:47:27Z",
     "kind": "package",
     "x_generated_by": "netkan"
 }

--- a/SmartTank/SmartTank-v0.1.2.ckan
+++ b/SmartTank/SmartTank-v0.1.2.ckan
@@ -50,6 +50,8 @@
         "sha256": "CBE25846ED379D0303E0D665C83C9F00F681B7A833CEF25C4572D351955D69C0"
     },
     "download_content_type": "application/zip",
+    "install_size": 198638,
+    "release_date": "2018-03-08T03:33:52Z",
     "kind": "package",
     "x_generated_by": "netkan"
 }

--- a/SmartTank/SmartTank-v0.2.0.ckan
+++ b/SmartTank/SmartTank-v0.2.0.ckan
@@ -49,6 +49,8 @@
         "sha256": "922F158BAE8C65ED96FBB1036DAA2A3281F11CE45FED211B706A109DCE9C49F6"
     },
     "download_content_type": "application/zip",
+    "install_size": 88942,
+    "release_date": "2018-12-27T05:33:55Z",
     "kind": "package",
     "x_generated_by": "netkan"
 }

--- a/SmartTank/SmartTank-v0.2.1.ckan
+++ b/SmartTank/SmartTank-v0.2.1.ckan
@@ -49,6 +49,8 @@
         "sha256": "A367A2C3B2724474B1BF9AA83269DED4136F0C29DDD536EBE2D461313C1A93FA"
     },
     "download_content_type": "application/zip",
+    "install_size": 88942,
+    "release_date": "2019-02-12T05:33:05Z",
     "kind": "package",
     "x_generated_by": "netkan"
 }

--- a/SmartTank/SmartTank-v0.3.0.ckan
+++ b/SmartTank/SmartTank-v0.3.0.ckan
@@ -55,6 +55,8 @@
         "sha256": "109CE7CC0D0AC840BD66CAC5F2938CCBDC7ABA52CA6BA69F6C3AE92D34B7B16B"
     },
     "download_content_type": "application/zip",
+    "install_size": 90542,
+    "release_date": "2019-02-14T01:56:21Z",
     "kind": "package",
     "x_generated_by": "netkan"
 }

--- a/SmartTank/SmartTank-v0.4.0.ckan
+++ b/SmartTank/SmartTank-v0.4.0.ckan
@@ -58,6 +58,7 @@
         "sha256": "3B2A24DB2DD47E8EAEE4F3D8C0D04FD72788B4C25BC670A37D913779D0217D4C"
     },
     "download_content_type": "application/zip",
+    "install_size": 90542,
     "release_date": "2019-11-12T18:03:34Z",
     "kind": "package",
     "x_generated_by": "netkan"

--- a/SmartTank/SmartTank-v0.5.0.ckan
+++ b/SmartTank/SmartTank-v0.5.0.ckan
@@ -60,7 +60,7 @@
         "sha256": "6DDE6B5DBFC115252A795860017BD3A04990A4AFAA0231EF4315AD5A24F9F395"
     },
     "download_content_type": "application/zip",
-    "install_size": 93981,
+    "install_size": 92286,
     "release_date": "2020-11-04T01:05:26Z",
     "kind": "package",
     "x_generated_by": "netkan"


### PR DESCRIPTION
After KSP-CKAN/CKAN#4348, SmartTank's `install_size` needs to be updated, but KSP-CKAN/NetKAN#10490 couldn't do it without also setting `release_status: development`. So now the .ckans are updated directly.
