### PR TITLE
Download KopernicusTech from archive.org

### DIFF
--- a/KopernicusTech/KopernicusTech-0.13.ckan
+++ b/KopernicusTech/KopernicusTech-0.13.ckan
@@ -39,7 +39,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://www.dropbox.com/s/7b999gme8p7cgfr/KopernicusTech_v0.13.zip?dl=1",
+    "download": "https://archive.org/download/KopernicusTech-0.13/4CAAE272-KopernicusTech-0.13.zip",
     "download_size": 161613,
     "download_hash": {
         "sha1": "4CAAE272C479C8CA8F3E6D42569719539A9A5781",


### PR DESCRIPTION
This mod has been removed from Dropbox:

- <https://www.dropbox.com/s/7b999gme8p7cgfr/KopernicusTech_v0.13.zip?dl=1>
  ![image](https://github.com/user-attachments/assets/4512f914-9e56-4174-9004-0a52fa73b280)

But it's still on archive.org:

- <https://archive.org/details/KopernicusTech-0.13>

I need this to try to reproduce KSP-CKAN/CKAN#930.
