### PR TITLE
Main DLC store is gone, add GOG and Epic

### DIFF
--- a/BreakingGround-DLC/BreakingGround-DLC-1.0.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.0.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.1.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.1.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.2.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.2.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.3.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.3.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.3.1.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.3.1.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.4.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.4.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.4.1.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.4.1.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.5.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.5.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.5.1.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.5.1.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.6.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.6.0.ckan
@@ -10,7 +10,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.6.1.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.6.1.ckan
@@ -10,7 +10,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.7.0.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.7.0.ckan
@@ -10,7 +10,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/BreakingGround-DLC/BreakingGround-DLC-1.7.1.ckan
+++ b/BreakingGround-DLC/BreakingGround-DLC-1.7.1.ckan
@@ -10,7 +10,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/",
-        "steamstore": "https://store.steampowered.com/app/982970"
+        "steamstore": "https://store.steampowered.com/app/982970",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_breaking_ground",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--breaking-ground-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.0.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.0.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.1.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.1.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.10.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.10.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.10.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.10.1.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.11.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.11.0.ckan
@@ -10,7 +10,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.11.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.11.1.ckan
@@ -10,7 +10,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.12.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.12.0.ckan
@@ -10,7 +10,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.12.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.12.1.ckan
@@ -10,7 +10,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.2.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.2.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.3.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.3.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.4.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.4.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.5.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.5.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.5.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.5.1.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.6.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.6.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.6.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.6.1.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.7.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.7.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.7.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.7.1.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.8.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.8.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.8.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.8.1.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.9.0.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.9.0.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }

--- a/MakingHistory-DLC/MakingHistory-DLC-1.9.1.ckan
+++ b/MakingHistory-DLC/MakingHistory-DLC-1.9.1.ckan
@@ -9,7 +9,8 @@
     "kind":         "dlc",
     "license":      "restricted",
     "resources": {
-        "store":      "https://www.kerbalspaceprogram.com/product/kerbal-space-program-making-history/",
-        "steamstore": "https://store.steampowered.com/app/283740"
+        "steamstore": "https://store.steampowered.com/app/283740",
+        "gogstore":   "https://www.gog.com/en/game/kerbal_space_program_making_history",
+        "epicstore":  "https://store.epicgames.com/en-US/p/kerbal-space-program--making-history-expansion"
     }
 }


### PR DESCRIPTION
The Private Division Store is closed:

- <https://www.kerbalspaceprogram.com/>

Now these broken links are removed from the DLC metadata, and `resources.gogstore` and `resources.epicstore` are added to provide the other places to buy. A future client update will display these links in the UI.
