### PR TITLE
PR template for CKAN-meta directing users to NetKAN repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--
+
+Hi, welcome, and thanks for wanting to contribute!
+
+Pull requests should only be submitted in this repo by experts maintaining historical metadata.
+
+DO NOT SUBMIT A .ckan FILE HERE FOR A NEW MOD!
+If you want to add a new mod, you should submit a .netkan file to this repo:
+
+https://github.com/KSP-CKAN/NetKAN
+
+See this guide for more information:
+
+https://github.com/KSP-CKAN/CKAN/wiki/Adding-a-mod-to-the-CKAN
+
+-->


### PR DESCRIPTION
Inspired by #3355, users starting a new CKAN-meta PR will now be told not to do so and directed to the NetKAN repo where new mods belong.

I looked for ways to make a separate banner but did not find any. The `.yml`-style templates appear to only be supported for issues, not pull requests.
