### PR TITLE
Use GitHub download for Near Future Spacecraft

### DIFF
--- a/NearFutureSpacecraft/NearFutureSpacecraft-1.4.6.ckan
+++ b/NearFutureSpacecraft/NearFutureSpacecraft-1.4.6.ckan
@@ -81,7 +81,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/708/Near%20Future%20Spacecraft/download/1.4.6",
+    "download": "https://github.com/post-kerbin-mining-corporation/NearFutureSpacecraft/releases/download/1.4.6/Near_Future_Spacecraft-1.4.6.zip",
     "download_size": 94037073,
     "download_hash": {
         "sha1": "08458B15112F41C7324E1D62E822A54D8632E758",


### PR DESCRIPTION
## Summary
- Switch Near Future Spacecraft 1.4.6 from SpaceDock to the official GitHub release asset.

## Why
The GitHub asset matches the existing CKAN metadata size and hashes and avoids SpaceDock/archive mirror download issues seen during installation.

## Validation
- Verified local archive size `94037073`
- Verified SHA256 `D187B4CCA119D7E6A1E8AFA37E1644C4EA529D51C3672241E5B697A487AFAA5C`
- Parsed the edited `.ckan` file with PowerShell `ConvertFrom-Json`
