### PR TITLE
Use GitHub download for Near Future Construction

### DIFF
--- a/NearFutureConstruction/NearFutureConstruction-1.3.3.ckan
+++ b/NearFutureConstruction/NearFutureConstruction-1.3.3.ckan
@@ -69,7 +69,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/563/Near%20Future%20Construction/download/1.3.3",
+    "download": "https://github.com/post-kerbin-mining-corporation/NearFutureConstruction/releases/download/1.3.3/NearFutureConstruction_1_3_3.zip",
     "download_size": 34890085,
     "download_hash": {
         "sha1": "A6289A6BC1CC1037DCF9920086C8AB44EFF701A2",


### PR DESCRIPTION
## Summary
- Switch Near Future Construction 1.3.3 from SpaceDock to the official GitHub release asset.

## Why
The GitHub asset matches the existing CKAN metadata size and hashes and avoids SpaceDock/archive mirror download issues seen during installation.

## Validation
- Verified local archive size `34890085`
- Verified SHA256 `306BBFABE7AAA93BFC35B99C2A997BF9C45F6B268CACC8FDB862F7B224B789C2`
- Parsed the edited `.ckan` file with PowerShell `ConvertFrom-Json`
