### PR TITLE
Use GitHub download for Near Future Propulsion

### DIFF
--- a/NearFuturePropulsion/NearFuturePropulsion-1.3.6.ckan
+++ b/NearFuturePropulsion/NearFuturePropulsion-1.3.6.ckan
@@ -72,7 +72,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/557/Near%20Future%20Propulsion/download/1.3.6",
+    "download": "https://github.com/post-kerbin-mining-corporation/NearFuturePropulsion/releases/download/1.3.6/NearFuturePropulsion_1_3_6.zip",
     "download_size": 35979770,
     "download_hash": {
         "sha1": "163D9B62CD60CEB6ECC367B654FCA391B3E7A935",


### PR DESCRIPTION
## Summary
- Switch Near Future Propulsion 1.3.6 from SpaceDock to the official GitHub release asset.

## Why
The GitHub asset matches the existing CKAN metadata size and hashes and avoids SpaceDock/archive mirror download issues seen during installation.

## Validation
- Verified local archive size `35979770`
- Verified SHA256 `FA2248D698032DBCEBCE31A00CDD23833950BA378485369B569BCEBC033763F8`
- Parsed the edited `.ckan` file with PowerShell `ConvertFrom-Json`
