### PR TITLE
Fix ProbesBeforeCrew 3.0.0 download

### DIFF
--- a/ProbesBeforeCrew/ProbesBeforeCrew-3.0.0.ckan
+++ b/ProbesBeforeCrew/ProbesBeforeCrew-3.0.0.ckan
@@ -120,11 +120,11 @@
             "find": "ProbesBeforeCrew"
         }
     ],
-    "download": "https://spacedock.info/mod/2043/Probes%20Before%20Crew/download/3.0.0",
-    "download_size": 1073257,
+    "download": "https://github.com/Moonlington/ProbesBeforeCrew/releases/download/v3.0.0/Probes_Before_Crew-v3.0.0.zip",
+    "download_size": 75046,
     "download_hash": {
-        "sha1": "9D6A6C73B737F037866695C7147E1575EF9B81AA",
-        "sha256": "9581D80356393485D58531DDECE206BEA9C964A5CACA0586F9529F789A908414"
+        "sha1": "0BFBCEAD4D3362DD1A796F80CB0A06611F1C4D61",
+        "sha256": "0C6A6CB174EAA1675AE724A283F7D12B6C23762CBCECFADF0628166106DE9B38"
     },
     "download_content_type": "application/zip",
     "install_size": 356520,


### PR DESCRIPTION
## Summary
- Switch ProbesBeforeCrew 3.0.0 metadata from the SpaceDock download to the official GitHub release asset.
- Update download size and hashes for the GitHub archive.

## Why
The SpaceDock/archive download currently produces a SHA256 mismatch for this release, preventing CKAN from installing it. The GitHub release asset is published by the upstream project and contains the expected `GameData/ProbesBeforeCrew` install path.

## Validation
- Downloaded `https://github.com/Moonlington/ProbesBeforeCrew/releases/download/v3.0.0/Probes_Before_Crew-v3.0.0.zip`
- Verified SHA1 `0BFBCEAD4D3362DD1A796F80CB0A06611F1C4D61`
- Verified SHA256 `0C6A6CB174EAA1675AE724A283F7D12B6C23762CBCECFADF0628166106DE9B38`
- Parsed the edited `.ckan` file with PowerShell `ConvertFrom-Json`
