### PR TITLE
Add GitLab mirror to repositories.json

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -7,6 +7,12 @@
             "x_comment": "Well-known default CKAN metadata repository for KSP1"
         },
         {
+            "name":      "KSP-backup",
+            "uri":       "https://gitlab.com/KSP-CKAN/CKAN-meta/-/archive/master/CKAN-meta-master.tar.gz",
+            "x_mirror":  true,
+            "x_comment": "Fall-back CKAN metadata repository for KSP1 in case the default repo is inaccessible"
+        },        
+        {
             "name":      "MechJeb2-dev",
             "uri":       "https://ksp.sarbian.com/ckan/MechJeb2-ci.tar.gz",
             "x_mirror":  false,
@@ -26,4 +32,3 @@
         }
     ]
 }
-


### PR DESCRIPTION
Some big important parts of GitHub broke today for about 5 hours. Issues and pull requests couldn't be searched, and releases couldn't be queried (causing inflation errors for most mods). The metadata repo downloads didn't seem to be affected this time, but they might be next time.

Luckily we did part of KSP-CKAN/CKAN#3337 and are not 100% dependent on GitHub for everything; there's an automated mirror here: 

- <https://gitlab.com/KSP-CKAN/CKAN-meta/>

Now this repo is added to the alternate repos list with the name `KSP-backup`, to make it easy to access in case GitHub is unavailable:

- <https://gitlab.com/KSP-CKAN/CKAN-meta/-/archive/master/CKAN-meta-master.tar.gz>

Conceivably this might also help users who have difficulty connecting to GitHub, but that's speculative at this point and would need to be tested.

Note that this will only be useful if the `repositories.json` file can still be retrieved while the metadata archive can't (unless someone decided to switch over before downtime occurred), but it seems worth a try.
