### PR TITLE
Update Parallax-StockScatterTextures hashes

### DIFF
--- a/Parallax-StockScatterTextures/Parallax-StockScatterTextures-2.0.8.ckan
+++ b/Parallax-StockScatterTextures/Parallax-StockScatterTextures-2.0.8.ckan
@@ -45,13 +45,13 @@
         }
     ],
     "download": "https://github.com/Gameslinx/Tessellation/releases/download/2.0.8/Parallax_ScatterTextures-2.0.8.zip",
-    "download_size": 1133606971,
+    "download_size": 1173233326,
     "download_hash": {
-        "sha1": "6F538AD8AC274E18B047714E24AE7AF737542FBE",
-        "sha256": "477634257610EB38DB76DD2DA4A4ED9D7B9F43A44C26F92EB0F349C1A1FCD854"
+        "sha1": "E6FB57E79ADAAEC6B04634D1E283362CEA46FA34",
+        "sha256": "D418BA20725F9474A56CC9A9CE2E3E4A70E576CD30AD6CAAF91FC040F56337E9"
     },
     "download_content_type": "application/zip",
-    "install_size": 2049457040,
-    "release_date": "2024-06-30T12:42:36Z",
+    "install_size": 2046502480,
+    "release_date": "2025-04-21T10:30:27Z",
     "x_generated_by": "netkan"
 }


### PR DESCRIPTION
Apparently the latest download of this mod was replaced after release (and archiving of the repo) and freezing of the netkan in KSP-CKAN/NetKAN#10459, presumably related to Gameslinx/Tessellation#170 (fixed in https://github.com/Gameslinx/Tessellation/compare/bc27cb8ec5dd33b335b3eb42e11fa75046dad180...9abc858630088e4110a3246c4747ca6c703b3670), leaving the hashes out of sync.

Now it's updated manually.
Fixes KSP-CKAN/NetKAN#10508.
