### PR TITLE
Fix missing epoch in BurstPQS dependency

### DIFF
--- a/BurstPQS/BurstPQS-0.1.10.ckan
+++ b/BurstPQS/BurstPQS-0.1.10.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.11.ckan
+++ b/BurstPQS/BurstPQS-0.1.11.ckan
@@ -33,7 +33,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.12.ckan
+++ b/BurstPQS/BurstPQS-0.1.12.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.13.ckan
+++ b/BurstPQS/BurstPQS-0.1.13.ckan
@@ -33,7 +33,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.14.ckan
+++ b/BurstPQS/BurstPQS-0.1.14.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.15.ckan
+++ b/BurstPQS/BurstPQS-0.1.15.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.16.ckan
+++ b/BurstPQS/BurstPQS-0.1.16.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.17.ckan
+++ b/BurstPQS/BurstPQS-0.1.17.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.18.ckan
+++ b/BurstPQS/BurstPQS-0.1.18.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.19.ckan
+++ b/BurstPQS/BurstPQS-0.1.19.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.2.ckan
+++ b/BurstPQS/BurstPQS-0.1.2.ckan
@@ -29,7 +29,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.3.ckan
+++ b/BurstPQS/BurstPQS-0.1.3.ckan
@@ -29,7 +29,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.4.ckan
+++ b/BurstPQS/BurstPQS-0.1.4.ckan
@@ -29,7 +29,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.5.ckan
+++ b/BurstPQS/BurstPQS-0.1.5.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.6.ckan
+++ b/BurstPQS/BurstPQS-0.1.6.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.7.ckan
+++ b/BurstPQS/BurstPQS-0.1.7.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.8.ckan
+++ b/BurstPQS/BurstPQS-0.1.8.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",

--- a/BurstPQS/BurstPQS-0.1.9.ckan
+++ b/BurstPQS/BurstPQS-0.1.9.ckan
@@ -32,7 +32,7 @@
         },
         {
             "name": "Kopernicus",
-            "min_version": "release-1.12.1-241"
+            "min_version": "2:release-1.12.1-241"
         },
         {
             "name": "KSPTextureLoader",


### PR DESCRIPTION
For background:

- <https://forum.kerbalspaceprogram.com/topic/229975-112x-burstpqs-optimized-terrain-generation-for-ksp/page/4/#findComment-4511631>

The latest version has the correct relationship. This PR fixes the historical versions, so users don't end up just installing an old one.
