### PR TITLE
Add historical BluedogDB data

### DIFF
--- a/BluedogDB/BluedogDB-v0.10.5.ckan
+++ b/BluedogDB/BluedogDB-v0.10.5.ckan
@@ -10,6 +10,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1458919235.934971.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v0.10.5",
     "ksp_version": "1.1.2",
     "depends": [
@@ -44,5 +47,7 @@
         "sha256": "F4D8AE7678F10F7FB5023D534004409A3DD49C93CA62C5B949D0A293AE05FA4D"
     },
     "download_content_type": "application/zip",
+    "install_size": 47963492,
+    "release_date": "2016-05-17T02:03:30Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v0.10.ckan
+++ b/BluedogDB/BluedogDB-v0.10.ckan
@@ -10,6 +10,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1458919235.934971.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v0.10",
     "ksp_version": "1.1.0",
     "depends": [
@@ -44,5 +47,7 @@
         "sha256": "C89B829A24DFEC99D448EC57F45B592EAB3466716A0F3113220D99E713F289DE"
     },
     "download_content_type": "application/zip",
+    "install_size": 40889015,
+    "release_date": "2016-03-25T15:14:10Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v0.11.ckan
+++ b/BluedogDB/BluedogDB-v0.11.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1463449953.9095032.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v0.11",
     "ksp_version": "1.1.3",
     "depends": [
@@ -47,5 +50,7 @@
         "sha256": "055F24877CAED836D1EDA05C305AEC01B2D02A7301370270A84CF743D9407036"
     },
     "download_content_type": "application/zip",
+    "install_size": 82227405,
+    "release_date": "2016-08-06T21:03:18Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.0.1.ckan
+++ b/BluedogDB/BluedogDB-v1.0.1.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1463449953.9095032.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.0.1",
     "ksp_version": "1.2.2",
     "depends": [
@@ -65,5 +68,7 @@
         "sha256": "C68CA4A7B276DB61984348A033ECB758AA39F3B12B3FB70A00082F1F31059185"
     },
     "download_content_type": "application/zip",
+    "install_size": 133890351,
+    "release_date": "2016-10-12T22:20:37Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.1.0.ckan
+++ b/BluedogDB/BluedogDB-v1.1.0.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1463449953.9095032.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.1.0",
     "ksp_version": "1.2.2",
     "depends": [
@@ -65,5 +68,7 @@
         "sha256": "FFEB916C82BE8E623A55C8221620FE495ECB71B784EE01AB48207750DDED047C"
     },
     "download_content_type": "application/zip",
+    "install_size": 239020173,
+    "release_date": "2017-02-24T11:52:02Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.1.5.ckan
+++ b/BluedogDB/BluedogDB-v1.1.5.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1463449953.9095032.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.1.5",
     "ksp_version": "1.3.0",
     "depends": [
@@ -65,5 +68,7 @@
         "sha256": "4E893870531AB11C3FB4BCF8D12483D2B34FBE1EFDC3CC8BD1A889246E285EC6"
     },
     "download_content_type": "application/zip",
+    "install_size": 164049258,
+    "release_date": "2017-06-03T21:21:02Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.1.5b.ckan
+++ b/BluedogDB/BluedogDB-v1.1.5b.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1463449953.9095032.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.1.5b",
     "ksp_version": "1.2.2",
     "depends": [
@@ -65,5 +68,7 @@
         "sha256": "2F8F8A3141750CE0E3A901A0D8E6F51258F25CE87C3454DAEB758503FA461CB0"
     },
     "download_content_type": "application/zip",
+    "install_size": 164049471,
+    "release_date": "2017-06-03T22:02:52Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.1.6.ckan
+++ b/BluedogDB/BluedogDB-v1.1.6.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1463449953.9095032.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.1.6",
     "ksp_version": "1.3.0",
     "depends": [
@@ -65,5 +68,7 @@
         "sha256": "2F2EE3594CA7268ADC34528D3D0F0A3C821F9AF2B05E07930D232B3930ED527B"
     },
     "download_content_type": "application/zip",
+    "install_size": 164049495,
+    "release_date": "2017-06-03T22:49:02Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.3.1.ckan
+++ b/BluedogDB/BluedogDB-v1.3.1.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1463449953.9095032.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.3.1",
     "ksp_version": "1.3.1",
     "depends": [
@@ -65,5 +68,7 @@
         "sha256": "3BF0578C7F29048F24FD134C52E62C81BAB16925CD6583C57A52575507CC8A0D"
     },
     "download_content_type": "application/zip",
+    "install_size": 217338598,
+    "release_date": "2017-10-14T18:30:31Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.3.ckan
+++ b/BluedogDB/BluedogDB-v1.3.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1463449953.9095032.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.3",
     "ksp_version": "1.3.0",
     "depends": [
@@ -65,5 +68,7 @@
         "sha256": "A0D82928F63FD7BF4064BB5B87BFBCC8E17276470F106F2FB5E9166C2CF5BB28"
     },
     "download_content_type": "application/zip",
+    "install_size": 217337574,
+    "release_date": "2017-07-18T03:34:14Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.4.0.ckan
+++ b/BluedogDB/BluedogDB-v1.4.0.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1463449953.9095032.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.4.0",
     "ksp_version": "1.3.1",
     "depends": [
@@ -65,5 +68,7 @@
         "sha256": "1FC3FFAD7087A0A0E540940F60227E6D75538A7869909238D48531D6383726AE"
     },
     "download_content_type": "application/zip",
