### PR TITLE
Fix HeapPadder compatibility

### DIFF
--- a/HeapPadder/HeapPadder-0.0.1.5.ckan
+++ b/HeapPadder/HeapPadder-0.0.1.5.ckan
@@ -11,8 +11,8 @@
         "repository": "https://github.com/linuxgurugamer/HeapPadder"
     },
     "version": "0.0.1.5",
-    "ksp_version_min": "1.5.1",
-    "ksp_version_max": "1.7.3",
+    "ksp_version_min": "1.5",
+    "ksp_version_max": "1.7",
     "download": "https://spacedock.info/mod/2190/HeapPadder/download/0.0.1.5",
     "download_size": 32194,
     "download_hash": {

--- a/HeapPadder/HeapPadder-0.0.2.1.ckan
+++ b/HeapPadder/HeapPadder-0.0.2.1.ckan
@@ -5,8 +5,8 @@
     "abstract": "This is a simple plugin to allocate extra space on the heap to help minimize the frequency of garbage collection.",
     "author": "linuxgurugamer",
     "version": "0.0.2.1",
-    "ksp_version_min": "1.12.0",
-    "ksp_version_max": "1.12.2",
+    "ksp_version_min": "1.5",
+    "ksp_version_max": "1.7",
     "license": "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/186521-*",

--- a/HeapPadder/HeapPadder-0.0.2.2.ckan
+++ b/HeapPadder/HeapPadder-0.0.2.2.ckan
@@ -5,8 +5,8 @@
     "abstract": "This is a simple plugin to allocate extra space on the heap to help minimize the frequency of garbage collection.",
     "author": "linuxgurugamer",
     "version": "0.0.2.2",
-    "ksp_version_min": "1.12.0",
-    "ksp_version_max": "1.12.3",
+    "ksp_version_min": "1.5",
+    "ksp_version_max": "1.7",
     "license": "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/186521-*",

--- a/HeapPadder/HeapPadder-0.0.2.3.ckan
+++ b/HeapPadder/HeapPadder-0.0.2.3.ckan
@@ -5,8 +5,8 @@
     "abstract": "This is a simple plugin to allocate extra space on the heap to help minimize the frequency of garbage collection.",
     "author": "linuxgurugamer",
     "version": "0.0.2.3",
-    "ksp_version_min": "1.12.0",
-    "ksp_version_max": "1.12.3",
+    "ksp_version_min": "1.5",
+    "ksp_version_max": "1.7",
     "license": "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/186521-*",

--- a/HeapPadder/HeapPadder-0.0.2.4.ckan
+++ b/HeapPadder/HeapPadder-0.0.2.4.ckan
@@ -5,8 +5,8 @@
     "abstract": "This is a simple plugin to allocate extra space on the heap to help minimize the frequency of garbage collection.",
     "author": "linuxgurugamer",
     "version": "0.0.2.4",
-    "ksp_version_min": "1.12.0",
-    "ksp_version_max": "1.12.5",
+    "ksp_version_min": "1.5",
+    "ksp_version_max": "1.7",
     "license": "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/186521-*",

--- a/HeapPadder/HeapPadder-0.0.2.5.ckan
+++ b/HeapPadder/HeapPadder-0.0.2.5.ckan
@@ -5,8 +5,8 @@
     "abstract": "This is a simple plugin to allocate extra space on the heap to help minimize the frequency of garbage collection.",
     "author": "linuxgurugamer",
     "version": "0.0.2.5",
-    "ksp_version_min": "1.7.77",
-    "ksp_version_max": "1.12.5",
+    "ksp_version_min": "1.5",
+    "ksp_version_max": "1.7",
     "license": "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/186521-*",

--- a/HeapPadder/HeapPadder-0.0.2.ckan
+++ b/HeapPadder/HeapPadder-0.0.2.ckan
@@ -5,8 +5,8 @@
     "abstract": "This is a simple plugin to allocate extra space on the heap to help minimize the frequency of garbage collection.",
     "author": "linuxgurugamer",
     "version": "0.0.2",
-    "ksp_version_min": "1.8.0",
-    "ksp_version_max": "1.8.1",
+    "ksp_version_min": "1.5",
+    "ksp_version_max": "1.7",
     "license": "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/186521-*",


### PR DESCRIPTION
See linuxgurugamer/HeapPadder#3, HeapPadder is only supposed to be used on KSP 1.7 and earlier.

@linuxgurugamer tried to address this with a new release, but unfortunately the version file says `_MIN` where it should have said `_MAX`, so the compatibility ended up basically the opposite of what it should be.

Now all HeapPadder releases are marked compatible with 1.5–1.7. I froze the netkan a few minutes ago, so the bot shouldn't re-break it with the bad upstream data.
