### PR TITLE
RasterPropMonitor: change 1.0.3.2 from "testing" to "stable"

### DIFF
--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-1-v1.0.3.2.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-1-v1.0.3.2.ckan
@@ -13,7 +13,7 @@
     "ksp_version_min": "1.12.3",
     "ksp_version_max": "1.12",
     "license": "GPL-3.0",
-    "release_status": "testing",
+    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/190737-18x-rasterpropmonitor-adopted/&tab=comments#comment-3723047",
         "repository": "https://github.com/FirstPersonKSP/RasterPropMonitor",

--- a/RasterPropMonitor-Core/RasterPropMonitor-Core-1-v1.0.3.2.ckan
+++ b/RasterPropMonitor-Core/RasterPropMonitor-Core-1-v1.0.3.2.ckan
@@ -13,7 +13,6 @@
     "ksp_version_min": "1.12.3",
     "ksp_version_max": "1.12",
     "license": "GPL-3.0",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/190737-18x-rasterpropmonitor-adopted/&tab=comments#comment-3723047",
         "repository": "https://github.com/FirstPersonKSP/RasterPropMonitor",

--- a/RasterPropMonitor/RasterPropMonitor-1-v1.0.3.2.ckan
+++ b/RasterPropMonitor/RasterPropMonitor-1-v1.0.3.2.ckan
@@ -12,7 +12,7 @@
     "ksp_version_min": "1.12.3",
     "ksp_version_max": "1.12",
     "license": "GPL-3.0",
-    "release_status": "testing",
+    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/190737-18x-rasterpropmonitor-adopted/&tab=comments#comment-3723047",
         "repository": "https://github.com/FirstPersonKSP/RasterPropMonitor",

--- a/RasterPropMonitor/RasterPropMonitor-1-v1.0.3.2.ckan
+++ b/RasterPropMonitor/RasterPropMonitor-1-v1.0.3.2.ckan
@@ -12,7 +12,6 @@
     "ksp_version_min": "1.12.3",
     "ksp_version_max": "1.12",
     "license": "GPL-3.0",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/190737-18x-rasterpropmonitor-adopted/&tab=comments#comment-3723047",
         "repository": "https://github.com/FirstPersonKSP/RasterPropMonitor",


### PR DESCRIPTION
I'd like to push these out as a full release, but they're no longer the most recent published version so they won't get inflated anymore.

However, I did just push this version to spacedock, so will this just happen automatically anyway?