+    "install_size": 258703062,
+    "release_date": "2017-12-23T00:54:44Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.4.1.ckan
+++ b/BluedogDB/BluedogDB-v1.4.1.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1463449953.9095032.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.4.1",
     "ksp_version": "1.3.1",
     "depends": [
@@ -71,5 +74,7 @@
         "sha256": "0762368538D890FEAEFEBBD1926D8AA9944345BDD8A3654CA971BC18AADE9110"
     },
     "download_content_type": "application/zip",
+    "install_size": 258703272,
+    "release_date": "2018-01-01T16:19:04Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.4.2.ckan
+++ b/BluedogDB/BluedogDB-v1.4.2.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1463449953.9095032.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.4.2",
     "ksp_version": "1.4.3",
     "depends": [
@@ -74,5 +77,7 @@
         "sha256": "54F69F33E416E75639BDC2909D26E22ACBB2AC950DAA4529A7C30A49B336781D"
     },
     "download_content_type": "application/zip",
+    "install_size": 278268224,
+    "release_date": "2018-02-02T03:28:44Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.5.0.ckan
+++ b/BluedogDB/BluedogDB-v1.5.0.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1548455630.0695882.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.5.0",
     "ksp_version": "1.6.1",
     "depends": [
@@ -74,5 +77,7 @@
         "sha256": "58459EE5E3D04C4486F360EC3F6C5E37929404BFE1B8EA43230DAD9055DA6A6E"
     },
     "download_content_type": "application/zip",
+    "install_size": 392331274,
+    "release_date": "2019-01-25T22:26:53Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.5.1.ckan
+++ b/BluedogDB/BluedogDB-v1.5.1.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1548455630.0695882.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.5.1",
     "ksp_version": "1.6.1",
     "depends": [
@@ -74,5 +77,7 @@
         "sha256": "60DB9C601A383CDEAC30E4FDB2CDAA019CC86B1506B5AEF5E173217BC80C3404"
     },
     "download_content_type": "application/zip",
+    "install_size": 392644126,
+    "release_date": "2019-02-02T17:03:55Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.5.2.ckan
+++ b/BluedogDB/BluedogDB-v1.5.2.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1548455630.0695882.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.5.2",
     "ksp_version": "1.7.0",
     "depends": [
@@ -74,5 +77,7 @@
         "sha256": "0120DFEE877C175631890272436E82163FC9682BA79727FE85B7AA656704939B"
     },
     "download_content_type": "application/zip",
+    "install_size": 391619498,
+    "release_date": "2019-02-09T00:26:27Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.6.0.ckan
+++ b/BluedogDB/BluedogDB-v1.6.0.ckan
@@ -13,6 +13,9 @@
         "spacedock": "https://spacedock.info/mod/442/Bluedog%20Design%20Bureau",
         "x_screenshot": "https://spacedock.info/content/CobaltWolf_2659/Bluedog_Design_Bureau/Bluedog_Design_Bureau-1548455630.0695882.png"
     },
+    "tags": [
+        "parts"
+    ],
     "version": "v1.6.0",
     "ksp_version": "1.8.0",
     "depends": [
@@ -74,5 +77,7 @@
         "sha256": "A728D6508B71C2A0DEB40878DDA94D6D1CBAAA6319B44FBB6CFD8E78D8E46670"
     },
     "download_content_type": "application/zip",
+    "install_size": 657376674,
+    "release_date": "2019-10-25T12:47:12Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.6.1.ckan
+++ b/BluedogDB/BluedogDB-v1.6.1.ckan
@@ -16,6 +16,9 @@
     "version": "v1.6.1",
     "ksp_version_min": "1.6.1",
     "ksp_version_max": "1.8.99",
+    "tags": [
+        "parts"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
@@ -75,5 +78,7 @@
         "sha256": "ED39302321CDAB103EB575C36B0BD033C95D5EA2C44445A356188CA26A9317F4"
     },
     "download_content_type": "application/zip",
+    "install_size": 657380784,
+    "release_date": "2019-10-26T14:22:13Z",
     "x_generated_by": "netkan"
 }

--- a/BluedogDB/BluedogDB-v1.6.2.ckan
+++ b/BluedogDB/BluedogDB-v1.6.2.ckan
@@ -16,6 +16,9 @@
     "version": "v1.6.2",
     "ksp_version_min": "1.7.3",
     "ksp_version_max": "1.8.99",
+    "tags": [
+        "parts"
+    ],
     "depends": [
         {
             "name": "ModuleManager"
@@ -75,5 +78,7 @@
         "sha256": "59FEB9565AA5DDB462AA8C2ADFE983C44E7338E85D9624402349733B6F747A23"
     },
     "download_content_type": "application/zip",
+    "install_size": 658151568,
+    "release_date": "2019-11-25T22:50:30Z",
     "x_generated_by": "netkan"
 }


### PR DESCRIPTION
I had to inflate these old modules in order to make a cool graph, and good metadata is a terrible thing to waste.

The other inflated properties are unreliable as they would have changed over time (relationships, etc.).

![image](https://github.com/user-attachments/assets/749a4386-0873-41b9-aa88-03604843d7cb)
