### PR TITLE
Use GitHub download for Community Tech Tree

### DIFF
--- a/CommunityTechTree/CommunityTechTree-1-3.4.5.ckan
+++ b/CommunityTechTree/CommunityTechTree-1-3.4.5.ckan
@@ -104,7 +104,7 @@
             "install_to": "GameData"
         }
     ],
-    "download": "https://spacedock.info/mod/534/Community%20Tech%20Tree/download/3.4.5",
+    "download": "https://github.com/post-kerbin-mining-corporation/CommunityTechTree/releases/download/3.4.5/CommunityTechTree_3_4_5.zip",
     "download_size": 631906,
     "download_hash": {
         "sha1": "B0FEFC3EC9765BAD3AABCDB09F8485F5B0F86B18",


### PR DESCRIPTION
## Summary
- Switch Community Tech Tree 1:3.4.5 from SpaceDock to the official GitHub release asset.

## Why
The GitHub asset matches the existing CKAN metadata size and hashes and avoids SpaceDock/archive mirror download issues seen during installation.

## Validation
- Verified local archive size `631906`
- Verified SHA1 `B0FEFC3EC9765BAD3AABCDB09F8485F5B0F86B18`
- Verified SHA256 `9C14A7075646694EF0C4E5B90E4BB01C84CEE1FCD3FA8B5303E5BC0E83A9E1D5`
- Parsed the edited `.ckan` file with PowerShell `ConvertFrom-Json`
