### PR TITLE
Add blacklist to repositories.json

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -24,5 +24,11 @@
             "x_mirror":  false,
             "x_comment": "Sol installation ckans (select Sol-Configs and hit apply)"
         }
+    ],
+    "blacklist": [
+        {
+            "uri_regex":   "/adventure-gpt/",
+            "description": "This repository contains untested, broken AI slop that will break your CKAN."
+        }
     ]
 }

--- a/repositories.json
+++ b/repositories.json
@@ -28,7 +28,7 @@
     "blacklist": [
         {
             "uri_regex":   "/adventure-gpt/",
-            "description": "This repository contains untested, broken AI slop that will break your CKAN."
+            "description": "This repository contains untested, broken AI slop that would break your CKAN."
         }
     ]
 }


### PR DESCRIPTION
## Motivation

Discord user Fireblaster5629 reported some issues installing Sol today, which were caused by using a custom metadata repository with lots of broken metadata. We have asked the creator of that repository to remove it so it stops causing problems for users and taking up support time (see adventure-gpt/more-open-NetKAN#1), but so far it's still there. And even if this repository is removed eventually, others could appear with the same problems.

## Changes

A future pull request in the CKAN repo will add the ability to parse an additional `blacklist` property from this repo's `repositories.json` file, which as of this pull request will contain something like this:

```json
"blacklist": [
    {
        "uri_regex":   "/adventure-gpt/",
        "description": "This repository contains untested, broken AI slop that will break your CKAN."
    }
]
```

For each element in the array, if the `uri_regex` regular expression matches a URL the user is trying to add, it won't be added and the `description` property will be displayed in an error popup:

<img width="1204" height="277" alt="image" src="https://github.com/user-attachments/assets/d12830df-96aa-41ec-b50f-bc9beb18f91d" />

I am planning to merge this PR before that feature is created so I can use the live data for testing.
