### PR TITLE
Use GitHub download for Near Future Electrical

### DIFF
--- a/NearFutureElectrical/NearFutureElectrical-2.0.1.ckan
+++ b/NearFutureElectrical/NearFutureElectrical-2.0.1.ckan
@@ -78,7 +78,7 @@
             "filter": "NearFutureElectrical.dll"
         }
     ],
-    "download": "https://spacedock.info/mod/558/Near%20Future%20Electrical/download/2.0.1",
+    "download": "https://github.com/post-kerbin-mining-corporation/NearFutureElectrical/releases/download/2.0.1/NearFutureElectrical_2_0_1.zip",
     "download_size": 31239619,
     "download_hash": {
         "sha1": "3B0EB4F6F18F037D4882D27E0D7653DE73D4EDA4",


### PR DESCRIPTION
## Summary
- Switch Near Future Electrical 2.0.1 from SpaceDock to the official GitHub release asset.

## Why
The GitHub asset matches the existing CKAN metadata size and hashes and avoids SpaceDock/archive mirror download issues seen during installation.

## Validation
- Verified local archive size `31239619`
- Verified SHA256 `F57098DF49448D130B1500A8F0EEAE4117CFC3510796B1D1A44E16A7466A5AA1`
- Parsed the edited `.ckan` file with PowerShell `ConvertFrom-Json`
