### PR TITLE
Use GitHub download for Near Future Launch Vehicles

### DIFF
--- a/NearFutureLaunchVehicles/NearFutureLaunchVehicles-2.2.2.ckan
+++ b/NearFutureLaunchVehicles/NearFutureLaunchVehicles-2.2.2.ckan
@@ -60,7 +60,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/1434/Near%20Future%20Launch%20Vehicles/download/2.2.2",
+    "download": "https://github.com/post-kerbin-mining-corporation/NearFutureLaunchVehicles/releases/download/2.2.2/Near_Future_Launch_Vehicles-2.2.2.zip",
     "download_size": 131286124,
     "download_hash": {
         "sha1": "E060E40D5B95754DAA6B5F947F550FBFAF46FE12",


### PR DESCRIPTION
## Summary
- Switch Near Future Launch Vehicles 2.2.2 from SpaceDock to the official GitHub release asset.

## Why
The GitHub asset matches the existing CKAN metadata size and hashes and avoids SpaceDock/archive mirror download issues seen during installation.

## Validation
- Verified local archive size `131286124`
- Verified SHA256 `C1787124BA17E9AA04D0A33CD328F4BAB893D29B30C2F2DFF0AD7037CF481894`
- Parsed the edited `.ckan` file with PowerShell `ConvertFrom-Json`
