### PR TITLE
Tidy up SETI-GreenHouse compatibility

### DIFF
--- a/SETI-Greenhouse/SETI-Greenhouse-0.9.3.ckan
+++ b/SETI-Greenhouse/SETI-Greenhouse-0.9.3.ckan
@@ -11,7 +11,7 @@
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Greenhouse/SETI-Greenhouse-1455815310.9182491.png"
     },
     "version": "0.9.3",
-    "ksp_version": "1.0.5",
+    "ksp_version": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-Greenhouse/SETI-Greenhouse-0.9.5.0.ckan
+++ b/SETI-Greenhouse/SETI-Greenhouse-0.9.5.0.ckan
@@ -14,7 +14,7 @@
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Greenhouse/SETI-Greenhouse-1455815310.9182491.png"
     },
     "version": "0.9.5.0",
-    "ksp_version": "any",
+    "ksp_version": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-Greenhouse/SETI-Greenhouse-0.9.5.1.ckan
+++ b/SETI-Greenhouse/SETI-Greenhouse-0.9.5.1.ckan
@@ -14,7 +14,7 @@
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Greenhouse/SETI-Greenhouse-1455815310.9182491.png"
     },
     "version": "0.9.5.1",
-    "ksp_version_max": "1.99.99",
+    "ksp_version": "1.0",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-Greenhouse/SETI-Greenhouse-1.2.1.0.ckan
+++ b/SETI-Greenhouse/SETI-Greenhouse-1.2.1.0.ckan
@@ -14,7 +14,7 @@
         "x_screenshot": "https://spacedock.info/content/Y3mo_158/SETI-Greenhouse/SETI-Greenhouse-1455815310.9182491.png"
     },
     "version": "1.2.1.0",
-    "ksp_version": "any",
+    "ksp_version": "1.2",
     "depends": [
         {
             "name": "ModuleManager"

--- a/SETI-Greenhouse/SETI-Greenhouse-1.2.2.0.ckan
+++ b/SETI-Greenhouse/SETI-Greenhouse-1.2.2.0.ckan
@@ -8,7 +8,7 @@
         "Yemo"
     ],
     "version": "1.2.2.0",
-    "ksp_version": "1.2.2",
+    "ksp_version": "1.2",
     "license": "CC-BY-NC-SA-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*",


### PR DESCRIPTION
SETI-GreenHouse had some very optimistic hopes about future compatibility that have not panned out according to KSP-CKAN/NetKAN#7406:

<img width="445" height="302" alt="image" src="https://github.com/user-attachments/assets/f759075d-a077-4f0c-a49f-0954bfcdefd1" />

Reported by Discord user Liquidium's KSP-AVC screenshot.

<img width="599" height="343" alt="image" src="https://github.com/user-attachments/assets/92a163bb-3f29-4a4e-b0e4-d733500e5bbb" />

Now these are updated to "KSP 1.0" for the 0.9.* series and "KSP 1.2" for the 1.2.* series.
