### PR TITLE
Remove Kopernicus_BE from repositories.json

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -19,12 +19,6 @@
             "x_comment": "MechJeb2 Development (prerelease and Jenkins) ckans"
         },
         {
-            "name":      "Kopernicus_BE",
-            "uri":       "https://github.com/R-T-B/CKAN-meta-dev-Kopernicus_BE/archive/master.tar.gz",
-            "x_mirror":  false,
-            "x_comment": "Kopernicus Bleeding Edge beta ckans"
-        },
-        {
             "name":      "Sol",
             "uri":       "https://github.com/RSS-Reborn/CKAN-meta/archive/main.tar.gz",
             "x_mirror":  false,


### PR DESCRIPTION
The Kopernicus_BE metadata was last updated 22 months ago, much longer ago than the main repo:

- <https://github.com/R-T-B/CKAN-meta-dev-Kopernicus_BE/commits/master/>

Users who add this expecting bleeding edge builds will be sorely disappointed.
Now it's removed.