### PR TITLE
Use GitHub download for Near Future Aeronautics

### DIFF
--- a/NearFutureAeronautics/NearFutureAeronautics-2.1.2.ckan
+++ b/NearFutureAeronautics/NearFutureAeronautics-2.1.2.ckan
@@ -58,7 +58,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/1957/Near%20Future%20Aeronautics/download/2.1.2",
+    "download": "https://github.com/post-kerbin-mining-corporation/NearFutureAeronautics/releases/download/2.1.2/NearFutureAeronautics_2_1_2.zip",
     "download_size": 40888324,
     "download_hash": {
         "sha1": "DA4D33B9812DB7D6525E5C6902141E1EFB50FE60",


### PR DESCRIPTION
## Summary
- Switch Near Future Aeronautics 2.1.2 from SpaceDock to the official GitHub release asset.

## Why
The GitHub asset matches the existing CKAN metadata size and hashes and avoids SpaceDock/archive mirror download issues seen during installation.

## Validation
- Verified local archive size `40888324`
- Verified SHA256 `AF96CBE643A2039819EB0A650FF55F972869FA20548D34450631114C954FBC24`
- Parsed the edited `.ckan` file with PowerShell `ConvertFrom-Json`
